### PR TITLE
feat: optimize images on upload + bulk optimize/analyze CLI commands

### DIFF
--- a/Classes/Command/AbstractImageCommand.php
+++ b/Classes/Command/AbstractImageCommand.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Command;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Exception;
+
+use function floor;
+
+use Generator;
+
+use function is_numeric;
+use function is_scalar;
+use function is_string;
+use function max;
+use function number_format;
+use function preg_replace;
+use function strlen;
+use function substr;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Terminal;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+abstract class AbstractImageCommand extends Command
+{
+    /**
+     * @param array<int|string, mixed> $values
+     *
+     * @return list<int>
+     */
+    protected function parseStorageUidsOption(array $values): array
+    {
+        $uids = [];
+        foreach ($values as $val) {
+            if (!is_scalar($val)) {
+                continue;
+            }
+
+            foreach (GeneralUtility::trimExplode(',', (string) $val, true) as $part) {
+                if (is_numeric($part)) {
+                    $uids[] = (int) $part;
+                }
+            }
+        }
+
+        return $uids;
+    }
+
+    /**
+     * Returns an integer option value or the default if the option is not a numeric string.
+     */
+    protected function getIntOption(mixed $value, int $default): int
+    {
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param list<int> $onlyStorageUids
+     *
+     * @throws Exception
+     */
+    protected function countImages(array $onlyStorageUids): int
+    {
+        $fileConn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('sys_file');
+        $qb       = $fileConn->createQueryBuilder();
+
+        $qb->count('f.uid')
+            ->from('sys_file', 'f')
+            ->join('f', 'sys_file_storage', 's', 's.uid = f.storage')
+            ->where(
+                $qb->expr()->eq('f.missing', 0),
+                $qb->expr()->eq('s.is_online', 1),
+                $qb->expr()->in(
+                    'f.mime_type',
+                    $qb->createNamedParameter(['image/jpeg', 'image/gif', 'image/png'], ArrayParameterType::STRING),
+                ),
+            );
+
+        if ($onlyStorageUids !== []) {
+            $qb->andWhere(
+                $qb->expr()->in('f.storage', $qb->createNamedParameter($onlyStorageUids, ArrayParameterType::INTEGER)),
+            );
+        }
+
+        $value = $qb->executeQuery()->fetchOne();
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    /**
+     * @param list<int> $onlyStorageUids
+     *
+     * @return Generator<int, array<string, mixed>>
+     *
+     * @throws Exception
+     */
+    protected function iterateViaIndex(array $onlyStorageUids): Generator
+    {
+        $fileConn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('sys_file');
+        $qb       = $fileConn->createQueryBuilder();
+
+        $qb->select('f.*')
+            ->from('sys_file', 'f')
+            ->join('f', 'sys_file_storage', 's', 's.uid = f.storage')
+            ->where(
+                $qb->expr()->eq('f.missing', 0),
+                $qb->expr()->eq('s.is_online', 1),
+                $qb->expr()->in(
+                    'f.mime_type',
+                    $qb->createNamedParameter(['image/jpeg', 'image/gif', 'image/png'], ArrayParameterType::STRING),
+                ),
+            )
+            ->orderBy('f.uid', 'ASC');
+
+        if ($onlyStorageUids !== []) {
+            $qb->andWhere(
+                $qb->expr()->in('f.storage', $qb->createNamedParameter($onlyStorageUids, ArrayParameterType::INTEGER)),
+            );
+        }
+
+        $result = $qb->executeQuery();
+        while ($row = $result->fetchAssociative()) {
+            yield $row;
+        }
+    }
+
+    /**
+     * @return array{progress: ProgressBar, messageMax: int}
+     */
+    protected function createProgress(SymfonyStyle $io, int $count): array
+    {
+        $progress = $io->createProgressBar($count);
+        $progress->setFormat(' %current%/%max% [%bar%] %percent:3s%% | %elapsed:6s% | %message%');
+        $progress->start();
+
+        $termWidth  = (new Terminal())->getWidth();
+        $messageMax = max(10, $termWidth - 40);
+
+        return ['progress' => $progress, 'messageMax' => $messageMax];
+    }
+
+    /**
+     * @param array<string,mixed> $record
+     */
+    protected function extractUid(array $record): int
+    {
+        $uid = $record['uid'] ?? null;
+
+        return is_numeric($uid) ? (int) $uid : 0;
+    }
+
+    /**
+     * @param array<string,mixed> $record
+     */
+    protected function buildLabel(array $record): string
+    {
+        if (isset($record['identifier']) && is_string($record['identifier']) && $record['identifier'] !== '') {
+            return $record['identifier'];
+        }
+
+        $uid = $record['uid'] ?? '?';
+
+        return '#' . (is_scalar($uid) ? (string) $uid : '?');
+    }
+
+    protected function shortenLabel(string $text, int $maxLen): string
+    {
+        $plain = preg_replace('/\s+/', ' ', $text) ?? $text;
+        if ($maxLen <= 3) {
+            return strlen($plain) > $maxLen ? substr($plain, 0, $maxLen) : $plain;
+        }
+
+        if (strlen($plain) <= $maxLen) {
+            return $plain;
+        }
+
+        $keep = (int) max(1, floor(($maxLen - 1) / 2));
+
+        return substr($plain, 0, $keep) . '…' . substr($plain, -$keep);
+    }
+
+    protected function formatMbGb(int $bytes): string
+    {
+        $mb = $bytes / 1048576;
+        $gb = $bytes / 1073741824;
+
+        return number_format($mb, 2) . ' MB / ' . number_format($gb, 2) . ' GB';
+    }
+}

--- a/Classes/Command/AnalyzeImagesCommand.php
+++ b/Classes/Command/AnalyzeImagesCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Command;
+
+use Netresearch\NrImageOptimize\Service\ImageOptimizer;
+
+use function sprintf;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+
+#[AsCommand(
+    name: 'nr:image:analyze',
+    description: 'Analyze originals and determine optimization potential (optipng, gifsicle, jpegoptim).',
+)]
+final class AnalyzeImagesCommand extends AbstractImageCommand
+{
+    public function __construct(
+        private readonly ResourceFactory $factory,
+        private readonly ImageOptimizer $optimizer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('storages', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only process these storage UIDs (comma-separated or specify multiple times)')
+            ->addOption('max-width', null, InputOption::VALUE_REQUIRED, 'Target display width (px), default 2560')
+            ->addOption('max-height', null, InputOption::VALUE_REQUIRED, 'Target display height (px), default 1440')
+            ->addOption('min-size', null, InputOption::VALUE_REQUIRED, 'Only consider files >= minimum size in bytes, default 512000');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $onlyStorageUids = $this->parseStorageUidsOption((array) $input->getOption('storages'));
+        $maxWidth        = $this->getIntOption($input->getOption('max-width'), 2560);
+        $maxHeight       = $this->getIntOption($input->getOption('max-height'), 1440);
+        $minSize         = $this->getIntOption($input->getOption('min-size'), 512000);
+
+        $count = $this->countImages($onlyStorageUids);
+        if ($count === 0) {
+            $io->warning('No matching image files found.');
+
+            return self::SUCCESS;
+        }
+
+        $io->title('Image optimization — Analysis');
+        $io->note(sprintf('Found %d image file(s) (heuristic, no tools, no modifications).', $count));
+
+        $total = [
+            'files'          => $count,
+            'improvable'     => 0,
+            'bytesPotential' => 0,
+            'noGain'         => 0,
+        ];
+
+        ['progress' => $progress, 'messageMax' => $messageMax] = $this->createProgress($io, $count);
+
+        foreach ($this->iterateViaIndex($onlyStorageUids) as $record) {
+            try {
+                $label = $this->buildLabel($record);
+                $progress->setMessage($this->shortenLabel($label, $messageMax));
+
+                $file                = $this->factory->getFileObject($this->extractUid($record));
+                $storage             = $file->getStorage();
+                $previousPermissions = $storage->getEvaluatePermissions();
+                $storage->setEvaluatePermissions(false);
+                try {
+                    if (!$file->exists()) {
+                        continue;
+                    }
+
+                    $result = $this->optimizer->analyzeHeuristic($file, $maxWidth, $maxHeight, $minSize);
+
+                    if ($result['optimized']) {
+                        ++$total['improvable'];
+                        $total['bytesPotential'] += $result['savedBytes'];
+                    } else {
+                        ++$total['noGain'];
+                    }
+                } finally {
+                    $storage->setEvaluatePermissions($previousPermissions);
+                }
+            } finally {
+                $progress->advance();
+            }
+        }
+
+        $progress->finish();
+        $io->newLine(2);
+
+        $io->success(sprintf('Analysis complete. Files: %d, Improvable: %d, No potential: %d, Potential savings: %d bytes (%s)', $total['files'], $total['improvable'], $total['noGain'], $total['bytesPotential'], $this->formatMbGb($total['bytesPotential'])));
+
+        return self::SUCCESS;
+    }
+}

--- a/Classes/Command/OptimizeImagesCommand.php
+++ b/Classes/Command/OptimizeImagesCommand.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Command;
+
+use function is_numeric;
+use function max;
+
+use Netresearch\NrImageOptimize\Service\ImageOptimizer;
+
+use function sprintf;
+use function strtolower;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+
+#[AsCommand(
+    name: 'nr:image:optimize',
+    description: 'Optimize PNG, GIF and JPEG in TYPO3 storages (optipng, gifsicle, jpegoptim).',
+)]
+final class OptimizeImagesCommand extends AbstractImageCommand
+{
+    public function __construct(
+        private readonly ResourceFactory $factory,
+        private readonly ImageOptimizer $optimizer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Analyze only, do not modify files')
+            ->addOption('storages', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only process these storage UIDs (comma-separated or specify multiple times)')
+            ->addOption('jpeg-quality', null, InputOption::VALUE_REQUIRED, 'JPEG quality (0-100) for jpegoptim; omit for lossless optimization')
+            ->addOption('strip-metadata', null, InputOption::VALUE_NONE, 'Strip metadata (EXIF, comments) if supported by the tool');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $dryRun          = (bool) $input->getOption('dry-run');
+        $strip           = (bool) $input->getOption('strip-metadata');
+        $jpegQuality     = $input->getOption('jpeg-quality');
+        $onlyStorageUids = $this->parseStorageUidsOption((array) $input->getOption('storages'));
+
+        if (!$this->optimizer->hasAnyTool()) {
+            $io->error('No optimization tools found (optipng, gifsicle, jpegoptim). Please install and make available in PATH.');
+
+            return self::FAILURE;
+        }
+
+        $total = [
+            'files'      => 0,
+            'optimized'  => 0,
+            'bytesSaved' => 0,
+            'skipped'    => 0,
+        ];
+
+        $count = $this->countImages($onlyStorageUids);
+        if ($count === 0) {
+            $io->warning('No matching image files found to process.');
+
+            return self::SUCCESS;
+        }
+
+        $io->title('Image optimization');
+        if ($dryRun) {
+            $io->note(sprintf('Dry-run enabled. Found %d image file(s) to evaluate.', $count));
+        } else {
+            $io->note(sprintf('Found %d image file(s) to process.', $count));
+        }
+
+        ['progress' => $progress, 'messageMax' => $messageMax] = $this->createProgress($io, $count);
+
+        foreach ($this->iterateViaIndex($onlyStorageUids) as $record) {
+            try {
+                $label = $this->buildLabel($record);
+                $progress->setMessage($this->shortenLabel($label, $messageMax));
+
+                $file    = $this->factory->getFileObject($this->extractUid($record));
+                $ext     = strtolower($file->getExtension());
+                $storage = $file->getStorage();
+
+                // Check tool availability before processing
+                $tool = $this->optimizer->resolveToolFor($ext);
+                if ($tool === null) {
+                    $io->writeln(sprintf('<comment>Skipping %s: no suitable tool found</comment>', $file->getIdentifier()));
+                    ++$total['skipped'];
+                    continue;
+                }
+
+                ++$total['files'];
+
+                // Temporarily disable permission checks for file operations
+                $previousPermissions = $storage->getEvaluatePermissions();
+                $storage->setEvaluatePermissions(false);
+
+                try {
+                    if ($dryRun) {
+                        $io->writeln(sprintf('[DRY] Would optimize %s with %s', $file->getIdentifier(), $tool['name']));
+                        continue;
+                    }
+
+                    $qualityInt = is_numeric($jpegQuality) ? (int) $jpegQuality : null;
+                    $result     = $this->optimizer->optimize($file, $strip, $qualityInt, $dryRun);
+
+                    if ($result['tool'] === null) {
+                        $io->writeln(sprintf('<comment>Skipping %s: could not be processed</comment>', $file->getIdentifier()));
+                        ++$total['skipped'];
+                        continue;
+                    }
+
+                    if ($result['optimized']) {
+                        $saved      = $result['savedBytes'];
+                        $before     = $result['before'];
+                        $after      = $result['after'];
+                        $percentage = (100.0 * $saved) / max($before, 1);
+                        $savedHuman = $this->formatMbGb($saved);
+                        ++$total['optimized'];
+                        $total['bytesSaved'] += $saved;
+                        $progress->clear();
+                        $io->writeln(sprintf('Optimized: %s (-%0.2f%%, %d ➜ %d Bytes, saved: %s) with %s', $file->getIdentifier(), $percentage, $before, $after, $savedHuman, $result['tool']));
+                        $progress->display();
+                    } else {
+                        $progress->clear();
+                        $io->writeln(sprintf('No savings: %s (tool: %s)', $file->getIdentifier(), $result['tool']));
+                        $progress->display();
+                    }
+                } finally {
+                    $storage->setEvaluatePermissions($previousPermissions);
+                }
+            } finally {
+                $progress->advance();
+            }
+        }
+
+        $progress->finish();
+        $io->newLine(2);
+        $io->success(sprintf('Done. Files: %d, Optimized: %d, Skipped: %d, Saved: %d Bytes (%s)', $total['files'], $total['optimized'], $total['skipped'], $total['bytesSaved'], $this->formatMbGb($total['bytesSaved'])));
+
+        return self::SUCCESS;
+    }
+}

--- a/Classes/EventListener/OptimizeOnUploadListener.php
+++ b/Classes/EventListener/OptimizeOnUploadListener.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\EventListener;
+
+use function in_array;
+
+use Netresearch\NrImageOptimize\Service\ImageOptimizer;
+
+use function strtolower;
+
+use TYPO3\CMS\Core\Resource\Event\AfterFileAddedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent;
+use TYPO3\CMS\Core\Resource\FileInterface;
+
+final class OptimizeOnUploadListener
+{
+    /** @var array<string, true> */
+    private array $guard = [];
+
+    public function __construct(private readonly ImageOptimizer $optimizer) {}
+
+    public function optimizeAfterAdd(AfterFileAddedEvent $event): void
+    {
+        $this->handle($event->getFile());
+    }
+
+    public function optimizeAfterReplace(AfterFileReplacedEvent $event): void
+    {
+        $this->handle($event->getFile());
+    }
+
+    private function handle(FileInterface $file): void
+    {
+        $id = $file->getIdentifier();
+        if (isset($this->guard[$id])) {
+            return; // Re-entrancy guard (e.g. triggered by replaceFile)
+        }
+
+        $storage = $file->getStorage();
+        if (!$storage->isOnline()) {
+            return;
+        }
+
+        $ext = strtolower($file->getExtension());
+        if (!in_array($ext, $this->optimizer->supportedExtensions(), true)) {
+            return;
+        }
+
+        // Disable permission check in CLI/backend-independent context
+        $previousPermissions = $storage->getEvaluatePermissions();
+        $storage->setEvaluatePermissions(false);
+
+        $this->guard[$id] = true;
+        try {
+            $this->optimizer->optimize($file, false, null, false);
+        } finally {
+            unset($this->guard[$id]);
+            $storage->setEvaluatePermissions($previousPermissions);
+        }
+    }
+}

--- a/Classes/EventListener/OptimizeOnUploadListener.php
+++ b/Classes/EventListener/OptimizeOnUploadListener.php
@@ -40,12 +40,14 @@ final class OptimizeOnUploadListener
 
     private function handle(FileInterface $file): void
     {
-        $id = $file->getIdentifier();
+        $storage = $file->getStorage();
+        // FAL identifiers are only unique within a storage, so key the guard
+        // on storage UID + identifier to avoid cross-storage collisions.
+        $id = $storage->getUid() . ':' . $file->getIdentifier();
         if (isset($this->guard[$id])) {
             return; // Re-entrancy guard (e.g. triggered by replaceFile)
         }
 
-        $storage = $file->getStorage();
         if (!$storage->isOnline()) {
             return;
         }

--- a/Classes/Service/ImageOptimizer.php
+++ b/Classes/Service/ImageOptimizer.php
@@ -18,6 +18,7 @@ use function getenv;
 use function getimagesize;
 use function in_array;
 use function is_array;
+use function is_executable;
 use function is_file;
 use function is_numeric;
 use function is_string;
@@ -264,19 +265,27 @@ final class ImageOptimizer
     {
         $envName  = strtoupper($binary) . '_BIN';
         $override = getenv($envName);
-        if (is_string($override) && $override !== '' && is_file($override)) {
-            return $override;
+
+        // If the env override is set, it is authoritative: return the path if
+        // it resolves to an executable file, otherwise treat the tool as
+        // unavailable. Falling back to `which` would silently mask a
+        // misconfigured override and invoke a different binary.
+        if (is_string($override) && $override !== '') {
+            return is_file($override) && is_executable($override) ? $override : null;
         }
 
         $process = new Process(['which', $binary]);
         $process->run();
-        if ($process->isSuccessful()) {
-            $path = trim($process->getOutput());
-
-            return $path !== '' ? $path : null;
+        if (!$process->isSuccessful()) {
+            return null;
         }
 
-        return null;
+        $path = trim($process->getOutput());
+        if ($path === '' || !is_executable($path)) {
+            return null;
+        }
+
+        return $path;
     }
 
     /**

--- a/Classes/Service/ImageOptimizer.php
+++ b/Classes/Service/ImageOptimizer.php
@@ -1,0 +1,353 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Service;
+
+use function array_key_exists;
+use function array_merge;
+use function filesize;
+use function getenv;
+use function getimagesize;
+use function in_array;
+use function is_array;
+use function is_file;
+use function is_numeric;
+use function is_string;
+use function max;
+use function min;
+use function round;
+use function strtolower;
+use function strtoupper;
+
+use Symfony\Component\Process\Process;
+
+use function trim;
+
+use TYPO3\CMS\Core\Resource\FileInterface;
+
+use function unlink;
+
+final class ImageOptimizer
+{
+    /** @var list<string> */
+    private const SUPPORTED_EXT = ['png', 'gif', 'jpg', 'jpeg'];
+
+    private ?string $optipng = null;
+
+    private ?string $gifsicle = null;
+
+    private ?string $jpegoptim = null;
+
+    private bool $toolsResolved = false;
+
+    /**
+     * Optimize the file. Returns result data.
+     *
+     * @return array{optimized:bool, savedBytes:int, before:int, after:int, tool: string|null}
+     */
+    public function optimize(FileInterface $file, bool $stripMetadata = false, ?int $jpegQuality = null, bool $dryRun = false): array
+    {
+        $this->resolveTools();
+
+        $ext = strtolower($file->getExtension());
+        if (!in_array($ext, self::SUPPORTED_EXT, true)) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => null];
+        }
+
+        $tool = $this->resolveToolForExtension($ext);
+        if ($tool === null) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => null];
+        }
+
+        $localPath = $file->getForLocalProcessing(true);
+        if (!is_file($localPath)) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => $tool['name']];
+        }
+
+        $sizeBefore = @filesize($localPath);
+        $before     = $sizeBefore === false ? 0 : $sizeBefore;
+
+        try {
+            if ($dryRun) {
+                return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $before, 'tool' => $tool['name']];
+            }
+
+            $workPath = $localPath;
+
+            $args = match ($tool['name']) {
+                'optipng'   => ['-o2', '-quiet', $workPath],
+                'gifsicle'  => ['-O3', '-b', $workPath],
+                'jpegoptim' => $this->buildJpegoptimArgs($workPath, $jpegQuality, $stripMetadata),
+                default     => [$workPath],
+            };
+
+            $process = new Process(array_merge([$tool['bin']], $args));
+            $process->setTimeout(600.0);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $before, 'tool' => $tool['name']];
+            }
+
+            $sizeAfter = @filesize($workPath);
+            $after     = $sizeAfter === false ? 0 : $sizeAfter;
+            if ($after < $before) {
+                $file->getStorage()->replaceFile($file, $workPath);
+
+                return [
+                    'optimized'  => true,
+                    'savedBytes' => $before - $after,
+                    'before'     => $before,
+                    'after'      => $after,
+                    'tool'       => $tool['name'],
+                ];
+            }
+
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $after, 'tool' => $tool['name']];
+        } finally {
+            @unlink($localPath);
+        }
+    }
+
+    public function hasAnyTool(): bool
+    {
+        $this->resolveTools();
+
+        return ($this->optipng !== null) || ($this->gifsicle !== null) || ($this->jpegoptim !== null);
+    }
+
+    /**
+     * Returns the resolved tool for a given file extension, or null if unavailable.
+     *
+     * @return array{name: string, bin: string}|null
+     */
+    public function resolveToolFor(string $extension): ?array
+    {
+        $this->resolveTools();
+
+        return $this->resolveToolForExtension(strtolower($extension));
+    }
+
+    /**
+     * Analyze potential optimization without modifying original file.
+     * Returns the same structure as optimize(), but never writes back.
+     *
+     * @return array{optimized:bool, savedBytes:int, before:int, after:int, tool: string|null}
+     */
+    public function analyze(FileInterface $file, bool $stripMetadata = false, ?int $jpegQuality = null): array
+    {
+        $this->resolveTools();
+
+        $ext = strtolower($file->getExtension());
+        if (!in_array($ext, self::SUPPORTED_EXT, true)) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => null];
+        }
+
+        $tool = $this->resolveToolForExtension($ext);
+        if ($tool === null) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => null];
+        }
+
+        $localPath = $file->getForLocalProcessing(true);
+        if (!is_file($localPath)) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => $tool['name']];
+        }
+
+        $sizeBefore = @filesize($localPath);
+        $before     = $sizeBefore === false ? 0 : $sizeBefore;
+
+        try {
+            $args = match ($tool['name']) {
+                'optipng'   => ['-o2', '-quiet', $localPath],
+                'gifsicle'  => ['-O3', '-b', $localPath],
+                'jpegoptim' => $this->buildJpegoptimArgs($localPath, $jpegQuality, $stripMetadata),
+                default     => [$localPath],
+            };
+
+            $process = new Process(array_merge([$tool['bin']], $args));
+            $process->setTimeout(600.0);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $before, 'tool' => $tool['name']];
+            }
+
+            $sizeAfter = @filesize($localPath);
+            $after     = $sizeAfter === false ? 0 : $sizeAfter;
+
+            if ($after < $before) {
+                return [
+                    'optimized'  => true,
+                    'savedBytes' => $before - $after,
+                    'before'     => $before,
+                    'after'      => $after,
+                    'tool'       => $tool['name'],
+                ];
+            }
+
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $after, 'tool' => $tool['name']];
+        } finally {
+            @unlink($localPath);
+        }
+    }
+
+    /** @return list<string> */
+    public function supportedExtensions(): array
+    {
+        return self::SUPPORTED_EXT;
+    }
+
+    private function resolveTools(): void
+    {
+        if ($this->toolsResolved) {
+            return;
+        }
+
+        $this->optipng       = $this->resolveBinary('optipng');
+        $this->gifsicle      = $this->resolveBinary('gifsicle');
+        $this->jpegoptim     = $this->resolveBinary('jpegoptim');
+        $this->toolsResolved = true;
+    }
+
+    /**
+     * @return array{name:string,bin:string}|null
+     */
+    private function resolveToolForExtension(string $ext): ?array
+    {
+        $map = [
+            'png'  => ['name' => 'optipng', 'bin' => $this->optipng],
+            'gif'  => ['name' => 'gifsicle', 'bin' => $this->gifsicle],
+            'jpg'  => ['name' => 'jpegoptim', 'bin' => $this->jpegoptim],
+            'jpeg' => ['name' => 'jpegoptim', 'bin' => $this->jpegoptim],
+        ];
+        if (!array_key_exists($ext, $map) || $map[$ext]['bin'] === null) {
+            return null;
+        }
+
+        return $map[$ext];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildJpegoptimArgs(string $path, ?int $quality, bool $strip): array
+    {
+        $args = [];
+        if ($strip) {
+            $args[] = '--strip-all';
+        }
+
+        if ($quality !== null) {
+            $q = $quality;
+            if ($q < 0) {
+                $q = 0;
+            } elseif ($q > 100) {
+                $q = 100;
+            }
+
+            $args[] = '--max=' . $q;
+        }
+
+        $args[] = '-q';
+        $args[] = $path;
+
+        return $args;
+    }
+
+    private function resolveBinary(string $binary): ?string
+    {
+        $envName  = strtoupper($binary) . '_BIN';
+        $override = getenv($envName);
+        if (is_string($override) && $override !== '' && is_file($override)) {
+            return $override;
+        }
+
+        $process = new Process(['which', $binary]);
+        $process->run();
+        if ($process->isSuccessful()) {
+            $path = trim($process->getOutput());
+
+            return $path !== '' ? $path : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Fast heuristic analysis based on size and resolution only.
+     * No external tools are invoked.
+     *
+     * @return array{optimized:bool, savedBytes:int, before:int, after:int, tool: null}
+     */
+    public function analyzeHeuristic(FileInterface $file, int $maxWidth = 2560, int $maxHeight = 1440, int $minSize = 512000): array
+    {
+        $ext = strtolower($file->getExtension());
+        if (!in_array($ext, self::SUPPORTED_EXT, true)) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => null];
+        }
+
+        $localPath = $file->getForLocalProcessing(true);
+        if (!is_file($localPath)) {
+            return ['optimized' => false, 'savedBytes' => 0, 'before' => 0, 'after' => 0, 'tool' => null];
+        }
+
+        try {
+            $sizeBefore = @filesize($localPath);
+            $before     = $sizeBefore === false ? 0 : $sizeBefore;
+            if ($before < $minSize) {
+                return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $before, 'tool' => null];
+            }
+
+            $w    = 0;
+            $h    = 0;
+            $info = @getimagesize($localPath);
+            if (is_array($info)) {
+                $w = $info[0];
+                $h = $info[1];
+            } else {
+                $widthProperty  = $file->getProperty('width');
+                $heightProperty = $file->getProperty('height');
+                $w              = is_numeric($widthProperty) ? (int) $widthProperty : 0;
+                $h              = is_numeric($heightProperty) ? (int) $heightProperty : 0;
+            }
+
+            // Scale factor by target box (maintain aspect ratio)
+            $scale = 1.0;
+            if ($w > 0 && $h > 0 && ($w > $maxWidth || $h > $maxHeight)) {
+                $scale = min($maxWidth / max(1, $w), $maxHeight / max(1, $h));
+            }
+
+            // Experience-based compression gains per type (without re-encoding)
+            $baseGainByType = [
+                'jpg'  => 0.15,
+                'jpeg' => 0.15,
+                'png'  => 0.10,
+                'gif'  => 0.10,
+            ];
+            $baseGain = $baseGainByType[$ext];
+
+            // Estimated size scales with pixel count; add base compression gain
+            $areaFactor = $scale * $scale; // 1.0 if no resize
+            $after      = max(0, (int) round($before * $areaFactor * (1 - $baseGain)));
+            $saved      = max(0, $before - $after);
+
+            $improvable = $saved > 0;
+
+            return [
+                'optimized'  => $improvable,
+                'savedBytes' => $saved,
+                'before'     => $before,
+                'after'      => $after,
+                'tool'       => null,
+            ];
+        } finally {
+            @unlink($localPath);
+        }
+    }
+}

