### PR TITLE
BUGFIX: Always render alt attribute

### DIFF
--- a/Classes/ViewHelpers/SourceSetViewHelper.php
+++ b/Classes/ViewHelpers/SourceSetViewHelper.php
@@ -164,7 +164,10 @@ class SourceSetViewHelper extends AbstractViewHelper
                 'img',
                 array_filter(
                     $props,
-                    static fn (int|string|null $value): bool => ($value !== null) && ($value !== '')
+                    static fn (int|string|null $value, string|int $key): bool => $key === 'alt'
+                        ? $value !== null
+                        : ($value !== null) && ($value !== ''),
+                    ARRAY_FILTER_USE_BOTH
                 )
             );
     }
@@ -196,7 +199,10 @@ class SourceSetViewHelper extends AbstractViewHelper
                 'img',
                 array_filter(
                     $props,
-                    static fn (int|string|null $value): bool => ($value !== null) && ($value !== '')
+                    static fn (int|string|null $value, string|int $key): bool => $key === 'alt'
+                        ? $value !== null
+                        : ($value !== null) && ($value !== ''),
+                    ARRAY_FILTER_USE_BOTH
                 )
             );
     }

--- a/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
@@ -114,6 +114,35 @@ class SourceSetViewHelperTest extends TestCase
     }
 
     #[Test]
+    public function renderAddsEmptyAltAttributeWhenOmitted(): void
+    {
+        $this->viewHelper->setArguments([
+            'path'             => '/path/to/image.jpg',
+            'width'            => 800,
+            'height'           => 600,
+            'responsiveSrcset' => true,
+        ]);
+
+        $result = $this->viewHelper->render();
+
+        self::assertStringContainsString('alt=""', $result);
+    }
+
+    #[Test]
+    public function renderLegacyModeAddsEmptyAltAttributeWhenOmitted(): void
+    {
+        $this->viewHelper->setArguments([
+            'path'   => '/path/to/image.jpg',
+            'width'  => 400,
+            'height' => 300,
+        ]);
+
+        $result = $this->viewHelper->render();
+
+        self::assertStringContainsString('alt=""', $result);
+    }
+
+    #[Test]
     public function renderCustomWidthVariants(): void
     {
         $this->viewHelper->setArguments([


### PR DESCRIPTION
## Summary
- ensure the SourceSetViewHelper keeps the alt attribute even when the value is empty
- add regression tests covering responsive and legacy rendering without provided alternative text

## Testing
- composer ci:test *(fails: phplint not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68efd0afd5fc833394a4d86343efeff0