### PR TITLE
TEST: streamline redundant coverage

### DIFF
--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -15,6 +15,7 @@ use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Netresearch\NrImageOptimize\Processor;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -161,99 +162,33 @@ class ProcessorTest extends TestCase
     }
 
     #[Test]
-    public function skipWebPCreationReadsQueryParameter(): void
+    #[DataProvider('skipVariantQueryProvider')]
+    public function skipVariantCreationEvaluatesQueryFlag(string $method, string $query, bool $expected): void
     {
         $processor = $this->createProcessor();
 
         $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('skipWebP=1');
+        $uri->method('getQuery')->willReturn($query);
 
         $request = $this->createMock(RequestInterface::class);
         $request->method('getUri')->willReturn($uri);
 
         $this->setProperty($processor, 'request', $request);
 
-        self::assertTrue($this->callMethod($processor, 'skipWebPCreation'));
+        self::assertSame($expected, $this->callMethod($processor, $method));
     }
 
-    #[Test]
-    public function skipWebPCreationDefaultsToFalseWhenFlagMissing(): void
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: bool}>
+     */
+    public static function skipVariantQueryProvider(): iterable
     {
-        $processor = $this->createProcessor();
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-
-        $request = $this->createMock(RequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $this->setProperty($processor, 'request', $request);
-
-        self::assertFalse($this->callMethod($processor, 'skipWebPCreation'));
-    }
-
-    #[Test]
-    public function skipWebPCreationTreatsZeroFlagAsFalse(): void
-    {
-        $processor = $this->createProcessor();
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('skipWebP=0');
-
-        $request = $this->createMock(RequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $this->setProperty($processor, 'request', $request);
-
-        self::assertFalse($this->callMethod($processor, 'skipWebPCreation'));
-    }
-
-    #[Test]
-    public function skipAvifCreationReadsQueryParameter(): void
-    {
-        $processor = $this->createProcessor();
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('skipAvif=1');
-
-        $request = $this->createMock(RequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $this->setProperty($processor, 'request', $request);
-
-        self::assertTrue($this->callMethod($processor, 'skipAvifCreation'));
-    }
-
-    #[Test]
-    public function skipAvifCreationDefaultsToFalseWhenFlagMissing(): void
-    {
-        $processor = $this->createProcessor();
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-
-        $request = $this->createMock(RequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $this->setProperty($processor, 'request', $request);
-
-        self::assertFalse($this->callMethod($processor, 'skipAvifCreation'));
-    }
-
-    #[Test]
-    public function skipAvifCreationTreatsZeroFlagAsFalse(): void
-    {
-        $processor = $this->createProcessor();
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('skipAvif=0');
-
-        $request = $this->createMock(RequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $this->setProperty($processor, 'request', $request);
-
-        self::assertFalse($this->callMethod($processor, 'skipAvifCreation'));
+        yield 'webp flag enabled' => ['skipWebPCreation', 'skipWebP=1', true];
+        yield 'webp flag disabled via zero' => ['skipWebPCreation', 'skipWebP=0', false];
+        yield 'webp flag missing' => ['skipWebPCreation', '', false];
+        yield 'avif flag enabled' => ['skipAvifCreation', 'skipAvif=1', true];
+        yield 'avif flag disabled via zero' => ['skipAvifCreation', 'skipAvif=0', false];
+        yield 'avif flag missing' => ['skipAvifCreation', '', false];
     }
 
     #[Test]

--- a/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
@@ -216,6 +216,7 @@ class SourceSetViewHelperTest extends TestCase
 
         self::assertStringNotContainsString('data-src=', $result);
         self::assertStringNotContainsString('data-srcset=', $result);
+        self::assertStringNotContainsString('loading="', $result);
     }
 
     #[Test]
@@ -339,22 +340,6 @@ class SourceSetViewHelperTest extends TestCase
     }
 
     #[Test]
-    public function useJsLazyLoadDetectsLazyloadClass(): void
-    {
-        $this->viewHelper->setArguments([
-            'class' => 'img-responsive lazyload',
-        ]);
-
-        self::assertTrue($this->viewHelper->useJsLazyLoad());
-
-        $this->viewHelper->setArguments([
-            'class' => 'img-responsive',
-        ]);
-
-        self::assertFalse($this->viewHelper->useJsLazyLoad());
-    }
-
-    #[Test]
     public function tagMergesAdditionalAttributesAndHonorsNativeLazyLoading(): void
     {
         $this->viewHelper->setArguments([
@@ -400,36 +385,21 @@ class SourceSetViewHelperTest extends TestCase
             'path'          => '/path/to/image.jpg',
             'width'         => 400,
             'height'        => 300,
+            'fetchpriority' => 'LOW',
+        ]);
+
+        $resultLow = $this->viewHelper->render();
+        self::assertStringContainsString('fetchpriority="low"', $resultLow);
+
+        $this->viewHelper->setArguments([
+            'path'          => '/path/to/image.jpg',
+            'width'         => 400,
+            'height'        => 300,
             'fetchpriority' => 'invalid',
         ]);
 
         $resultInvalid = $this->viewHelper->render();
         self::assertStringNotContainsString('fetchpriority="', $resultInvalid);
-    }
-
-    #[Test]
-    public function tagMergesAdditionalAttributesAndNativeLazyload(): void
-    {
-        $this->viewHelper->setArguments([
-            'attributes' => [
-                'data-role'   => 'hero-image',
-                'aria-hidden' => 'false',
-            ],
-            'lazyload' => true,
-        ]);
-
-        $result = $this->callMethod('tag', 'img', [
-            'src' => '/processed/path/image.jpg',
-            'alt' => 'Example',
-        ]);
-
-        self::assertStringStartsWith('<img ', $result);
-        self::assertStringContainsString('src="/processed/path/image.jpg"', $result);
-        self::assertStringContainsString('alt="Example"', $result);
-        self::assertStringContainsString('data-role="hero-image"', $result);
-        self::assertStringContainsString('aria-hidden="false"', $result);
-        self::assertStringContainsString('loading="lazy"', $result);
-        self::assertStringEndsWith(PHP_EOL, $result);
     }
 
     #[Test]
@@ -511,40 +481,5 @@ class SourceSetViewHelperTest extends TestCase
         ]);
 
         self::assertSame($set, $this->callMethod('getArgSet'));
-    }
-
-    #[Test]
-    public function useNativeLazyLoadReflectsArgument(): void
-    {
-        $this->viewHelper->setArguments([
-            'path'     => '/images/demo.jpg',
-            'lazyload' => true,
-        ]);
-
-        self::assertTrue($this->callMethod('useNativeLazyLoad'));
-
-        $this->viewHelper->setArguments([
-            'path' => '/images/demo.jpg',
-        ]);
-
-        self::assertFalse($this->callMethod('useNativeLazyLoad'));
-    }
-
-    #[Test]
-    public function getArgFetchpriorityNormalizesAllowedValues(): void
-    {
-        $this->viewHelper->setArguments([
-            'path'          => '/path/to/image.jpg',
-            'fetchpriority' => 'LOW',
-        ]);
-
-        self::assertSame('low', $this->callMethod('getArgFetchpriority'));
-
-        $this->viewHelper->setArguments([
-            'path'          => '/path/to/image.jpg',
-            'fetchpriority' => 'unsupported',
-        ]);
-
-        self::assertSame('', $this->callMethod('getArgFetchpriority'));
     }
 }


### PR DESCRIPTION
## Summary
- merge the WebP and AVIF skip flag assertions into a single data-provider-driven test that covers both methods and query permutations
- drop redundant lazyload helper unit tests while asserting via render output that native lazy loading is omitted when not requested

## Testing
- composer ci:test

------
https://chatgpt.com/codex/tasks/task_e_68d64649676083238e3022579c3c8b0e