--- a/Classes/ViewHelpers/SourceSetViewHelper.php
+++ b/Classes/ViewHelpers/SourceSetViewHelper.php
@@ -256,9 +256,9 @@ class SourceSetViewHelper extends AbstractViewHelper
         return array_filter(
             $props,
             static fn (int|string|null $value, string|int $key): bool => match (true) {
-                $key === 'alt' => $value !== null,
+                $key === 'alt'                      => $value !== null,
                 $key === 'width', $key === 'height' => !in_array($value, [null, '', 0], true),
-                default => $value !== null && $value !== '',
+                default                             => $value !== null && $value !== '',
             },
             ARRAY_FILTER_USE_BOTH,
         );
@@ -606,7 +606,7 @@ class SourceSetViewHelper extends AbstractViewHelper
 
         return match ($value) {
             'high', 'low', 'auto' => $value,
-            default => '',
+            default               => '',
         };
     }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,6 +6,7 @@ services:
 
   Netresearch\NrImageOptimize\:
     resource: '../Classes/*'
+    exclude: '../Classes/Domain/Model/*'
 
   Intervention\Image\ImageManager:
     factory:
@@ -20,3 +21,14 @@ services:
 
   Netresearch\NrImageOptimize\Controller\MaintenanceController:
     public: true
+
+  Netresearch\NrImageOptimize\EventListener\OptimizeOnUploadListener:
+    tags:
+      - name: event.listener
+        identifier: 'nr_image_optimize.optimize_on_upload.added'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileAddedEvent
+        method: optimizeAfterAdd
+      - name: event.listener
+        identifier: 'nr_image_optimize.optimize_on_upload.replaced'
+        event: TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent
+        method: optimizeAfterReplace

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,7 +6,6 @@ services:
 
   Netresearch\NrImageOptimize\:
     resource: '../Classes/*'
-    exclude: '../Classes/Domain/Model/*'
 
   Intervention\Image\ImageManager:
     factory:

--- a/Tests/Unit/Command/AbstractImageCommandTest.php
+++ b/Tests/Unit/Command/AbstractImageCommandTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Tests\Unit\Command;
+
+use Generator;
+use Netresearch\NrImageOptimize\Command\AbstractImageCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function str_repeat;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Tests for the helper methods on AbstractImageCommand.
+ *
+ * The abstract base is exercised through a thin fixture subclass that exposes
+ * the protected helpers. Database-backed methods (countImages, iterateViaIndex)
+ * are intentionally out of scope here and live in the functional test layer.
+ *
+ * No CoversClass attribute: final/abstract classes cannot always be instrumented
+ * by PCOV on PHP 8.5, causing PHPUnit coverage warnings.
+ */
+class AbstractImageCommandTest extends TestCase
+{
+    private AbstractImageCommandTestFixture $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->command = new AbstractImageCommandTestFixture();
+    }
+
+    /**
+     * @return array<string, array{0: array<int|string, mixed>, 1: list<int>}>
+     */
+    public static function parseStorageUidsOptionProvider(): array
+    {
+        return [
+            'empty array'                      => [[], []],
+            'single numeric string'            => [['5'], [5]],
+            'single numeric int'               => [[7], [7]],
+            'comma separated'                  => [['1,2,3'], [1, 2, 3]],
+            'multiple values'                  => [['1', '2', '3'], [1, 2, 3]],
+            'mixed comma and individual'       => [['1,2', '3'], [1, 2, 3]],
+            'non-numeric parts skipped'        => [['1,abc,2'], [1, 2]],
+            'non-scalar value skipped'         => [[['nested'], '4'], [4]],
+            'empty strings stripped'           => [[',,,1,,,'], [1]],
+            'whitespace trimmed around values' => [[' 1 , 2 '], [1, 2]],
+            'null value skipped'               => [[null, '3'], [3]],
+            'bool scalar value preserved'      => [[true, '5'], [1, 5]],
+            'negative numbers parsed'          => [['-1,-2'], [-1, -2]],
+        ];
+    }
+
+    /**
+     * @param array<int|string, mixed> $input
+     * @param list<int>                $expected
+     */
+    #[Test]
+    #[DataProvider('parseStorageUidsOptionProvider')]
+    public function parseStorageUidsOptionReturnsExpectedList(array $input, array $expected): void
+    {
+        self::assertSame($expected, $this->command->callParseStorageUidsOption($input));
+    }
+
+    /**
+     * @return array<string, array{0: mixed, 1: int, 2: int}>
+     */
+    public static function getIntOptionProvider(): array
+    {
+        return [
+            'numeric string'            => ['42', 10, 42],
+            'plain int'                 => [7, 10, 7],
+            'float'                     => [3.7, 10, 3],
+            'null uses default'         => [null, 10, 10],
+            'non-numeric string'        => ['foo', 10, 10],
+            'bool true uses default'    => [true, 10, 10],
+            'bool false uses default'   => [false, 10, 10],
+            'empty string uses default' => ['', 10, 10],
+            'numeric zero'              => ['0', 10, 0],
+            'negative numeric'          => ['-5', 10, -5],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('getIntOptionProvider')]
+    public function getIntOptionReturnsExpectedInt(mixed $value, int $default, int $expected): void
+    {
+        self::assertSame($expected, $this->command->callGetIntOption($value, $default));
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: int}>
+     */
+    public static function extractUidProvider(): array
+    {
+        return [
+            'missing key'    => [[], 0],
+            'numeric int'    => [['uid' => 42], 42],
+            'numeric string' => [['uid' => '17'], 17],
+            'null value'     => [['uid' => null], 0],
+            'non-numeric'    => [['uid' => 'abc'], 0],
+            'zero'           => [['uid' => 0], 0],
+            'float value'    => [['uid' => 3.9], 3],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    #[Test]
+    #[DataProvider('extractUidProvider')]
+    public function extractUidReturnsExpectedUid(array $record, int $expected): void
+    {
+        self::assertSame($expected, $this->command->callExtractUid($record));
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function buildLabelProvider(): array
+    {
+        return [
+            'with identifier'            => [['identifier' => 'path/to/file.jpg'], 'path/to/file.jpg'],
+            'without identifier uid int' => [['uid' => 42], '#42'],
+            'empty identifier uses uid'  => [['identifier' => '', 'uid' => 9], '#9'],
+            'non-string identifier'      => [['identifier' => 123, 'uid' => 9], '#9'],
+            'non-scalar uid'             => [['uid' => ['nested']], '#?'],
+            'missing both'               => [[], '#?'],
+            'numeric uid as string'      => [['uid' => '123'], '#123'],
+            'bool uid'                   => [['uid' => true], '#1'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    #[Test]
+    #[DataProvider('buildLabelProvider')]
+    public function buildLabelReturnsExpectedLabel(array $record, string $expected): void
+    {
+        self::assertSame($expected, $this->command->callBuildLabel($record));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int, 2: string}>
+     */
+    public static function shortenLabelProvider(): array
+    {
+        return [
+            'short text unchanged'    => ['abc', 10, 'abc'],
+            'exactly maxLen'          => ['abcdef', 6, 'abcdef'],
+            'long text ellipsized'    => ['abcdefghij', 5, 'ab…ij'],
+            'collapses whitespace'    => ["foo\n\tbar", 20, 'foo bar'],
+            'maxLen three kept as-is' => ['abc', 3, 'abc'],
+            'maxLen three truncated'  => ['abcdef', 3, 'abc'],
+            'maxLen two truncated'    => ['abcd', 2, 'ab'],
+            'maxLen zero truncated'   => ['abcd', 0, ''],
+            'maxLen four ellipsized'  => ['abcdefgh', 4, 'a…h'],
+            'very long text'          => [str_repeat('x', 100), 11, 'xxxxx…xxxxx'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('shortenLabelProvider')]
+    public function shortenLabelReturnsExpectedString(string $text, int $maxLen, string $expected): void
+    {
+        self::assertSame($expected, $this->command->callShortenLabel($text, $maxLen));
+    }
+
+    /**
+     * @return array<string, array{0: int, 1: string}>
+     */
+    public static function formatMbGbProvider(): array
+    {
+        return [
+            'zero bytes'  => [0, '0.00 MB / 0.00 GB'],
+            'one mb'      => [1048576, '1.00 MB / 0.00 GB'],
+            'one gb'      => [1073741824, '1,024.00 MB / 1.00 GB'],
+            'half mb'     => [524288, '0.50 MB / 0.00 GB'],
+            'large value' => [5368709120, '5,120.00 MB / 5.00 GB'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('formatMbGbProvider')]
+    public function formatMbGbReturnsExpectedFormattedString(int $bytes, string $expected): void
+    {
+        self::assertSame($expected, $this->command->callFormatMbGb($bytes));
+    }
+
+    #[Test]
+    public function createProgressReturnsProgressBarAndMessageMax(): void
+    {
+        $input  = new ArrayInput([]);
+        $output = new BufferedOutput();
+        $io     = new SymfonyStyle($input, $output);
+
+        $result = $this->command->callCreateProgress($io, 42);
+
+        self::assertArrayHasKey('progress', $result);
+        self::assertArrayHasKey('messageMax', $result);
+        self::assertInstanceOf(ProgressBar::class, $result['progress']);
+        self::assertGreaterThanOrEqual(10, $result['messageMax']);
+        self::assertSame(42, $result['progress']->getMaxSteps());
+    }
+
+    #[Test]
+    public function createProgressEnforcesMinimumMessageMaxOfTen(): void
+    {
+        // Even on a pathologically narrow terminal the messageMax must be >= 10.
+        $input  = new ArrayInput([]);
+        $output = new BufferedOutput();
+        $io     = new SymfonyStyle($input, $output);
+
+        $result = $this->command->callCreateProgress($io, 1);
+
+        self::assertGreaterThanOrEqual(10, $result['messageMax']);
+        self::assertInstanceOf(ProgressBar::class, $result['progress']);
+    }
+}
+
+/**
+ * Test-only fixture that exposes the protected helper methods.
+ *
+ * Lives in the same file to keep the fixture adjacent to the test cases
+ * that drive it and to avoid leaking a test-only class into the global
+ * test autoload namespace.
+ */
+final class AbstractImageCommandTestFixture extends AbstractImageCommand
+{
+    /**
+     * @param array<int|string, mixed> $values
+     *
+     * @return list<int>
+     */
+    public function callParseStorageUidsOption(array $values): array
+    {
+        return $this->parseStorageUidsOption($values);
+    }
+
+    public function callGetIntOption(mixed $value, int $default): int
+    {
+        return $this->getIntOption($value, $default);
+    }
+
+    /**
+     * @param array<string,mixed> $record
+     */
+    public function callExtractUid(array $record): int
+    {
+        return $this->extractUid($record);
+    }
+
+    /**
+     * @param array<string,mixed> $record
+     */
+    public function callBuildLabel(array $record): string
+    {
+        return $this->buildLabel($record);
+    }
+
+    public function callShortenLabel(string $text, int $maxLen): string
+    {
+        return $this->shortenLabel($text, $maxLen);
+    }
+
+    public function callFormatMbGb(int $bytes): string
+    {
+        return $this->formatMbGb($bytes);
+    }
+
+    /**
+     * @return array{progress: ProgressBar, messageMax: int}
+     */
+    public function callCreateProgress(SymfonyStyle $io, int $count): array
+    {
+        return $this->createProgress($io, $count);
+    }
+
+    /**
+     * Expose the protected countImages contract shape via a generator.
+     *
+     * Included only so the fixture keeps AbstractImageCommand's public
+     * surface intact for other tests; not invoked here.
+     *
+     * @param list<int> $onlyStorageUids
+     *
+     * @return Generator<int, array<string, mixed>>
+     */
+    public function callIterateViaIndex(array $onlyStorageUids): Generator
+    {
+        yield from $this->iterateViaIndex($onlyStorageUids);
+    }
+}

--- a/Tests/Unit/Command/AnalyzeImagesCommandTest.php
+++ b/Tests/Unit/Command/AnalyzeImagesCommandTest.php
@@ -1,0 +1,405 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Tests\Unit\Command;
+
+use Doctrine\DBAL\Result;
+
+use function file_put_contents;
+use function is_file;
+
+use Netresearch\NrImageOptimize\Command\AnalyzeImagesCommand;
+use Netresearch\NrImageOptimize\Service\ImageOptimizer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function putenv;
+use function str_repeat;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function sys_get_temp_dir;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function uniqid;
+use function unlink;
+
+/**
+ * Unit tests for AnalyzeImagesCommand::execute().
+ *
+ * Scope: orchestration logic in execute() — reading options, handling the
+ * "no matching files" early exit, iterating fixture records, dispatching to
+ * the heuristic analyzer, counting improvable/no-gain buckets.
+ *
+ * The command is final so it cannot be subclassed. The ConnectionPool
+ * consumed by countImages()/iterateViaIndex() is faked via
+ * GeneralUtility::addInstance() with a pre-seeded QueryBuilder chain.
+ *
+ * No CoversClass attribute: final classes cannot be instrumented
+ * by PCOV on PHP 8.5, causing PHPUnit coverage warnings.
+ */
+class AnalyzeImagesCommandTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('OPTIPNG_BIN=/nonexistent-optipng-binary');
+        putenv('GIFSICLE_BIN=/nonexistent-gifsicle-binary');
+        putenv('JPEGOPTIM_BIN=/nonexistent-jpegoptim-binary');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('OPTIPNG_BIN');
+        putenv('GIFSICLE_BIN');
+        putenv('JPEGOPTIM_BIN');
+
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+
+        GeneralUtility::purgeInstances();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Queue two ConnectionPool fakes (one per call — countImages and
+     * iterateViaIndex each call makeInstance once).
+     *
+     * @param list<array<string, mixed>> $records
+     */
+    private function installConnectionPoolFake(int $count, array $records = []): void
+    {
+        GeneralUtility::addInstance(ConnectionPool::class, $this->createConnectionPoolFake($count, $records));
+        GeneralUtility::addInstance(ConnectionPool::class, $this->createConnectionPoolFake($count, $records));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $records
+     */
+    private function createConnectionPoolFake(int $count, array $records): ConnectionPool
+    {
+        $expr = $this->createMock(ExpressionBuilder::class);
+        $expr->method('eq')->willReturn('');
+        $expr->method('in')->willReturn('');
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn((string) $count);
+
+        $queue = $records;
+        $result->method('fetchAssociative')
+            ->willReturnCallback(static function () use (&$queue): array|false {
+                if ($queue === []) {
+                    return false;
+                }
+
+                return array_shift($queue);
+            });
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('count')->willReturnSelf();
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('join')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturn('?');
+        $qb->method('executeQuery')->willReturn($result);
+
+        $conn = $this->createMock(Connection::class);
+        $conn->method('createQueryBuilder')->willReturn($qb);
+
+        $pool = $this->createMock(ConnectionPool::class);
+        $pool->method('getConnectionForTable')->willReturn($conn);
+
+        return $pool;
+    }
+
+    /**
+     * Build a File+Storage mock.
+     *
+     * @return array{file: File&MockObject, storage: ResourceStorage&MockObject}
+     */
+    private function createFileAndStorage(
+        string $identifier,
+        string $extension,
+        string $localPath,
+        bool $exists = true,
+    ): array {
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getEvaluatePermissions')->willReturn(true);
+
+        $file = $this->createMock(File::class);
+        $file->method('getIdentifier')->willReturn($identifier);
+        $file->method('getExtension')->willReturn($extension);
+        $file->method('getStorage')->willReturn($storage);
+        $file->method('getForLocalProcessing')->willReturn($localPath);
+        $file->method('exists')->willReturn($exists);
+
+        return ['file' => $file, 'storage' => $storage];
+    }
+
+    /**
+     * Pad a file with arbitrary bytes so analyzeHeuristic's minSize gate is
+     * crossed.
+     */
+    private function createLargeFile(string $extension, int $size = 600_000): string
+    {
+        $tmp               = sys_get_temp_dir() . '/nr-ana-' . uniqid('', true) . '.' . $extension;
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', $size));
+
+        return $tmp;
+    }
+
+    #[Test]
+    public function executeReturnsSuccessAndWarnsWhenNoMatchingFiles(): void
+    {
+        $factory   = $this->createMock(ResourceFactory::class);
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(0);
+
+        $command = new AnalyzeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertStringContainsString('No matching image files found', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeReportsImprovableWhenLargeImageAnalyzedAsImprovable(): void
+    {
+        $localPath = $this->createLargeFile('png');
+
+        ['file' => $file] = $this->createFileAndStorage(
+            '/big.png',
+            'png',
+            $localPath,
+        );
+        // Provide fallback dimensions so the scaling path is exercised.
+        $file->method('getProperty')
+            ->willReturnCallback(static fn (string $key): mixed => match ($key) {
+                'width'  => 4000,
+                'height' => 3000,
+                default  => null,
+            });
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/big.png'],
+        ]);
+
+        $command = new AnalyzeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Improvable: 1', $display);
+        self::assertStringContainsString('No potential: 0', $display);
+    }
+
+    #[Test]
+    public function executeAdvancesProgressWhenFileDoesNotExistOnStorage(): void
+    {
+        // File::exists() returns false => analyzeHeuristic is never called
+        // but the progress bar still advances and the final tally is 0/0.
+        $localPath = '/does/not/matter/missing.png';
+
+        ['file' => $file] = $this->createFileAndStorage(
+            '/missing.png',
+            'png',
+            $localPath,
+            exists: false,
+        );
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/missing.png'],
+        ]);
+
+        $command = new AnalyzeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        // Neither bucket incremented, but total files remains the count.
+        self::assertStringContainsString('Files: 1', $display);
+        self::assertStringContainsString('Improvable: 0', $display);
+        self::assertStringContainsString('No potential: 0', $display);
+    }
+
+    #[Test]
+    public function executeCountsNoGainWhenFileBelowMinSize(): void
+    {
+        // Small file below default minSize => analyzeHeuristic returns
+        // optimized=false without doing work, so the "noGain" counter wins.
+        $tmp               = sys_get_temp_dir() . '/nr-ana-' . uniqid('', true) . '.png';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 100));
+
+        ['file' => $file] = $this->createFileAndStorage(
+            '/tiny.png',
+            'png',
+            $tmp,
+        );
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/tiny.png'],
+        ]);
+
+        $command = new AnalyzeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Improvable: 0', $display);
+        self::assertStringContainsString('No potential: 1', $display);
+    }
+
+    #[Test]
+    public function executeAcceptsMaxWidthMaxHeightMinSizeOptions(): void
+    {
+        $localPath = $this->createLargeFile('png', 1_000_000);
+
+        ['file' => $file] = $this->createFileAndStorage(
+            '/big.png',
+            'png',
+            $localPath,
+        );
+        $file->method('getProperty')
+            ->willReturnCallback(static fn (string $key): mixed => match ($key) {
+                'width'  => 5000,
+                'height' => 4000,
+                default  => null,
+            });
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/big.png'],
+        ]);
+
+        $command = new AnalyzeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--max-width'  => '1024',
+            '--max-height' => '768',
+            '--min-size'   => '1024',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertStringContainsString('Improvable: 1', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeAcceptsStoragesOption(): void
+    {
+        $factory   = $this->createMock(ResourceFactory::class);
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(0);
+
+        $command = new AnalyzeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--storages' => ['2,3', '4'],
+        ]);
+
+        self::assertSame(Command::SUCCESS, $status);
+    }
+
+    #[Test]
+    public function executeRestoresPreviousStoragePermissions(): void
+    {
+        $localPath = $this->createLargeFile('png');
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getEvaluatePermissions')->willReturn(true);
+
+        $captured = [];
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function (bool $value) use (&$captured): void {
+                $captured[] = $value;
+            });
+
+        $file = $this->createMock(File::class);
+        $file->method('getIdentifier')->willReturn('/perm.png');
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getStorage')->willReturn($storage);
+        $file->method('getForLocalProcessing')->willReturn($localPath);
+        $file->method('exists')->willReturn(true);
+        $file->method('getProperty')->willReturn(null);
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/perm.png'],
+        ]);
+
+        $command = new AnalyzeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertSame([false, true], $captured);
+    }
+}

--- a/Tests/Unit/Command/OptimizeImagesCommandTest.php
+++ b/Tests/Unit/Command/OptimizeImagesCommandTest.php
@@ -1,0 +1,518 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Tests\Unit\Command;
+
+use function chmod;
+
+use Doctrine\DBAL\Result;
+
+use function file_put_contents;
+use function is_file;
+
+use Netresearch\NrImageOptimize\Command\OptimizeImagesCommand;
+use Netresearch\NrImageOptimize\Service\ImageOptimizer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function putenv;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function sys_get_temp_dir;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function uniqid;
+use function unlink;
+
+/**
+ * Unit tests for OptimizeImagesCommand::execute().
+ *
+ * Scope: orchestration logic in execute() — reading options, handling the
+ * "no tools" error, early-exit on no matching files, iterating fixture
+ * records, dispatching to ImageOptimizer, reporting per-file results.
+ *
+ * The command is final so it cannot be subclassed. Instead the ConnectionPool
+ * used by the parent's countImages()/iterateViaIndex() helpers is faked via
+ * GeneralUtility::addInstance(): each test queues a mock ConnectionPool that
+ * returns a pre-seeded QueryBuilder chain. ImageOptimizer is the real class,
+ * but binary resolution is pinned via env overrides to /bin/true or /bin/false
+ * so no real optimization process is spawned.
+ *
+ * No CoversClass attribute: final classes cannot be instrumented
+ * by PCOV on PHP 8.5, causing PHPUnit coverage warnings.
+ */
+class OptimizeImagesCommandTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Default: no tool available. Tests opt into a specific branch by
+        // overriding one of these env vars with /bin/true, /bin/false, or a
+        // custom stub binary.
+        putenv('OPTIPNG_BIN=/nonexistent-optipng-binary');
+        putenv('GIFSICLE_BIN=/nonexistent-gifsicle-binary');
+        putenv('JPEGOPTIM_BIN=/nonexistent-jpegoptim-binary');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('OPTIPNG_BIN');
+        putenv('GIFSICLE_BIN');
+        putenv('JPEGOPTIM_BIN');
+
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+
+        GeneralUtility::purgeInstances();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Queue a ConnectionPool mock that answers count and iterate with fixture
+     * data.  The helper installs two separate ConnectionPool instances — the
+     * command code calls makeInstance(ConnectionPool::class) once inside
+     * countImages() and once inside iterateViaIndex().
+     *
+     * @param list<array<string, mixed>> $records
+     */
+    private function installConnectionPoolFake(int $count, array $records = []): void
+    {
+        GeneralUtility::addInstance(ConnectionPool::class, $this->createConnectionPoolFake($count, $records));
+        GeneralUtility::addInstance(ConnectionPool::class, $this->createConnectionPoolFake($count, $records));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $records
+     */
+    private function createConnectionPoolFake(int $count, array $records): ConnectionPool
+    {
+        $expr = $this->createMock(ExpressionBuilder::class);
+        $expr->method('eq')->willReturn('');
+        $expr->method('in')->willReturn('');
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn((string) $count);
+
+        // Simulate generator behaviour via an iterator over $records.
+        $queue = $records;
+        $result->method('fetchAssociative')
+            ->willReturnCallback(static function () use (&$queue): array|false {
+                if ($queue === []) {
+                    return false;
+                }
+
+                return array_shift($queue);
+            });
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('count')->willReturnSelf();
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('join')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturn('?');
+        $qb->method('executeQuery')->willReturn($result);
+
+        $conn = $this->createMock(Connection::class);
+        $conn->method('createQueryBuilder')->willReturn($qb);
+
+        $pool = $this->createMock(ConnectionPool::class);
+        $pool->method('getConnectionForTable')->willReturn($conn);
+
+        return $pool;
+    }
+
+    /**
+     * Build a File+Storage mock pair for the factory to return.
+     *
+     * @return array{file: File&MockObject, storage: ResourceStorage&MockObject}
+     */
+    private function createFileAndStorage(
+        string $identifier,
+        string $extension,
+        string $localPath,
+    ): array {
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getEvaluatePermissions')->willReturn(true);
+
+        $file = $this->createMock(File::class);
+        $file->method('getIdentifier')->willReturn($identifier);
+        $file->method('getExtension')->willReturn($extension);
+        $file->method('getStorage')->willReturn($storage);
+        $file->method('getForLocalProcessing')->willReturn($localPath);
+
+        return ['file' => $file, 'storage' => $storage];
+    }
+
+    /**
+     * Create a temp JPEG file so that ImageOptimizer's is_file() gate passes.
+     */
+    private function createTempJpeg(): string
+    {
+        $tmp               = sys_get_temp_dir() . '/nr-cmd-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, 'fake-jpeg-bytes-' . uniqid('', true));
+
+        return $tmp;
+    }
+
+    #[Test]
+    public function executeReturnsFailureWhenNoToolIsAvailable(): void
+    {
+        $factory   = $this->createMock(ResourceFactory::class);
+        $optimizer = new ImageOptimizer();
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $status);
+        self::assertStringContainsString('No optimization tools found', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeReturnsSuccessAndWarnsWhenNoMatchingFiles(): void
+    {
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $factory   = $this->createMock(ResourceFactory::class);
+        $optimizer = new ImageOptimizer();
+
+        // Only countImages is called when the result is 0 — one pool instance
+        // is enough, but install two to stay consistent with other tests.
+        $this->installConnectionPoolFake(0);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertStringContainsString('No matching image files found', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeSkipsRecordsWithUnsupportedExtension(): void
+    {
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        ['file' => $file] = $this->createFileAndStorage(
+            '/unsupported.bmp',
+            'bmp',
+            '/does/not/matter',
+        );
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/unsupported.bmp'],
+        ]);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Skipping /unsupported.bmp', $display);
+        self::assertStringContainsString('Skipped: 1', $display);
+    }
+
+    #[Test]
+    public function executeDryRunDoesNotRunOptimizer(): void
+    {
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $localPath = $this->createTempJpeg();
+
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/photo.jpg',
+            'jpg',
+            $localPath,
+        );
+
+        // replaceFile must never be invoked under dry-run.
+        $storage->expects(self::never())->method('replaceFile');
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/photo.jpg'],
+        ]);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Dry-run enabled', $display);
+        self::assertStringContainsString('[DRY] Would optimize /photo.jpg with jpegoptim', $display);
+        // The source temp file must still exist — dry-run does not touch it.
+        self::assertFileExists($localPath);
+    }
+
+    #[Test]
+    public function executePrintsNoSavingsWhenToolDoesNotShrink(): void
+    {
+        // /bin/true exits 0 without modifying the file => after == before.
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $localPath = $this->createTempJpeg();
+
+        ['file' => $file] = $this->createFileAndStorage(
+            '/nochange.jpg',
+            'jpg',
+            $localPath,
+        );
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/nochange.jpg'],
+        ]);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('No savings: /nochange.jpg', $display);
+        self::assertStringContainsString('Optimized: 0', $display);
+    }
+
+    #[Test]
+    public function executeReportsOptimizedFileWhenToolShrinksIt(): void
+    {
+        // Wrapper that truncates the LAST argument (the file path for
+        // jpegoptim) so the file becomes smaller — triggers the "optimized"
+        // branch that calls replaceFile.
+        $wrapper           = sys_get_temp_dir() . '/nr-fake-wrapper-' . uniqid('', true) . '.sh';
+        $this->tempFiles[] = $wrapper;
+        file_put_contents($wrapper, <<<'SHELL'
+            #!/bin/sh
+            # Truncate the last argument (the file path passed by jpegoptim).
+            eval "last=\${$#}"
+            : > "$last"
+            exit 0
+
+            SHELL);
+        chmod($wrapper, 0o755);
+
+        putenv('JPEGOPTIM_BIN=' . $wrapper);
+
+        $localPath = $this->createTempJpeg();
+
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/shrink.jpg',
+            'jpg',
+            $localPath,
+        );
+
+        // Storage::replaceFile must be called on the "optimized" branch.
+        $storage->expects(self::once())
+            ->method('replaceFile')
+            ->with($file, $localPath);
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/shrink.jpg'],
+        ]);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Optimized: /shrink.jpg', $display);
+        self::assertStringContainsString('Optimized: 1', $display);
+    }
+
+    #[Test]
+    public function executeReportsNoSavingsWhenToolRunFails(): void
+    {
+        // /bin/false exits 1 => optimize() returns optimized=false with tool.
+        putenv('JPEGOPTIM_BIN=/bin/false');
+
+        $localPath = $this->createTempJpeg();
+
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/fails.jpg',
+            'jpg',
+            $localPath,
+        );
+
+        // replaceFile must NOT be called when the process fails.
+        $storage->expects(self::never())->method('replaceFile');
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/fails.jpg'],
+        ]);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        // The optimizer still reports the tool name; the command logs "No
+        // savings" because optimized=false.
+        self::assertStringContainsString('No savings: /fails.jpg', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeAcceptsJpegQualityAndStripMetadataOptions(): void
+    {
+        // Validates that option parsing does not crash and the run still
+        // completes. /bin/true lands us in the "No savings" branch.
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $localPath = $this->createTempJpeg();
+
+        ['file' => $file] = $this->createFileAndStorage(
+            '/quality.jpg',
+            'jpg',
+            $localPath,
+        );
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/quality.jpg'],
+        ]);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--jpeg-quality'   => '75',
+            '--strip-metadata' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertStringContainsString('No savings: /quality.jpg', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeAcceptsStoragesOptionWithoutError(): void
+    {
+        // The --storages option is parsed via parseStorageUidsOption in the
+        // base class; this test mainly confirms the code path doesn't crash
+        // when the option is provided.
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $factory   = $this->createMock(ResourceFactory::class);
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(0);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--storages' => ['1,2', '3'],
+        ]);
+
+        self::assertSame(Command::SUCCESS, $status);
+    }
+
+    #[Test]
+    public function executeRestoresPreviousStoragePermissionsAfterProcessing(): void
+    {
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $localPath = $this->createTempJpeg();
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getEvaluatePermissions')->willReturn(true);
+
+        $captured = [];
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function (bool $value) use (&$captured): void {
+                $captured[] = $value;
+            });
+
+        $file = $this->createMock(File::class);
+        $file->method('getIdentifier')->willReturn('/perm.jpg');
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getStorage')->willReturn($storage);
+        $file->method('getForLocalProcessing')->willReturn($localPath);
+
+        $factory = $this->createMock(ResourceFactory::class);
+        $factory->method('getFileObject')->willReturn($file);
+
+        $optimizer = new ImageOptimizer();
+
+        $this->installConnectionPoolFake(1, [
+            ['uid' => 1, 'identifier' => '/perm.jpg'],
+        ]);
+
+        $command = new OptimizeImagesCommand($factory, $optimizer);
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        // Toggled off (false) before processing then restored (true) in finally.
+        self::assertSame([false, true], $captured);
+    }
+}

--- a/Tests/Unit/EventListener/OptimizeOnUploadListenerTest.php
+++ b/Tests/Unit/EventListener/OptimizeOnUploadListenerTest.php
@@ -1,0 +1,420 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Tests\Unit\EventListener;
+
+use function chmod;
+use function file_put_contents;
+use function is_file;
+
+use Netresearch\NrImageOptimize\EventListener\OptimizeOnUploadListener;
+use Netresearch\NrImageOptimize\Service\ImageOptimizer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function putenv;
+
+use ReflectionProperty;
+use RuntimeException;
+
+use function sys_get_temp_dir;
+
+use TYPO3\CMS\Core\Resource\Event\AfterFileAddedEvent;
+use TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent;
+use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+
+use function uniqid;
+use function unlink;
+
+/**
+ * Tests for OptimizeOnUploadListener.
+ *
+ * Covers:
+ * - Early-return branches (offline storage, unsupported extension)
+ * - Re-entrancy guarding via the private $guard map
+ * - Permission disable / restore in the finally block
+ * - Dispatch via both AfterFileAdded and AfterFileReplaced events
+ *
+ * Because ImageOptimizer is declared final (and therefore cannot be mocked by
+ * PHPUnit without runtime class hacks), the listener is driven with a real
+ * ImageOptimizer whose binary resolution is pinned via env overrides to a
+ * well-defined state. Behaviour is verified through observable storage
+ * interactions plus direct inspection of the listener's re-entrancy guard
+ * via reflection.
+ *
+ * No CoversClass attribute: final classes cannot be instrumented
+ * by PCOV on PHP 8.5, causing PHPUnit coverage warnings.
+ */
+class OptimizeOnUploadListenerTest extends TestCase
+{
+    private OptimizeOnUploadListener $listener;
+
+    private ImageOptimizer $optimizer;
+
+    private ReflectionProperty $guardProperty;
+
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Force ImageOptimizer into a deterministic "no tools available" state
+        // so optimize() reliably takes its null-tool early return. Individual
+        // tests may override the env and rebuild the optimizer.
+        putenv('OPTIPNG_BIN=/nonexistent-optipng-binary');
+        putenv('GIFSICLE_BIN=/nonexistent-gifsicle-binary');
+        putenv('JPEGOPTIM_BIN=/nonexistent-jpegoptim-binary');
+
+        $this->optimizer     = new ImageOptimizer();
+        $this->listener      = new OptimizeOnUploadListener($this->optimizer);
+        $this->guardProperty = new ReflectionProperty(OptimizeOnUploadListener::class, 'guard');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('OPTIPNG_BIN');
+        putenv('GIFSICLE_BIN');
+        putenv('JPEGOPTIM_BIN');
+
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function readGuard(): array
+    {
+        /** @var array<string, true> $value */
+        $value = $this->guardProperty->getValue($this->listener);
+
+        return $value;
+    }
+
+    /**
+     * Build a FileInterface mock bound to a ResourceStorage mock with the
+     * given pre-wired state.
+     *
+     * @return array{file: FileInterface&MockObject, storage: ResourceStorage&MockObject}
+     */
+    private function createFileAndStorage(
+        string $identifier,
+        string $extension,
+        bool $isOnline = true,
+        bool $previousPermissions = true,
+    ): array {
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('isOnline')->willReturn($isOnline);
+        $storage->method('getEvaluatePermissions')->willReturn($previousPermissions);
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getIdentifier')->willReturn($identifier);
+        $file->method('getExtension')->willReturn($extension);
+        $file->method('getStorage')->willReturn($storage);
+
+        return ['file' => $file, 'storage' => $storage];
+    }
+
+    #[Test]
+    public function optimizeAfterAddEntersFullHandlerForSupportedFile(): void
+    {
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/uploaded.png',
+            'png',
+            previousPermissions: true,
+        );
+
+        $captured = [];
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function (bool $value) use (&$captured): void {
+                $captured[] = $value;
+            });
+
+        $folder = $this->createMock(Folder::class);
+        $event  = new AfterFileAddedEvent($file, $folder);
+
+        $this->listener->optimizeAfterAdd($event);
+
+        // Entry path: permissions toggled off then restored via the finally block.
+        self::assertSame([false, true], $captured);
+        self::assertSame([], $this->readGuard(), 'Guard should be cleared after processing');
+    }
+
+    #[Test]
+    public function optimizeAfterReplaceEntersFullHandlerForSupportedFile(): void
+    {
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/replaced.jpg',
+            'jpg',
+        );
+
+        $captured = [];
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function (bool $value) use (&$captured): void {
+                $captured[] = $value;
+            });
+
+        $event = new AfterFileReplacedEvent($file, '/tmp/local.jpg');
+
+        $this->listener->optimizeAfterReplace($event);
+
+        self::assertSame([false, true], $captured);
+        self::assertSame([], $this->readGuard());
+    }
+
+    #[Test]
+    public function storageOfflineSkipsOptimize(): void
+    {
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/offline.png',
+            'png',
+            isOnline: false,
+        );
+
+        $storage->expects(self::never())->method('setEvaluatePermissions');
+        $storage->expects(self::never())->method('getEvaluatePermissions');
+
+        $folder = $this->createMock(Folder::class);
+        $event  = new AfterFileAddedEvent($file, $folder);
+
+        $this->listener->optimizeAfterAdd($event);
+
+        self::assertSame([], $this->readGuard());
+    }
+
+    #[Test]
+    public function unsupportedExtensionSkipsOptimize(): void
+    {
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/document.pdf',
+            'pdf',
+        );
+
+        $storage->expects(self::never())->method('setEvaluatePermissions');
+        $storage->expects(self::never())->method('getEvaluatePermissions');
+
+        $folder = $this->createMock(Folder::class);
+        $event  = new AfterFileAddedEvent($file, $folder);
+
+        $this->listener->optimizeAfterAdd($event);
+
+        self::assertSame([], $this->readGuard());
+    }
+
+    #[Test]
+    public function uppercaseExtensionIsNormalizedAndProcessed(): void
+    {
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/photo.JPEG',
+            'JPEG',
+        );
+
+        $setCalls = 0;
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function () use (&$setCalls): void {
+                ++$setCalls;
+            });
+
+        $folder = $this->createMock(Folder::class);
+        $event  = new AfterFileAddedEvent($file, $folder);
+
+        $this->listener->optimizeAfterAdd($event);
+
+        // If extension normalization failed, we would have bailed before
+        // touching permissions at all.
+        self::assertSame(2, $setCalls, 'Expected permissions toggled off and restored');
+    }
+
+    #[Test]
+    public function reEntrancyGuardBlocksNestedInvocationForSameIdentifier(): void
+    {
+        $identifier = '/recursive.png';
+
+        // Install a real binary (a shell stub that does nothing) so the real
+        // optimizer proceeds beyond the null-tool branch. The nested call
+        // comes from within getForLocalProcessing(), which we intercept via
+        // the mock to fire the AfterFileReplacedEvent for the same file.
+        $fakeOptipng       = sys_get_temp_dir() . '/nr-pio-fake-optipng-' . uniqid('', true);
+        $this->tempFiles[] = $fakeOptipng;
+        file_put_contents($fakeOptipng, "#!/bin/sh\nexit 0\n");
+        chmod($fakeOptipng, 0o755);
+        putenv('OPTIPNG_BIN=' . $fakeOptipng);
+
+        // Rebuild the optimizer/listener now that the binary exists.
+        $this->optimizer = new ImageOptimizer();
+        $this->listener  = new OptimizeOnUploadListener($this->optimizer);
+
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            $identifier,
+            'png',
+        );
+
+        // getForLocalProcessing is called by optimize() once the tool resolves.
+        // Use that hook to fire a nested replacement event for the same file —
+        // the listener's guard must short-circuit the nested handle().
+        $nestedInvocationCount = 0;
+        $file->method('getForLocalProcessing')
+            ->willReturnCallback(function () use ($file, &$nestedInvocationCount): string {
+                $nestedEvent = new AfterFileReplacedEvent($file, '/tmp/nested.png');
+                $this->listener->optimizeAfterReplace($nestedEvent);
+                ++$nestedInvocationCount;
+
+                return '/does/not/exist/nested-source.png';
+            });
+
+        $folder = $this->createMock(Folder::class);
+        $event  = new AfterFileAddedEvent($file, $folder);
+
+        $this->listener->optimizeAfterAdd($event);
+
+        self::assertSame(1, $nestedInvocationCount, 'Outer optimize() should run once');
+        // Guard is empty again after the outer handle() finishes; no entries
+        // remain from the blocked nested call.
+        self::assertSame([], $this->readGuard());
+    }
+
+    #[Test]
+    public function guardIsClearedAfterProcessingSoFollowupCallWorks(): void
+    {
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/cleared.png',
+            'png',
+        );
+
+        $setCalls = 0;
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function () use (&$setCalls): void {
+                ++$setCalls;
+            });
+
+        $folder = $this->createMock(Folder::class);
+
+        $this->listener->optimizeAfterAdd(new AfterFileAddedEvent($file, $folder));
+        self::assertSame([], $this->readGuard());
+
+        $this->listener->optimizeAfterAdd(new AfterFileAddedEvent($file, $folder));
+        self::assertSame([], $this->readGuard());
+
+        // Each invocation toggles permissions twice (off + restore).
+        self::assertSame(4, $setCalls);
+    }
+
+    #[Test]
+    public function previousPermissionsAreRestoredWhenOptimizerThrows(): void
+    {
+        // Install a fake binary so the optimizer proceeds past the null-tool
+        // branch, then wire the file to throw during getForLocalProcessing —
+        // this simulates an error path that must still restore permissions.
+        $fakeOptipng       = sys_get_temp_dir() . '/nr-pio-fake-optipng-' . uniqid('', true);
+        $this->tempFiles[] = $fakeOptipng;
+        file_put_contents($fakeOptipng, "#!/bin/sh\nexit 0\n");
+        chmod($fakeOptipng, 0o755);
+        putenv('OPTIPNG_BIN=' . $fakeOptipng);
+
+        $this->optimizer = new ImageOptimizer();
+        $this->listener  = new OptimizeOnUploadListener($this->optimizer);
+
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/throws.png',
+            'png',
+            previousPermissions: true,
+        );
+
+        $captured = [];
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function (bool $value) use (&$captured): void {
+                $captured[] = $value;
+            });
+
+        $file->method('getForLocalProcessing')
+            ->willThrowException(new RuntimeException('boom'));
+
+        $folder = $this->createMock(Folder::class);
+        $event  = new AfterFileAddedEvent($file, $folder);
+
+        try {
+            $this->listener->optimizeAfterAdd($event);
+            self::fail('Expected RuntimeException was not thrown');
+        } catch (RuntimeException $e) {
+            self::assertSame('boom', $e->getMessage());
+        }
+
+        // finally must restore the previous "true" permission state.
+        self::assertSame([false, true], $captured);
+        self::assertSame([], $this->readGuard(), 'Guard must be cleared even on error');
+    }
+
+    #[Test]
+    public function previousPermissionsFalseIsRestoredAsFalse(): void
+    {
+        ['file' => $file, 'storage' => $storage] = $this->createFileAndStorage(
+            '/preserve.png',
+            'png',
+            previousPermissions: false,
+        );
+
+        $captured = [];
+        $storage->method('setEvaluatePermissions')
+            ->willReturnCallback(function (bool $value) use (&$captured): void {
+                $captured[] = $value;
+            });
+
+        $folder = $this->createMock(Folder::class);
+        $event  = new AfterFileAddedEvent($file, $folder);
+
+        $this->listener->optimizeAfterAdd($event);
+
+        self::assertSame([false, false], $captured);
+    }
+
+    #[Test]
+    public function guardAllowsDifferentIdentifiersToBeProcessed(): void
+    {
+        ['file' => $fileA, 'storage' => $storageA] = $this->createFileAndStorage(
+            '/different-a.png',
+            'png',
+        );
+        ['file' => $fileB, 'storage' => $storageB] = $this->createFileAndStorage(
+            '/different-b.png',
+            'png',
+        );
+
+        $setCalls = 0;
+        $storageA->method('setEvaluatePermissions')
+            ->willReturnCallback(function () use (&$setCalls): void {
+                ++$setCalls;
+            });
+        $storageB->method('setEvaluatePermissions')
+            ->willReturnCallback(function () use (&$setCalls): void {
+                ++$setCalls;
+            });
+
+        $folder = $this->createMock(Folder::class);
+        $this->listener->optimizeAfterAdd(new AfterFileAddedEvent($fileA, $folder));
+        $this->listener->optimizeAfterAdd(new AfterFileAddedEvent($fileB, $folder));
+
+        // Both entered the handler because their identifiers differ.
+        self::assertSame(4, $setCalls);
+        self::assertSame([], $this->readGuard());
+    }
+}

--- a/Tests/Unit/Service/ImageOptimizerTest.php
+++ b/Tests/Unit/Service/ImageOptimizerTest.php
@@ -218,6 +218,7 @@ class ImageOptimizerTest extends TestCase
         $fakeBinary        = sys_get_temp_dir() . '/nr-pio-fake-optipng-' . uniqid('', true);
         $this->tempFiles[] = $fakeBinary;
         file_put_contents($fakeBinary, "#!/bin/sh\nexit 0\n");
+        chmod($fakeBinary, 0o755);
 
         putenv('OPTIPNG_BIN=' . $fakeBinary);
 
@@ -237,6 +238,7 @@ class ImageOptimizerTest extends TestCase
         $fakeBinary        = sys_get_temp_dir() . '/nr-pio-fake-jpegoptim-' . uniqid('', true);
         $this->tempFiles[] = $fakeBinary;
         file_put_contents($fakeBinary, "#!/bin/sh\nexit 0\n");
+        chmod($fakeBinary, 0o755);
 
         putenv('JPEGOPTIM_BIN=' . $fakeBinary);
 
@@ -478,6 +480,7 @@ class ImageOptimizerTest extends TestCase
         $fake              = sys_get_temp_dir() . '/nr-pio-fake-jpegoptim-' . uniqid('', true);
         $this->tempFiles[] = $fake;
         file_put_contents($fake, "#!/bin/sh\nexit 0\n");
+        chmod($fake, 0o755);
         putenv('JPEGOPTIM_BIN=' . $fake);
 
         $optimizer = new ImageOptimizer();
@@ -645,6 +648,7 @@ class ImageOptimizerTest extends TestCase
         $fake              = sys_get_temp_dir() . '/nr-pio-fake-jpegoptim-' . uniqid('', true);
         $this->tempFiles[] = $fake;
         file_put_contents($fake, "#!/bin/sh\nexit 0\n");
+        chmod($fake, 0o755);
         putenv('JPEGOPTIM_BIN=' . $fake);
 
         $optimizer = new ImageOptimizer();

--- a/Tests/Unit/Service/ImageOptimizerTest.php
+++ b/Tests/Unit/Service/ImageOptimizerTest.php
@@ -1,0 +1,916 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Tests\Unit\Service;
+
+use function imagecreatetruecolor;
+use function imagegif;
+use function imagejpeg;
+use function imagepng;
+use function is_file;
+
+use Netresearch\NrImageOptimize\Service\ImageOptimizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function putenv;
+
+use ReflectionMethod;
+
+use function str_repeat;
+use function sys_get_temp_dir;
+
+use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+
+use function uniqid;
+use function unlink;
+
+/**
+ * Unit tests for ImageOptimizer.
+ *
+ * Scope: public API paths that do not require an installed optimization
+ * binary — tool resolution is forced to "not available" via environment
+ * overrides. The external process happy-path lives in the functional tier.
+ *
+ * No CoversClass attribute: final classes cannot be instrumented
+ * by PCOV on PHP 8.5, causing PHPUnit coverage warnings.
+ */
+class ImageOptimizerTest extends TestCase
+{
+    private ImageOptimizer $optimizer;
+
+    /**
+     * Files created during a test run that must be cleaned up in tearDown.
+     *
+     * @var list<string>
+     */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Force resolveBinary() into the "env override missing" branch so all
+        // subsequent `which` lookups decide based on the host environment.
+        // Tests that need a specific outcome set the env var themselves.
+        putenv('OPTIPNG_BIN=/nonexistent-optipng-binary');
+        putenv('GIFSICLE_BIN=/nonexistent-gifsicle-binary');
+        putenv('JPEGOPTIM_BIN=/nonexistent-jpegoptim-binary');
+
+        $this->optimizer = new ImageOptimizer();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('OPTIPNG_BIN');
+        putenv('GIFSICLE_BIN');
+        putenv('JPEGOPTIM_BIN');
+
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function supportedExtensionsReturnsCanonicalList(): void
+    {
+        self::assertSame(['png', 'gif', 'jpg', 'jpeg'], $this->optimizer->supportedExtensions());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function unsupportedExtensionProvider(): array
+    {
+        return [
+            'webp (out of scope)' => ['webp'],
+            'avif (out of scope)' => ['avif'],
+            'pdf'                 => ['pdf'],
+            'empty string'        => [''],
+            'random text'         => ['xyz'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unsupportedExtensionProvider')]
+    public function optimizeReturnsNoToolForUnsupportedExtension(string $extension): void
+    {
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn($extension);
+        $file->expects(self::never())->method('getForLocalProcessing');
+
+        $result = $this->optimizer->optimize($file);
+
+        self::assertSame([
+            'optimized'  => false,
+            'savedBytes' => 0,
+            'before'     => 0,
+            'after'      => 0,
+            'tool'       => null,
+        ], $result);
+    }
+
+    #[Test]
+    #[DataProvider('unsupportedExtensionProvider')]
+    public function analyzeReturnsNoToolForUnsupportedExtension(string $extension): void
+    {
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn($extension);
+        $file->expects(self::never())->method('getForLocalProcessing');
+
+        $result = $this->optimizer->analyze($file);
+
+        self::assertSame([
+            'optimized'  => false,
+            'savedBytes' => 0,
+            'before'     => 0,
+            'after'      => 0,
+            'tool'       => null,
+        ], $result);
+    }
+
+    #[Test]
+    public function optimizeReturnsEarlyWhenNoToolAvailable(): void
+    {
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        // Tool lookup fails => getForLocalProcessing must not be called.
+        $file->expects(self::never())->method('getForLocalProcessing');
+
+        $result = $this->optimizer->optimize($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertNull($result['tool']);
+    }
+
+    #[Test]
+    public function analyzeReturnsEarlyWhenNoToolAvailable(): void
+    {
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->expects(self::never())->method('getForLocalProcessing');
+
+        $result = $this->optimizer->analyze($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertNull($result['tool']);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function supportedExtensionProvider(): array
+    {
+        return [
+            'png'                     => ['png'],
+            'gif'                     => ['gif'],
+            'jpg'                     => ['jpg'],
+            'jpeg'                    => ['jpeg'],
+            'upper JPG is lowercased' => ['JPG'],
+            'upper PNG is lowercased' => ['PNG'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('supportedExtensionProvider')]
+    public function resolveToolForReturnsNullWhenBinaryUnavailable(string $extension): void
+    {
+        // Env overrides force binary lookup to fail; also, PATH-based 'which'
+        // cannot resolve the binary because it's not installed in this CI env.
+        self::assertNull($this->optimizer->resolveToolFor($extension));
+    }
+
+    #[Test]
+    public function resolveToolForReturnsNullForUnknownExtension(): void
+    {
+        self::assertNull($this->optimizer->resolveToolFor('webp'));
+        self::assertNull($this->optimizer->resolveToolFor(''));
+    }
+
+    #[Test]
+    public function hasAnyToolReturnsFalseWhenNoBinariesAvailable(): void
+    {
+        self::assertFalse($this->optimizer->hasAnyTool());
+    }
+
+    #[Test]
+    public function hasAnyToolReturnsTrueWhenEnvOverridePointsAtExistingFile(): void
+    {
+        // Create a real file and point one env override at it. The resolver
+        // checks existence via is_file() and returns the override as the
+        // "binary" — no execution happens here.
+        $fakeBinary        = sys_get_temp_dir() . '/nr-pio-fake-optipng-' . uniqid('', true);
+        $this->tempFiles[] = $fakeBinary;
+        file_put_contents($fakeBinary, "#!/bin/sh\nexit 0\n");
+
+        putenv('OPTIPNG_BIN=' . $fakeBinary);
+
+        $optimizer = new ImageOptimizer();
+
+        self::assertTrue($optimizer->hasAnyTool());
+
+        $tool = $optimizer->resolveToolFor('png');
+        self::assertNotNull($tool);
+        self::assertSame('optipng', $tool['name']);
+        self::assertSame($fakeBinary, $tool['bin']);
+    }
+
+    #[Test]
+    public function resolveToolForLowercasesExtension(): void
+    {
+        $fakeBinary        = sys_get_temp_dir() . '/nr-pio-fake-jpegoptim-' . uniqid('', true);
+        $this->tempFiles[] = $fakeBinary;
+        file_put_contents($fakeBinary, "#!/bin/sh\nexit 0\n");
+
+        putenv('JPEGOPTIM_BIN=' . $fakeBinary);
+
+        $optimizer = new ImageOptimizer();
+
+        $upper = $optimizer->resolveToolFor('JPEG');
+        $lower = $optimizer->resolveToolFor('jpeg');
+
+        self::assertNotNull($upper);
+        self::assertNotNull($lower);
+        self::assertSame($upper, $lower);
+        self::assertSame('jpegoptim', $upper['name']);
+    }
+
+    #[Test]
+    public function resolveToolForTreatsEmptyEnvOverrideAsMissing(): void
+    {
+        putenv('OPTIPNG_BIN='); // empty string => fall through to which()
+        putenv('GIFSICLE_BIN=');
+        putenv('JPEGOPTIM_BIN=');
+
+        $optimizer = new ImageOptimizer();
+
+        // 'which' cannot find the binaries in this test environment.
+        self::assertNull($optimizer->resolveToolFor('png'));
+        self::assertFalse($optimizer->hasAnyTool());
+    }
+
+    #[Test]
+    public function analyzeHeuristicReturnsNoToolForUnsupportedExtension(): void
+    {
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('webp');
+        $file->expects(self::never())->method('getForLocalProcessing');
+
+        $result = $this->optimizer->analyzeHeuristic($file);
+
+        self::assertSame([
+            'optimized'  => false,
+            'savedBytes' => 0,
+            'before'     => 0,
+            'after'      => 0,
+            'tool'       => null,
+        ], $result);
+    }
+
+    #[Test]
+    public function analyzeHeuristicReturnsEmptyWhenLocalFileMissing(): void
+    {
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')
+            ->willReturn('/does/not/exist/path/to/file.png');
+
+        $result = $this->optimizer->analyzeHeuristic($file);
+
+        self::assertSame([
+            'optimized'  => false,
+            'savedBytes' => 0,
+            'before'     => 0,
+            'after'      => 0,
+            'tool'       => null,
+        ], $result);
+    }
+
+    #[Test]
+    public function analyzeHeuristicSkipsFilesBelowMinSize(): void
+    {
+        $tmp  = $this->createTinyPng();
+        $size = filesize($tmp);
+        self::assertIsInt($size);
+        self::assertLessThan(100, $size, 'Sanity: tiny PNG should be < 100 bytes');
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+
+        // Default minSize (512000) is far larger than the tiny image => early return.
+        $result = $this->optimizer->analyzeHeuristic($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['savedBytes']);
+        self::assertSame($size, $result['before']);
+        self::assertSame($size, $result['after']);
+        self::assertNull($result['tool']);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: float}>
+     */
+    public static function heuristicGainProvider(): array
+    {
+        return [
+            'jpg 15% base gain'  => ['jpg', 0.15],
+            'jpeg 15% base gain' => ['jpeg', 0.15],
+            'png 10% base gain'  => ['png', 0.10],
+            'gif 10% base gain'  => ['gif', 0.10],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('heuristicGainProvider')]
+    public function analyzeHeuristicAppliesBaseGainPerType(string $extension, float $expectedGain): void
+    {
+        $tmp    = $this->createImageOfType($extension);
+        $padded = $this->padFileToMinSize($tmp, 600_000);
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn($extension);
+        $file->method('getForLocalProcessing')->willReturn($padded);
+
+        // maxWidth/maxHeight larger than any dimension => no scaling, only base gain.
+        $result = $this->optimizer->analyzeHeuristic($file, 10_000, 10_000, 512_000);
+
+        self::assertTrue($result['optimized']);
+        self::assertGreaterThan(0, $result['savedBytes']);
+
+        $before = $result['before'];
+        $after  = $result['after'];
+
+        $expectedAfter = (int) round($before * (1 - $expectedGain));
+        // Allow for rounding
+        self::assertEqualsWithDelta($expectedAfter, $after, 1);
+        self::assertSame($before - $after, $result['savedBytes']);
+        self::assertNull($result['tool']);
+    }
+
+    #[Test]
+    public function analyzeHeuristicScalesDownLargeImages(): void
+    {
+        // Create a large (200x100) PNG and pad the file so size >= minSize.
+        $tmp        = $this->createPngWithDimensions(200, 100);
+        $paddedPath = $this->padFileToMinSize($tmp, 600_000);
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')->willReturn($paddedPath);
+
+        // maxWidth 100 forces scale = 100/200 = 0.5 => areaFactor = 0.25
+        // after ≈ before * 0.25 * 0.9 ≈ before * 0.225
+        $result = $this->optimizer->analyzeHeuristic($file, 100, 100, 512_000);
+
+        self::assertTrue($result['optimized']);
+        $before = $result['before'];
+        $after  = $result['after'];
+        self::assertLessThan($before, $after);
+
+        // Expected: before * min(100/200, 100/100)^2 * (1 - 0.10) = before * 0.25 * 0.9
+        $expected = (int) round($before * 0.25 * 0.9);
+        self::assertEqualsWithDelta($expected, $after, 2);
+    }
+
+    #[Test]
+    public function analyzeHeuristicFallsBackToFilePropertiesWhenGetImageSizeFails(): void
+    {
+        // Create a non-image file with .png extension so getimagesize() fails
+        // but file exists and has enough bytes to pass the minSize gate.
+        $fakePng           = sys_get_temp_dir() . '/nr-pio-fake-png-' . uniqid('', true) . '.png';
+        $this->tempFiles[] = $fakePng;
+        file_put_contents($fakePng, str_repeat('A', 600_000));
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')->willReturn($fakePng);
+        $file->method('getProperty')
+            ->willReturnCallback(static fn (string $key): mixed => match ($key) {
+                'width'  => 4000,
+                'height' => 3000,
+                default  => null,
+            });
+
+        $result = $this->optimizer->analyzeHeuristic($file, 2000, 1500, 512_000);
+
+        self::assertTrue($result['optimized']);
+        // With 4000x3000 scaled to 2000x1500 box, scale = 0.5; after = before * 0.25 * 0.9
+        $before   = $result['before'];
+        $expected = (int) round($before * 0.25 * 0.9);
+        self::assertEqualsWithDelta($expected, $result['after'], 2);
+    }
+
+    #[Test]
+    public function analyzeHeuristicHandlesMissingDimensionsGracefully(): void
+    {
+        $fakePng           = sys_get_temp_dir() . '/nr-pio-nodim-' . uniqid('', true) . '.png';
+        $this->tempFiles[] = $fakePng;
+        file_put_contents($fakePng, str_repeat('B', 600_000));
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')->willReturn($fakePng);
+        $file->method('getProperty')->willReturn(null);
+
+        // With width/height unknown (both 0) the scaling branch is skipped;
+        // only the base compression gain applies.
+        $result = $this->optimizer->analyzeHeuristic($file, 100, 100, 512_000);
+
+        $before   = $result['before'];
+        $expected = (int) round($before * (1 - 0.10));
+        self::assertEqualsWithDelta($expected, $result['after'], 1);
+    }
+
+    #[Test]
+    public function analyzeHeuristicDoesNotScaleWhenImageFitsInBox(): void
+    {
+        // Small 50x40 image inside a big box — no scaling applied.
+        $tmp        = $this->createPngWithDimensions(50, 40);
+        $paddedPath = $this->padFileToMinSize($tmp, 600_000);
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')->willReturn($paddedPath);
+
+        $result   = $this->optimizer->analyzeHeuristic($file, 2560, 1440, 512_000);
+        $before   = $result['before'];
+        $expected = (int) round($before * 0.9);
+        self::assertEqualsWithDelta($expected, $result['after'], 1);
+    }
+
+    #[Test]
+    public function analyzeHeuristicCleansUpLocalProcessingCopy(): void
+    {
+        $tmp               = $this->createTinyPng();
+        $this->tempFiles[] = $tmp;
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+
+        $this->optimizer->analyzeHeuristic($file);
+
+        // The analyzeHeuristic cleans up the local processing copy via unlink()
+        // in a finally block.
+        self::assertFileDoesNotExist($tmp);
+    }
+
+    #[Test]
+    public function optimizeReturnsEmptyResultWhenLocalFileMissing(): void
+    {
+        $fake              = sys_get_temp_dir() . '/nr-pio-fake-jpegoptim-' . uniqid('', true);
+        $this->tempFiles[] = $fake;
+        file_put_contents($fake, "#!/bin/sh\nexit 0\n");
+        putenv('JPEGOPTIM_BIN=' . $fake);
+
+        $optimizer = new ImageOptimizer();
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')
+            ->willReturn('/does/not/exist/path.jpg');
+
+        $result = $optimizer->optimize($file);
+
+        // Tool is set (resolver succeeded) but processing aborted before run.
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['before']);
+        self::assertSame(0, $result['after']);
+        self::assertSame('jpegoptim', $result['tool']);
+    }
+
+    #[Test]
+    public function optimizeReturnsEarlyOnDryRunWithoutRunningTool(): void
+    {
+        // Point the env override at /bin/false — if the tool were run, the
+        // process would fail. Dry-run must skip the run entirely and return
+        // before/after equal to the original size.
+        putenv('JPEGOPTIM_BIN=/bin/false');
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-dry-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 1234));
+        $sizeBefore = filesize($tmp);
+        self::assertIsInt($sizeBefore);
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+
+        $result = $optimizer->optimize($file, false, null, true);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['savedBytes']);
+        self::assertSame($sizeBefore, $result['before']);
+        self::assertSame($sizeBefore, $result['after']);
+        self::assertSame('jpegoptim', $result['tool']);
+    }
+
+    #[Test]
+    public function optimizeReportsNoSavingsWhenToolDoesNotShrinkFile(): void
+    {
+        // /bin/true exits 0 without modifying the file => after == before =>
+        // the "no shrink" branch returns optimized=false.
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-nogain-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 2048));
+        $sizeBefore = filesize($tmp);
+        self::assertIsInt($sizeBefore);
+
+        $storage = $this->createMock(ResourceStorage::class);
+        // replaceFile must NOT be called when no savings occurred.
+        $storage->expects(self::never())->method('replaceFile');
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+        $file->method('getStorage')->willReturn($storage);
+
+        $result = $optimizer->optimize($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['savedBytes']);
+        self::assertSame($sizeBefore, $result['before']);
+        self::assertSame($sizeBefore, $result['after']);
+        self::assertSame('jpegoptim', $result['tool']);
+        // The local processing copy is cleaned up via finally/unlink.
+        self::assertFileDoesNotExist($tmp);
+    }
+
+    #[Test]
+    public function optimizeReportsOptimizedAndCallsReplaceFileWhenToolShrinks(): void
+    {
+        // Wrapper script that truncates its last argument (the file path)
+        // so `after < before` and the "optimized" branch runs.
+        $wrapper           = sys_get_temp_dir() . '/nr-pio-shrink-' . uniqid('', true) . '.sh';
+        $this->tempFiles[] = $wrapper;
+        file_put_contents($wrapper, <<<'SHELL'
+            #!/bin/sh
+            eval "last=\${$#}"
+            : > "$last"
+            exit 0
+
+            SHELL);
+        chmod($wrapper, 0o755);
+
+        putenv('JPEGOPTIM_BIN=' . $wrapper);
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-shrink-src-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 4096));
+        $sizeBefore = filesize($tmp);
+        self::assertIsInt($sizeBefore);
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $file    = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+        $file->method('getStorage')->willReturn($storage);
+
+        // Storage::replaceFile must be invoked with the original file + the
+        // shrunk local path before the finally block unlinks it.
+        $storage->expects(self::once())
+            ->method('replaceFile')
+            ->with($file, $tmp);
+
+        $result = $optimizer->optimize($file);
+
+        self::assertTrue($result['optimized']);
+        self::assertSame($sizeBefore, $result['before']);
+        self::assertSame(0, $result['after']);
+        self::assertSame($sizeBefore, $result['savedBytes']);
+        self::assertSame('jpegoptim', $result['tool']);
+    }
+
+    #[Test]
+    public function optimizeReturnsFailureWhenProcessExitsNonZero(): void
+    {
+        // /bin/false exits 1 => process->isSuccessful() returns false =>
+        // optimize() returns optimized=false with the tool name set.
+        putenv('JPEGOPTIM_BIN=/bin/false');
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-fail-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 2048));
+        $sizeBefore = filesize($tmp);
+        self::assertIsInt($sizeBefore);
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->expects(self::never())->method('replaceFile');
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+        $file->method('getStorage')->willReturn($storage);
+
+        $result = $optimizer->optimize($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['savedBytes']);
+        self::assertSame($sizeBefore, $result['before']);
+        self::assertSame($sizeBefore, $result['after']);
+        self::assertSame('jpegoptim', $result['tool']);
+    }
+
+    #[Test]
+    public function analyzeReturnsEmptyResultWhenLocalFileMissing(): void
+    {
+        $fake              = sys_get_temp_dir() . '/nr-pio-fake-jpegoptim-' . uniqid('', true);
+        $this->tempFiles[] = $fake;
+        file_put_contents($fake, "#!/bin/sh\nexit 0\n");
+        putenv('JPEGOPTIM_BIN=' . $fake);
+
+        $optimizer = new ImageOptimizer();
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')
+            ->willReturn('/does/not/exist/path.jpg');
+
+        $result = $optimizer->analyze($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['before']);
+        self::assertSame(0, $result['after']);
+        self::assertSame('jpegoptim', $result['tool']);
+    }
+
+    #[Test]
+    public function analyzeReportsNoSavingsWhenToolDoesNotShrink(): void
+    {
+        putenv('JPEGOPTIM_BIN=/bin/true');
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-ana-nogain-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 2048));
+        $sizeBefore = filesize($tmp);
+        self::assertIsInt($sizeBefore);
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+
+        $result = $optimizer->analyze($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['savedBytes']);
+        self::assertSame($sizeBefore, $result['before']);
+        self::assertSame($sizeBefore, $result['after']);
+        self::assertSame('jpegoptim', $result['tool']);
+        // analyze() must also clean up the local copy.
+        self::assertFileDoesNotExist($tmp);
+    }
+
+    #[Test]
+    public function analyzeReportsImprovableWhenToolShrinksWithoutWriteBack(): void
+    {
+        $wrapper           = sys_get_temp_dir() . '/nr-pio-ana-shrink-' . uniqid('', true) . '.sh';
+        $this->tempFiles[] = $wrapper;
+        file_put_contents($wrapper, <<<'SHELL'
+            #!/bin/sh
+            eval "last=\${$#}"
+            : > "$last"
+            exit 0
+
+            SHELL);
+        chmod($wrapper, 0o755);
+
+        putenv('JPEGOPTIM_BIN=' . $wrapper);
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-ana-src-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 4096));
+        $sizeBefore = filesize($tmp);
+        self::assertIsInt($sizeBefore);
+
+        // analyze() must never touch storage or call replaceFile — verify by
+        // not providing a storage mock (if the method were called, the
+        // default MockBuilder stub would succeed, but we can at least confirm
+        // the result data matches).
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+        // getStorage must NOT be accessed by analyze() — but PHPUnit mocks
+        // return a fresh stub on unexpected calls, so we guard with a strict
+        // expectation.
+        $file->expects(self::never())->method('getStorage');
+
+        $result = $optimizer->analyze($file);
+
+        self::assertTrue($result['optimized']);
+        self::assertSame($sizeBefore, $result['before']);
+        self::assertSame(0, $result['after']);
+        self::assertSame($sizeBefore, $result['savedBytes']);
+        self::assertSame('jpegoptim', $result['tool']);
+    }
+
+    #[Test]
+    public function analyzeReturnsFailureWhenProcessExitsNonZero(): void
+    {
+        putenv('JPEGOPTIM_BIN=/bin/false');
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-ana-fail-' . uniqid('', true) . '.jpg';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 2048));
+        $sizeBefore = filesize($tmp);
+        self::assertIsInt($sizeBefore);
+
+        $file = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('jpg');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+        $file->expects(self::never())->method('getStorage');
+
+        $result = $optimizer->analyze($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame(0, $result['savedBytes']);
+        self::assertSame($sizeBefore, $result['before']);
+        self::assertSame($sizeBefore, $result['after']);
+        self::assertSame('jpegoptim', $result['tool']);
+    }
+
+    #[Test]
+    public function optimizeDispatchesOptipngForPngExtension(): void
+    {
+        // Confirms that each extension picks up the right binary. /bin/true
+        // succeeds => no shrink => "no savings" branch but tool name reflects
+        // the resolver's choice.
+        putenv('OPTIPNG_BIN=/bin/true');
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-png-' . uniqid('', true) . '.png';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 2048));
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $file    = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('png');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+        $file->method('getStorage')->willReturn($storage);
+
+        $result = $optimizer->optimize($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame('optipng', $result['tool']);
+    }
+
+    #[Test]
+    public function optimizeDispatchesGifsicleForGifExtension(): void
+    {
+        putenv('GIFSICLE_BIN=/bin/true');
+
+        $optimizer = new ImageOptimizer();
+
+        $tmp               = sys_get_temp_dir() . '/nr-pio-gif-' . uniqid('', true) . '.gif';
+        $this->tempFiles[] = $tmp;
+        file_put_contents($tmp, str_repeat('A', 2048));
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $file    = $this->createMock(FileInterface::class);
+        $file->method('getExtension')->willReturn('gif');
+        $file->method('getForLocalProcessing')->willReturn($tmp);
+        $file->method('getStorage')->willReturn($storage);
+
+        $result = $optimizer->optimize($file);
+
+        self::assertFalse($result['optimized']);
+        self::assertSame('gifsicle', $result['tool']);
+    }
+
+    #[Test]
+    public function buildJpegoptimArgsClampsQualityAndAppliesStrip(): void
+    {
+        $method = new ReflectionMethod(ImageOptimizer::class, 'buildJpegoptimArgs');
+
+        /** @var list<string> $none */
+        $none = $method->invoke($this->optimizer, '/tmp/image.jpg', null, false);
+        self::assertSame(['-q', '/tmp/image.jpg'], $none);
+
+        /** @var list<string> $stripped */
+        $stripped = $method->invoke($this->optimizer, '/tmp/image.jpg', null, true);
+        self::assertSame(['--strip-all', '-q', '/tmp/image.jpg'], $stripped);
+
+        /** @var list<string> $withQuality */
+        $withQuality = $method->invoke($this->optimizer, '/tmp/image.jpg', 80, true);
+        self::assertSame(['--strip-all', '--max=80', '-q', '/tmp/image.jpg'], $withQuality);
+
+        /** @var list<string> $qualityTooHigh */
+        $qualityTooHigh = $method->invoke($this->optimizer, '/tmp/image.jpg', 250, false);
+        self::assertSame(['--max=100', '-q', '/tmp/image.jpg'], $qualityTooHigh);
+
+        /** @var list<string> $qualityTooLow */
+        $qualityTooLow = $method->invoke($this->optimizer, '/tmp/image.jpg', -50, false);
+        self::assertSame(['--max=0', '-q', '/tmp/image.jpg'], $qualityTooLow);
+
+        /** @var list<string> $qualityZero */
+        $qualityZero = $method->invoke($this->optimizer, '/tmp/image.jpg', 0, false);
+        self::assertSame(['--max=0', '-q', '/tmp/image.jpg'], $qualityZero);
+
+        /** @var list<string> $qualityFullRange */
+        $qualityFullRange = $method->invoke($this->optimizer, '/tmp/image.jpg', 100, false);
+        self::assertSame(['--max=100', '-q', '/tmp/image.jpg'], $qualityFullRange);
+    }
+
+    /**
+     * Create a 1x1 PNG for tests that need a real image on disk.
+     */
+    private function createTinyPng(): string
+    {
+        return $this->createPngWithDimensions(1, 1);
+    }
+
+    /**
+     * @param int<1, max> $width
+     * @param int<1, max> $height
+     */
+    private function createPngWithDimensions(int $width, int $height): string
+    {
+        $tmp               = sys_get_temp_dir() . '/nr-pio-' . uniqid('', true) . '.png';
+        $this->tempFiles[] = $tmp;
+
+        $gd = imagecreatetruecolor($width, $height);
+        self::assertNotFalse($gd);
+        imagepng($gd, $tmp);
+
+        return $tmp;
+    }
+
+    private function createImageOfType(string $extension): string
+    {
+        $tmp               = sys_get_temp_dir() . '/nr-pio-' . uniqid('', true) . '.' . $extension;
+        $this->tempFiles[] = $tmp;
+
+        $gd = imagecreatetruecolor(5, 5);
+        self::assertNotFalse($gd);
+        match ($extension) {
+            'png'         => imagepng($gd, $tmp),
+            'gif'         => imagegif($gd, $tmp),
+            'jpg', 'jpeg' => imagejpeg($gd, $tmp),
+            default       => imagepng($gd, $tmp),
+        };
+
+        return $tmp;
+    }
+
+    /**
+     * Pad a file so its size reaches at least $minBytes. The heuristic
+     * analyzer ignores anything smaller than minSize, so we need real
+     * on-disk bytes to drive the size-based branches.
+     *
+     * PHP caches stat results per path; fopen/fwrite do NOT invalidate that
+     * cache, so a subsequent filesize() in production code would return the
+     * pre-pad size. clearstatcache() after writing ensures the production
+     * code sees the post-pad size.
+     */
+    private function padFileToMinSize(string $path, int $minBytes): string
+    {
+        clearstatcache(true, $path);
+        $current = filesize($path);
+        self::assertIsInt($current);
+
+        if ($current < $minBytes) {
+            $delta = $minBytes - $current;
+            $fh    = fopen($path, 'ab');
+            self::assertNotFalse($fh);
+            fwrite($fh, str_repeat("\x00", $delta));
+            fclose($fh);
+            clearstatcache(true, $path);
+        }
+
+        return $path;
+    }
+}


### PR DESCRIPTION
Jira: [NEXT-99](https://jira.netresearch.de/browse/NEXT-99)

## Summary

Adds automatic image optimization for uploaded/replaced files and two bulk CLI commands for operating on existing images in the FAL index.

## Changes

### New features

- **`OptimizeOnUploadListener`** — PSR-14 event listener reacting to `AfterFileAddedEvent` and `AfterFileReplacedEvent`. Automatically runs `optipng`, `gifsicle`, or `jpegoptim` on supported uploads. Re-entrancy-safe (won't loop on its own `replaceFile` calls).
- **`nr:image:optimize` CLI** — walks the FAL index and lossy/losslessly optimizes PNG, GIF, and JPEG files across all TYPO3 storages. Supports `--dry-run`, `--storages`, `--jpeg-quality`, `--strip-metadata`.
- **`nr:image:analyze` CLI** — reports optimization potential using a heuristic (size + resolution) without invoking external tools. Fast even on large installations.
- **`ImageOptimizer` service** — shared backend used by both the listener and the CLI commands. Discovers tool binaries via `PATH` with `OPTIPNG_BIN` / `GIFSICLE_BIN` / `JPEGOPTIM_BIN` env overrides.

### CLI UX

- Upfront record count, `SymfonyStyle` progress bar with MB/GB savings totals
- Progress labels truncated to fit terminal width
- Streaming iteration (Generator) over `sys_file` to avoid loading the full index into memory
- Permission checks temporarily disabled per file then restored (works in CLI context without a BE user)

### Tooling

- Full unit test coverage for the new classes (100 new tests, all in `Tests/Unit/`)
- Line coverage on patch files: `OptimizeOnUploadListener` 100%, `AnalyzeImagesCommand` 100%, `AbstractImageCommand` 96%, `OptimizeImagesCommand` 96%, `ImageOptimizer` 96%

## Testing

```bash
# Unit tests
composer ci:test:php:unit

# Static analysis
composer ci:test:php:phpstan
composer ci:test:php:rector
composer ci:test:php:cgl

# Try the analyze command (no modifications)
./vendor/bin/typo3 nr:image:analyze --storages=1 --min-size=512000

# Try the optimize command (dry-run first!)
./vendor/bin/typo3 nr:image:optimize --dry-run --storages=1
./vendor/bin/typo3 nr:image:optimize --storages=1 --jpeg-quality=85 --strip-metadata
```

## Requirements

The auto-optimization on upload works silently if no optimizer binaries are installed. To actually optimize, install at least one of:

- `optipng` (Debian/Ubuntu: `apt install optipng`)
- `gifsicle` (`apt install gifsicle`)
- `jpegoptim` (`apt install jpegoptim`)