### PR TITLE
docs: review, enhance and sync full documentation with extension

### DIFF
--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -18,7 +18,7 @@ Unreleased
 -   Added ``OptimizeOnUploadListener`` -- PSR-14 listener
     that runs ``optipng`` / ``gifsicle`` / ``jpegoptim`` on
     ``AfterFileAddedEvent`` and ``AfterFileReplacedEvent``.
-    Keyed by ``storageUid + ':' + identifier`` to avoid
+    Keyed by ``storageUid . ':' . identifier`` to avoid
     cross-storage re-entrancy collisions; restores
     ``setEvaluatePermissions`` in a ``finally`` block.
 -   Added ``nr:image:optimize`` -- bulk optimization command

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -1,10 +1,41 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _changelog:
 
 =========
 Changelog
 =========
+
+..  _changelog-unreleased:
+
+Unreleased
+==========
+
+..  versionadded:: next
+    Automatic optimization on upload and bulk CLI commands
+    for optimizing or analyzing the FAL image inventory.
+
+-   Added ``OptimizeOnUploadListener`` -- PSR-14 listener
+    that runs ``optipng`` / ``gifsicle`` / ``jpegoptim`` on
+    ``AfterFileAddedEvent`` and ``AfterFileReplacedEvent``.
+    Keyed by ``storageUid + ':' + identifier`` to avoid
+    cross-storage re-entrancy collisions; restores
+    ``setEvaluatePermissions`` in a ``finally`` block.
+-   Added ``nr:image:optimize`` -- bulk optimization command
+    with ``--dry-run``, ``--storages``, ``--jpeg-quality``,
+    and ``--strip-metadata`` options. Uses a streaming
+    Generator over ``sys_file`` so large installations
+    don't load the full index into memory.
+-   Added ``nr:image:analyze`` -- heuristic analysis
+    command that estimates optimization potential without
+    invoking any binary. Fast even on large installations.
+-   Added ``ImageOptimizer`` service -- shared backend used
+    by the listener and both CLI commands. Env overrides
+    (``OPTIPNG_BIN``, ``GIFSICLE_BIN``, ``JPEGOPTIM_BIN``)
+    are authoritative: a set-but-invalid override is
+    reported as unavailable rather than silently falling
+    back to ``$PATH``. ``$PATH`` lookups also verify
+    ``is_executable()``.
 
 ..  _changelog-2-2-1:
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -25,11 +25,12 @@ with ``srcset`` attributes.
 
     {namespace nr=Netresearch\NrImageOptimize\ViewHelpers}
 
-    <nr:sourceSet file="{image}"
+    <nr:sourceSet path="{f:uri.image(image: image)}"
                   width="1200"
                   height="800"
-                  quality="85"
+                  alt="{image.properties.alternative}"
                   sizes="(max-width: 768px) 100vw, 50vw"
+                  responsiveSrcset="1"
     />
 
 ..  _configuration-parameters:
@@ -37,59 +38,68 @@ with ``srcset`` attributes.
 Parameters
 ----------
 
-..  confval:: file
-    :name: confval-file
-    :type: object
-    :required: true
-
-    Image file resource (FAL file reference). Either ``file``
-    or ``path`` must be provided.
-
 ..  confval:: path
     :name: confval-path
     :type: string
+    :required: true
 
-    URI string path to the image, typically generated via
-    ``f:uri.image()``. Use ``path`` instead of ``file`` when
-    passing a pre-resolved image URI. Either ``file`` or
-    ``path`` must be provided.
+    Public path to the source image (for example
+    ``/fileadmin/foo.jpg``), typically generated via
+    ``f:uri.image()``.
 
 ..  confval:: width
     :name: confval-width
-    :type: integer
+    :type: int|float
+    :Default: 0
 
-    Target width in pixels. Clamped by the processor to
-    1 -- 8192.
+    Base width in pixels for the rendered ``<img>``. ``0``
+    resolves automatically from the source file.
+    :ref:`Clamped by the processor <configuration-limits>` to
+    1--8192 when baked into the variant URL.
 
 ..  confval:: height
     :name: confval-height
-    :type: integer
+    :type: int|float
+    :Default: 0
 
-    Target height in pixels. Clamped by the processor to
-    1 -- 8192.
+    Base height in pixels. ``0`` preserves aspect ratio
+    relative to :confval:`width <confval-width>`.
+    :ref:`Clamped by the processor <configuration-limits>`
+    to 1--8192.
 
-..  confval:: quality
-    :name: confval-quality
-    :type: integer
-    :Default: 100
+..  confval:: set
+    :name: confval-set
+    :type: array
+    :Default: []
 
-    JPEG / WebP / AVIF quality (1--100). Clamped by the
-    processor.
+    Responsive set in the form
+    ``{maxWidth: {width: int, height: int}}``. Each entry
+    becomes a ``<source media="(max-width: <maxWidth>px)">``
+    tag.
 
-..  confval:: sizes
-    :name: confval-sizes
+..  confval:: alt
+    :name: confval-alt
     :type: string
+    :Default: empty string
 
-    Responsive ``sizes`` attribute for the generated
-    ``<img>`` tag.
+    Alternative text for the image. Always rendered (even
+    when empty) to keep assistive-tech compatibility.
 
-..  confval:: format
-    :name: confval-format
+..  confval:: title
+    :name: confval-title
     :type: string
-    :Default: auto
+    :Default: empty string
 
-    Output format. Allowed values: ``auto``, ``webp``,
-    ``avif``, ``jpg``, ``png``.
+    HTML-escaped title attribute.
+
+..  confval:: class
+    :name: confval-class
+    :type: string
+    :Default: empty string
+
+    CSS classes for the ``<img>`` tag. Include
+    ``lazyload`` to switch from native to JS-based lazy
+    loading (see :ref:`configuration-lazy-loading`).
 
 ..  confval:: mode
     :name: confval-mode
@@ -97,16 +107,24 @@ Parameters
     :Default: cover
 
     Render mode. ``cover`` resizes images to fully cover
-    the given dimensions. ``fit`` resizes images to fit
-    within the given dimensions.
+    the given dimensions (crop/fill). ``fit`` resizes images
+    to fit within the given dimensions.
+
+..  confval:: lazyload
+    :name: confval-lazyload
+    :type: boolean
+    :Default: false
+
+    Add ``loading="lazy"`` (native lazy loading).
 
 ..  confval:: responsiveSrcset
     :name: confval-responsive-srcset
     :type: boolean
     :Default: false
 
-    Enable width-based responsive ``srcset`` instead of
-    density-based ``2x`` srcset.
+    Enable width-based responsive ``srcset`` instead of the
+    density-based ``2x`` output (preserved for backward
+    compatibility).
 
 ..  confval:: widthVariants
     :name: confval-width-variants
@@ -114,15 +132,43 @@ Parameters
     :Default: 480, 576, 640, 768, 992, 1200, 1800
 
     Width variants for responsive ``srcset``
-    (comma-separated string or array).
+    (comma-separated string or array). Only honored when
+    :confval:`responsiveSrcset <confval-responsive-srcset>`
+    is enabled.
+
+..  confval:: sizes
+    :name: confval-sizes
+    :type: string
+    :Default: auto, (min-width: 992px) 991px, 100vw
+
+    Responsive ``sizes`` attribute for the generated
+    ``<img>`` tag.
 
 ..  confval:: fetchpriority
     :name: confval-fetchpriority
     :type: string
+    :Default: empty string
 
     Native HTML ``fetchpriority`` attribute. Allowed
     values: ``high``, ``low``, ``auto``. Omitted when
     empty.
+
+..  confval:: attributes
+    :name: confval-attributes
+    :type: array
+    :Default: []
+
+    Extra HTML attributes merged into the rendered tag.
+
+..  note::
+
+    Quality and output format are not exposed as ViewHelper
+    arguments. Quality defaults to 100 and is baked into the
+    generated ``/processed/...q<n>...`` URL; the variant's
+    file extension is inherited from the source image. Use
+    :ref:`the URL format <configuration-url-format>` and
+    :ref:`variant negotiation <configuration-variant-negotiation>`
+    to influence the served format.
 
 ..  _configuration-source-sets:
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _configuration:
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -6,10 +6,11 @@
 Configuration
 =============
 
-The extension works out of the box with sensible defaults.
-Images are automatically optimized when accessed via the
-``/processed/`` path. All configuration happens through
-ViewHelper attributes in your Fluid templates.
+The extension works out of the box with sensible defaults. All
+three operating modes -- on-demand frontend processing, on-upload
+compression, and bulk CLI -- activate automatically after
+installation. This page documents the extension points that can
+be tweaked.
 
 ..  _configuration-viewhelper:
 
@@ -57,20 +58,23 @@ Parameters
     :name: confval-width
     :type: integer
 
-    Target width in pixels.
+    Target width in pixels. Clamped by the processor to
+    1 -- 8192.
 
 ..  confval:: height
     :name: confval-height
     :type: integer
 
-    Target height in pixels.
+    Target height in pixels. Clamped by the processor to
+    1 -- 8192.
 
 ..  confval:: quality
     :name: confval-quality
     :type: integer
     :Default: 100
 
-    JPEG/WebP quality (1--100).
+    JPEG / WebP / AVIF quality (1--100). Clamped by the
+    processor.
 
 ..  confval:: sizes
     :name: confval-sizes
@@ -191,3 +195,144 @@ By default :confval:`responsiveSrcset <confval-responsive-srcset>`
 is ``false``, preserving the existing 2x density-based
 ``srcset`` behavior. All existing templates continue to work
 without modifications.
+
+..  _configuration-url-format:
+
+Variant URL format
+==================
+
+Processed variants are served from a dedicated URL path. The
+ViewHelper generates these URLs automatically, but any markup
+that writes a URL of this form will be intercepted by the
+:ref:`ProcessingMiddleware <developer-middleware>`:
+
+..  code-block:: text
+    :caption: URL template
+
+    /processed/<original-path>.<mode-config>.<ext>[?<query>]
+
+``<original-path>``
+    Public path of the source image, including the
+    ``/fileadmin/`` (or other storage) prefix. Path traversal
+    sequences (``..``) are rejected at URL-parsing time.
+
+``<mode-config>``
+    Concatenation of one or more of:
+
+    ``w<n>``
+        Target width in pixels.
+
+    ``h<n>``
+        Target height in pixels.
+
+    ``q<n>``
+        Quality (1--100).
+
+    ``m<n>``
+        Processing mode (``0`` = cover, ``1`` = scale/fit).
+
+``<ext>``
+    Source image extension. The processor decides at
+    response time whether to serve the original, the
+    ``.webp`` sidecar, or the ``.avif`` sidecar based on
+    the ``Accept`` header and the query flags below.
+
+..  code-block:: text
+    :caption: Example URL
+
+    /processed/fileadmin/photos/hero.w1200h800m0q85.jpg
+
+..  _configuration-variant-negotiation:
+
+Variant negotiation
+===================
+
+When the processor generates a variant, it writes the original
+file to disk and additionally produces a ``.webp`` and an
+``.avif`` sidecar (same base name). On each request it inspects
+the ``Accept`` header and returns the best match the client
+supports, preferring AVIF over WebP over the original format.
+
+Two query parameters let callers opt out of sidecar generation
+for individual URLs:
+
+``skipWebP=1``
+    Do not produce or serve a WebP variant for this URL. The
+    ``Content-Type`` always matches the source extension.
+
+``skipAvif=1``
+    Do not produce or serve an AVIF variant for this URL. If
+    WebP is still allowed and the client supports it, WebP is
+    served.
+
+These flags are useful when specific consumers (for example
+e-mail clients or legacy RSS renderers) cannot handle modern
+formats.
+
+..  _configuration-cache-headers:
+
+Cache headers
+=============
+
+Processed variant URLs are effectively content-addressed -- any
+change to dimensions, quality, or format produces a different
+URL. The processor therefore responds with an immutable,
+long-lived cache header:
+
+..  code-block:: text
+
+    Cache-Control: public, max-age=31536000, immutable
+
+This value is a compile-time constant and not user-configurable.
+
+..  _configuration-image-driver:
+
+Image driver selection
+======================
+
+Intervention Image is instantiated through
+:php:class:`~Netresearch\\NrImageOptimize\\Service\\ImageManagerFactory`,
+which selects the best available driver at runtime:
+
+1.  **Imagick** when the ``imagick`` PHP extension is loaded
+    (preferred -- supports AVIF natively if the underlying
+    ImageMagick build does).
+2.  **GD** when ``imagick`` is unavailable and the ``gd``
+    extension is loaded.
+
+If neither extension is present, the factory throws a
+``RuntimeException`` with a descriptive message. Use the
+:ref:`backend maintenance module <maintenance-system-requirements>`
+to verify driver availability on your host.
+
+..  _configuration-middleware:
+
+Middleware registration
+=======================
+
+:file:`Configuration/RequestMiddlewares.php` registers the
+``ProcessingMiddleware`` on the frontend pipeline **before**
+``typo3/cms-frontend/site``. This ordering is required so the
+middleware can intercept ``/processed/`` URLs before
+TYPO3's frontend routing claims them. The registration has no
+user-configurable options.
+
+..  _configuration-limits:
+
+Processor limits
+================
+
+The processor enforces the following bounds when parsing a URL:
+
+``MAX_DIMENSION``
+    Width and height are clamped to 1--8192 pixels to prevent
+    denial-of-service via excessive memory allocation.
+
+``MIN_QUALITY`` / ``MAX_QUALITY``
+    Quality is clamped to 1--100.
+
+``LOCK_MAX_RETRIES``
+    Up to 10 attempts (at 100 ms intervals) to acquire the
+    per-variant processing lock before returning HTTP 503.
+    Prevents duplicate work when multiple clients hit the
+    same uncached variant simultaneously.

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -16,20 +16,21 @@ optimization backend:
 
 1.  **ProcessingMiddleware** intercepts frontend requests
     matching the ``/processed/`` path and asks the
-    **Processor** to create a variant on demand.
-2.  **OptimizeOnUploadListener** reacts to PSR-14 file
-    events (``AfterFileAddedEvent`` and
-    ``AfterFileReplacedEvent``) and delegates to the shared
-    **ImageOptimizer** service for in-place lossless
-    compression.
+    :ref:`Processor <developer-processor>` to create a variant
+    on demand.
+2.  **OptimizeOnUploadListener** reacts to PSR-14 file events
+    (``AfterFileAddedEvent`` and ``AfterFileReplacedEvent``)
+    and delegates to the shared
+    :ref:`ImageOptimizer <developer-image-optimizer>` service
+    for in-place lossless compression.
 3.  **OptimizeImagesCommand** and **AnalyzeImagesCommand**
     iterate the FAL index from the CLI. Both extend
-    **AbstractImageCommand**, which provides shared
-    database iteration, progress rendering, and option
-    parsing.
+    :ref:`AbstractImageCommand <developer-commands>`, which
+    provides shared database iteration, progress rendering,
+    and option parsing.
 
-The **MaintenanceController** provides the backend module
-for statistics, cleanup, and system-requirement checks.
+The **MaintenanceController** provides the backend module for
+statistics, cleanup, and system-requirement checks.
 
 ..  _developer-directory-structure:
 
@@ -50,6 +51,11 @@ Directory structure
 
             *   MaintenanceController.php
 
+        *   Event/
+
+            *   ImageProcessedEvent.php
+            *   VariantServedEvent.php
+
         *   EventListener/
 
             *   OptimizeOnUploadListener.php
@@ -67,6 +73,7 @@ Directory structure
             *   SystemRequirementsService.php
 
         *   Processor.php
+        *   ProcessorInterface.php
         *   ViewHelpers/
 
             *   SourceSetViewHelper.php
@@ -90,10 +97,14 @@ Processing middleware
 
 ..  php:class:: ProcessingMiddleware
 
-    Frontend middleware registered before
-    ``typo3/cms-frontend/site``. Intercepts requests whose
-    path starts with ``/processed/`` and delegates image
-    processing to the :php:class:`Processor` class.
+    Frontend PSR-15 middleware registered **before**
+    ``typo3/cms-frontend/site`` (see
+    :ref:`configuration-middleware`). Intercepts every
+    request whose path starts with ``/processed/`` and
+    delegates to the
+    :php:class:`~Netresearch\\NrImageOptimize\\ProcessorInterface`
+    implementation. Any other request is passed to the next
+    handler unchanged.
 
 ..  _developer-processor:
 
@@ -102,13 +113,113 @@ Processor
 
 ..  php:namespace:: Netresearch\NrImageOptimize
 
+..  php:class:: ProcessorInterface
+
+    Contract for the on-demand processor -- declares
+    ``generateAndSend(ServerRequestInterface): ResponseInterface``.
+    The middleware depends on this interface, so integrators
+    can replace the implementation via a Services.yaml alias.
+
 ..  php:class:: Processor
 
-    Core image processing engine. Parses the requested URL
-    to extract dimensions, quality, mode, and format
-    parameters. Uses the Intervention Image library for the
-    actual manipulation. Processed images are cached on disk
-    to avoid repeated processing.
+    Default implementation. Parses the requested URL (see
+    :ref:`configuration-url-format`) to extract path,
+    dimensions, quality, and mode. Loads the original via
+    the ``ImageReaderInterface`` adapter (see
+    :ref:`developer-image-manager`), generates the primary
+    variant plus optional
+    WebP / AVIF sidecars, and streams a PSR-7 response back
+    with long-lived cache headers.
+
+    Key behaviors:
+
+    -   Rejects path-traversal (``..``) sequences at URL
+        parse time, returning HTTP 400.
+    -   Clamps ``w`` / ``h`` to 1--8192 and ``q`` to 1--100.
+    -   Uses TYPO3's ``LockFactory`` to serialize concurrent
+        requests for the same variant; a 503 is returned if
+        the lock can't be acquired within ~1 second.
+    -   Respects the ``Accept`` header plus the ``skipWebP``
+        and ``skipAvif`` query parameters when choosing
+        which cached sidecar to serve.
+    -   Dispatches :php:class:`~Netresearch\\NrImageOptimize\\Event\\ImageProcessedEvent`
+        after a new variant is written and
+        :php:class:`~Netresearch\\NrImageOptimize\\Event\\VariantServedEvent`
+        before the response body is sent.
+
+..  _developer-events:
+
+PSR-14 events
+=============
+
+..  php:namespace:: Netresearch\NrImageOptimize\Event
+
+Integrators can subscribe to the processor's lifecycle to
+collect metrics, trigger cache warming, or apply additional
+post-processing.
+
+..  php:class:: ImageProcessedEvent
+
+    Dispatched after the processor has written a new variant
+    to disk. Properties (all ``public readonly``):
+
+    ``pathOriginal`` (``string``)
+        Absolute path of the source image.
+
+    ``pathVariant`` (``string``)
+        Absolute path of the variant -- the actual served
+        file may be a ``.webp`` or ``.avif`` sidecar of this
+        path.
+
+    ``extension`` (``string``)
+        Lowercased extension of the variant (``jpg``,
+        ``png``, ``webp``, ``avif`` ...).
+
+    ``targetWidth`` / ``targetHeight`` (``?int``)
+        Final clamped dimensions in pixels, or ``null`` if
+        the URL omitted the value.
+
+    ``targetQuality`` (``int``)
+        Output quality (1--100).
+
+    ``processingMode`` (``int``)
+        ``0`` = cover, ``1`` = scale / fit.
+
+    ``webpGenerated`` / ``avifGenerated`` (``bool``)
+        Whether the respective sidecar was written alongside.
+
+..  php:class:: VariantServedEvent
+
+    Dispatched immediately before the response body is
+    streamed to the client -- both for fresh variants and for
+    cache hits. Properties:
+
+    ``pathVariant`` (``string``)
+        Absolute base path of the variant being served.
+
+    ``extension`` (``string``)
+        Lowercased source extension.
+
+    ``responseStatusCode`` (``int``)
+        HTTP status code (always 200 in practice).
+
+    ``fromCache`` (``bool``)
+        ``true`` when the response reuses a previously
+        generated file on disk; ``false`` when the variant
+        was produced in this request.
+
+Register listeners via ``Configuration/Services.yaml`` or the
+per-class ``#[AsEventListener]`` attribute:
+
+..  code-block:: yaml
+    :caption: Configuration/Services.yaml
+
+    services:
+      Acme\Example\Listener\MetricsListener:
+        tags:
+          - name: event.listener
+            identifier: 'acme.metrics.variant_served'
+            event: Netresearch\NrImageOptimize\Event\VariantServedEvent
 
 ..  _developer-event-listener:
 
@@ -125,17 +236,19 @@ Upload event listener
     offline storages, and delegates to
     :php:class:`~Netresearch\\NrImageOptimize\\Service\\ImageOptimizer`.
 
-    Re-entrancy guard: the listener keys its guard by
-    ``storageUid + ':' + identifier`` to avoid
-    cross-storage collisions while still catching the
+    Re-entrancy guard: keyed by
+    ``storageUid + ':' + identifier`` so two storages sharing
+    an identifier (``/image.jpg`` in different driver roots)
+    don't block each other, while still catching the
     ``replaceFile()`` loop that the optimizer's own write
     would otherwise trigger.
 
     Storage state: ``setEvaluatePermissions(false)`` is
     applied before delegation and restored to its previous
-    value in a ``finally`` block.
+    value in a ``finally`` block so long-running CLI runs
+    don't leak permission state across iterations.
 
-..  _developer-service:
+..  _developer-image-optimizer:
 
 ImageOptimizer service
 ======================
@@ -145,14 +258,14 @@ ImageOptimizer service
 ..  php:class:: ImageOptimizer
 
     Shared backend used by both the event listener and the
-    CLI commands. Resolves optimizer binaries via
-    ``$PATH``, with env overrides (``OPTIPNG_BIN``,
-    ``GIFSICLE_BIN``, ``JPEGOPTIM_BIN``). A set-but-invalid
-    override is authoritative -- the tool is reported
-    unavailable rather than silently falling back to
-    ``$PATH``.
+    CLI commands. Resolves optimizer binaries via ``$PATH``,
+    with env overrides (``OPTIPNG_BIN``, ``GIFSICLE_BIN``,
+    ``JPEGOPTIM_BIN``). A set-but-invalid override is
+    authoritative -- the tool is reported unavailable rather
+    than silently falling back to ``$PATH``. ``$PATH``
+    lookups also verify ``is_executable()``.
 
-    Public surface:
+    Public API:
 
     ``optimize(FileInterface, stripMetadata, jpegQuality, dryRun): array``
         Run the appropriate tool in place and replace the
@@ -175,6 +288,57 @@ ImageOptimizer service
     ``supportedExtensions(): list<string>``
         Returns ``['png', 'gif', 'jpg', 'jpeg']``.
 
+..  _developer-image-manager:
+
+ImageManager abstraction
+========================
+
+..  php:class:: ImageManagerFactory
+
+    Selects the best available Intervention Image driver
+    (Imagick over GD). See
+    :ref:`configuration-image-driver` for behavior and
+    failure modes.
+
+..  php:class:: ImageReaderInterface
+
+    Version-agnostic abstraction around Intervention Image's
+    loading API. v3 uses ``ImageManager::read()``, v4 uses
+    ``ImageManager::decode()``; this interface hides that
+    difference so consumers and static analysis see a single
+    stable contract.
+
+..  php:class:: ImageManagerAdapter
+
+    Default implementation. Dispatches to whichever method is
+    present on the installed ``ImageManager``, letting the
+    extension support Intervention Image ``^3 || ^4``
+    simultaneously without version-conditional code paths.
+
+..  _developer-system-requirements:
+
+SystemRequirementsService
+=========================
+
+..  php:class:: SystemRequirementsService
+
+    Produces the data shown on the
+    :ref:`System requirements <maintenance-system-requirements>`
+    tab of the backend module. Inspects:
+
+    -   PHP version and loaded extensions (``imagick``,
+        ``gd``, ``fileinfo``).
+    -   ImageMagick / GraphicsMagick capabilities as
+        reported by Imagick (WebP, AVIF support).
+    -   Intervention Image installed version and the active
+        driver (Imagick or GD).
+    -   TYPO3 version.
+    -   Availability of optional CLI tools (``magick``,
+        ``convert``, ``identify``, ``gm``).
+
+    Returns a structured array the controller renders into a
+    Fluid template.
+
 ..  _developer-commands:
 
 CLI commands
@@ -187,7 +351,7 @@ CLI commands
     Base class for the image CLI commands. Exposes
     ``parseStorageUidsOption``, ``getIntOption``,
     ``extractUid``, ``countImages``, ``iterateViaIndex``
-    (Generator over ``sys_file`` rows),
+    (Generator over ``sys_file`` rows -- constant memory),
     ``createProgress``, ``buildLabel``, ``shortenLabel``,
     and ``formatMbGb``.
 
@@ -196,13 +360,13 @@ CLI commands
     Implements ``nr:image:optimize``. Delegates to
     :php:class:`~Netresearch\\NrImageOptimize\\Service\\ImageOptimizer`
     per file and renders a Symfony progress bar with
-    cumulative savings.
+    cumulative savings. See :ref:`usage-cli-optimize`.
 
 ..  php:class:: AnalyzeImagesCommand
 
     Implements ``nr:image:analyze``. Uses
     ``ImageOptimizer::analyzeHeuristic()`` -- no external
-    tool is invoked.
+    tool is invoked. See :ref:`usage-cli-analyze`.
 
 ..  _developer-viewhelper:
 
@@ -216,7 +380,37 @@ SourceSetViewHelper
     Fluid ViewHelper that generates ``<img>`` tags with
     ``srcset`` attributes for responsive image delivery.
     Supports both density-based (2x) and width-based
-    responsive srcset modes.
+    responsive srcset modes. See :ref:`usage` for examples
+    and :ref:`configuration-viewhelper` for the parameter
+    reference.
+
+..  _developer-controller:
+
+MaintenanceController
+=====================
+
+..  php:namespace:: Netresearch\NrImageOptimize\Controller
+
+..  php:class:: MaintenanceController
+
+    Extbase controller powering the backend module. Three
+    actions:
+
+    ``indexAction``
+        Overview of the processed-images directory: file
+        count, total size, largest files, type distribution.
+
+    ``systemRequirementsAction``
+        Renders the data produced by
+        :php:class:`~Netresearch\\NrImageOptimize\\Service\\SystemRequirementsService`.
+
+    ``clearProcessedImagesAction``
+        Recursively deletes every file under the configured
+        processed-images directory. A flash message reports
+        the freed space.
+
+    Module registration (access limited to ``systemMaintainer``)
+    lives in :file:`Configuration/Backend/Modules.php`.
 
 ..  _developer-testing:
 

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _developer:
 
@@ -11,17 +11,25 @@ Developer reference
 Architecture
 ============
 
-The extension uses a middleware-based approach for image
-processing:
+The extension has three entry points that share the same
+optimization backend:
 
 1.  **ProcessingMiddleware** intercepts frontend requests
-    matching the ``/processed/`` path.
-2.  **Processor** handles image optimization, format
-    conversion, and caching.
-3.  **SourceSetViewHelper** generates responsive ``<img>``
-    markup in Fluid templates.
-4.  **MaintenanceController** provides the backend module
-    for statistics and cleanup.
+    matching the ``/processed/`` path and asks the
+    **Processor** to create a variant on demand.
+2.  **OptimizeOnUploadListener** reacts to PSR-14 file
+    events (``AfterFileAddedEvent`` and
+    ``AfterFileReplacedEvent``) and delegates to the shared
+    **ImageOptimizer** service for in-place lossless
+    compression.
+3.  **OptimizeImagesCommand** and **AnalyzeImagesCommand**
+    iterate the FAL index from the CLI. Both extend
+    **AbstractImageCommand**, which provides shared
+    database iteration, progress rendering, and option
+    parsing.
+
+The **MaintenanceController** provides the backend module
+for statistics, cleanup, and system-requirement checks.
 
 ..  _developer-directory-structure:
 
@@ -32,9 +40,19 @@ Directory structure
 
     *   Classes/
 
+        *   Command/
+
+            *   AbstractImageCommand.php
+            *   AnalyzeImagesCommand.php
+            *   OptimizeImagesCommand.php
+
         *   Controller/
 
             *   MaintenanceController.php
+
+        *   EventListener/
+
+            *   OptimizeOnUploadListener.php
 
         *   Middleware/
 
@@ -42,6 +60,10 @@ Directory structure
 
         *   Service/
 
+            *   ImageManagerAdapter.php
+            *   ImageManagerFactory.php
+            *   ImageOptimizer.php
+            *   ImageReaderInterface.php
             *   SystemRequirementsService.php
 
         *   Processor.php
@@ -84,9 +106,103 @@ Processor
 
     Core image processing engine. Parses the requested URL
     to extract dimensions, quality, mode, and format
-    parameters. Uses the Intervention Image library for
-    actual image manipulation. Processed images are cached
-    on disk to avoid repeated processing.
+    parameters. Uses the Intervention Image library for the
+    actual manipulation. Processed images are cached on disk
+    to avoid repeated processing.
+
+..  _developer-event-listener:
+
+Upload event listener
+=====================
+
+..  php:namespace:: Netresearch\NrImageOptimize\EventListener
+
+..  php:class:: OptimizeOnUploadListener
+
+    PSR-14 listener registered for ``AfterFileAddedEvent``
+    and ``AfterFileReplacedEvent``. Normalizes the file
+    extension, short-circuits unsupported extensions and
+    offline storages, and delegates to
+    :php:class:`~Netresearch\\NrImageOptimize\\Service\\ImageOptimizer`.
+
+    Re-entrancy guard: the listener keys its guard by
+    ``storageUid + ':' + identifier`` to avoid
+    cross-storage collisions while still catching the
+    ``replaceFile()`` loop that the optimizer's own write
+    would otherwise trigger.
+
+    Storage state: ``setEvaluatePermissions(false)`` is
+    applied before delegation and restored to its previous
+    value in a ``finally`` block.
+
+..  _developer-service:
+
+ImageOptimizer service
+======================
+
+..  php:namespace:: Netresearch\NrImageOptimize\Service
+
+..  php:class:: ImageOptimizer
+
+    Shared backend used by both the event listener and the
+    CLI commands. Resolves optimizer binaries via
+    ``$PATH``, with env overrides (``OPTIPNG_BIN``,
+    ``GIFSICLE_BIN``, ``JPEGOPTIM_BIN``). A set-but-invalid
+    override is authoritative -- the tool is reported
+    unavailable rather than silently falling back to
+    ``$PATH``.
+
+    Public surface:
+
+    ``optimize(FileInterface, stripMetadata, jpegQuality, dryRun): array``
+        Run the appropriate tool in place and replace the
+        FAL file when the result shrinks.
+
+    ``analyze(FileInterface, stripMetadata, jpegQuality): array``
+        Same pipeline, but never writes back.
+
+    ``analyzeHeuristic(FileInterface, maxWidth, maxHeight, minSize): array``
+        Fast estimation from size and resolution. No binary
+        is invoked.
+
+    ``resolveToolFor(string extension): ?array``
+        Tool discovery for callers that want to pre-check.
+
+    ``hasAnyTool(): bool``
+        Quick check whether at least one optimizer is
+        installed.
+
+    ``supportedExtensions(): list<string>``
+        Returns ``['png', 'gif', 'jpg', 'jpeg']``.
+
+..  _developer-commands:
+
+CLI commands
+============
+
+..  php:namespace:: Netresearch\NrImageOptimize\Command
+
+..  php:class:: AbstractImageCommand
+
+    Base class for the image CLI commands. Exposes
+    ``parseStorageUidsOption``, ``getIntOption``,
+    ``extractUid``, ``countImages``, ``iterateViaIndex``
+    (Generator over ``sys_file`` rows),
+    ``createProgress``, ``buildLabel``, ``shortenLabel``,
+    and ``formatMbGb``.
+
+..  php:class:: OptimizeImagesCommand
+
+    Implements ``nr:image:optimize``. Delegates to
+    :php:class:`~Netresearch\\NrImageOptimize\\Service\\ImageOptimizer`
+    per file and renders a Symfony progress bar with
+    cumulative savings.
+
+..  php:class:: AnalyzeImagesCommand
+
+    Implements ``nr:image:analyze``. Uses
+    ``ImageOptimizer::analyzeHeuristic()`` -- no external
+    tool is invoked.
 
 ..  _developer-viewhelper:
 
@@ -122,3 +238,9 @@ Individual test commands:
     composer ci:test:php:phpstan  # Static analysis
     composer ci:test:php:unit     # PHPUnit tests
     composer ci:test:php:rector   # Code quality
+
+..  code-block:: bash
+    :caption: Docker-based matrix runner (also used by CI)
+
+    Build/Scripts/runTests.sh -s unit -p 8.4
+    Build/Scripts/runTests.sh -s phpstan -p 8.4

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -237,7 +237,7 @@ Upload event listener
     :php:class:`~Netresearch\\NrImageOptimize\\Service\\ImageOptimizer`.
 
     Re-entrancy guard: keyed by
-    ``storageUid + ':' + identifier`` so two storages sharing
+    ``storageUid . ':' . identifier`` so two storages sharing
     an identifier (``/image.jpg`` in different driver roots)
     don't block each other, while still catching the
     ``replaceFile()`` loop that the optimizer's own write
@@ -267,18 +267,18 @@ ImageOptimizer service
 
     Public API:
 
-    ``optimize(FileInterface, stripMetadata, jpegQuality, dryRun): array``
+    ``optimize(FileInterface $file, bool $stripMetadata = false, ?int $jpegQuality = null, bool $dryRun = false): array``
         Run the appropriate tool in place and replace the
         FAL file when the result shrinks.
 
-    ``analyze(FileInterface, stripMetadata, jpegQuality): array``
+    ``analyze(FileInterface $file, bool $stripMetadata = false, ?int $jpegQuality = null): array``
         Same pipeline, but never writes back.
 
-    ``analyzeHeuristic(FileInterface, maxWidth, maxHeight, minSize): array``
+    ``analyzeHeuristic(FileInterface $file, int $maxWidth = 2560, int $maxHeight = 1440, int $minSize = 512000): array``
         Fast estimation from size and resolution. No binary
         is invoked.
 
-    ``resolveToolFor(string extension): ?array``
+    ``resolveToolFor(string $extension): ?array``
         Tool discovery for callers that want to pre-check.
 
     ``hasAnyTool(): bool``

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,8 +1,4 @@
-..  This file contains global includes for all documentation files.
-    Include at the top of every RST file via:
-    ``..  include:: /Includes.rst.txt``
-
-..  |extension_key| replace:: nr_image_optimize
-..  |extension_name| replace:: Image Optimization for TYPO3
-..  |vendor| replace:: Netresearch DTT GmbH
-..  |release| replace:: 2.2.1
+.. |extension_key| replace:: nr_image_optimize
+.. |extension_name| replace:: Image Optimization for TYPO3
+.. |vendor| replace:: Netresearch DTT GmbH
+.. |release| replace:: 2.2.1

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _start:
 
@@ -7,7 +7,7 @@ Image Optimization for TYPO3
 ================================
 
 :Extension key:
-    |extension_key|
+    nr_image_optimize
 
 :Package name:
     netresearch/nr-image-optimize

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -55,9 +55,13 @@ Optional: install optimizer binaries
 ====================================
 
 The automatic on-upload compression and the
-:ref:`CLI commands <usage-cli>` call out to ``optipng``,
-``gifsicle``, and ``jpegoptim``. Install whichever tools you
-need and make them available in ``$PATH``:
+:ref:`nr:image:optimize <usage-cli-optimize>` CLI command call
+out to ``optipng``, ``gifsicle``, and ``jpegoptim``. The
+:ref:`nr:image:analyze <usage-cli-analyze>` command is purely
+heuristic and does not require these binaries.
+
+Install whichever tools you need and make them available in
+``$PATH``:
 
 ..  code-block:: bash
     :caption: Debian/Ubuntu
@@ -82,11 +86,14 @@ set one or more of the following environment variables:
     Absolute path to ``jpegoptim``.
 
 A set-but-invalid override is authoritative: the tool is
-reported unavailable and the listener/commands simply skip the
-file. There is no silent fallback to ``$PATH``.
+reported unavailable. There is no silent fallback to ``$PATH``.
 
 ..  tip::
 
-    If no binary is installed, on-upload compression and
-    ``nr:image:optimize`` simply do nothing -- they never
-    raise errors.
+    If no supported binary is installed, the on-upload
+    listener skips optimization silently. The
+    ``nr:image:optimize`` CLI command, by contrast, reports
+    the missing tools and exits with failure so an operator
+    running a bulk job gets immediate feedback.
+    ``nr:image:analyze`` works regardless because it never
+    invokes an external binary.

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _installation:
 
@@ -32,14 +32,61 @@ Manual installation
 Setup
 =====
 
-The extension works out of the box after installation. No
-additional configuration is required. Images accessed through
-the ``/processed/`` path are automatically optimized by the
-frontend middleware.
+The extension works out of the box after installation:
+
+-   The frontend middleware picks up any request to the
+    ``/processed/`` path and produces a variant on demand.
+-   The PSR-14 event listener for
+    ``AfterFileAddedEvent`` and ``AfterFileReplacedEvent``
+    runs on every new or replaced image.
+
+No additional configuration is required.
 
 ..  tip::
 
     For best results, ensure that your server has the
-    **Imagick** or **GD** PHP extension installed. The backend
-    maintenance module can verify all prerequisites for you
-    (see :ref:`maintenance-system-requirements`).
+    **Imagick** or **GD** PHP extension installed. The
+    backend maintenance module can verify all prerequisites
+    for you (see :ref:`maintenance-system-requirements`).
+
+..  _installation-optional-binaries:
+
+Optional: install optimizer binaries
+====================================
+
+The automatic on-upload compression and the
+:ref:`CLI commands <usage-cli>` call out to ``optipng``,
+``gifsicle``, and ``jpegoptim``. Install whichever tools you
+need and make them available in ``$PATH``:
+
+..  code-block:: bash
+    :caption: Debian/Ubuntu
+
+    sudo apt-get install optipng gifsicle jpegoptim
+
+..  code-block:: bash
+    :caption: macOS (Homebrew)
+
+    brew install optipng gifsicle jpegoptim
+
+To pin a specific path (useful in containerized environments)
+set one or more of the following environment variables:
+
+``OPTIPNG_BIN``
+    Absolute path to ``optipng``.
+
+``GIFSICLE_BIN``
+    Absolute path to ``gifsicle``.
+
+``JPEGOPTIM_BIN``
+    Absolute path to ``jpegoptim``.
+
+A set-but-invalid override is authoritative: the tool is
+reported unavailable and the listener/commands simply skip the
+file. There is no silent fallback to ``$PATH``.
+
+..  tip::
+
+    If no binary is installed, on-upload compression and
+    ``nr:image:optimize`` simply do nothing -- they never
+    raise errors.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -11,59 +11,80 @@ Introduction
 What does it do?
 ================
 
-The *Image Optimization for TYPO3* extension (``nr_image_optimize``) compresses
-images in TYPO3 on three layers:
+The *Image Optimization for TYPO3* extension (``nr_image_optimize``)
+compresses images in TYPO3 on three independent layers:
 
--   **On upload.** A PSR-14 event listener runs lossless
-    optimization when a file is added to, or replaced in, a
-    FAL storage (via ``optipng``, ``gifsicle``,
-    ``jpegoptim``).
--   **On demand in the frontend.** Resized and re-encoded
-    variants are produced lazily by the
-    :php:class:`~Netresearch\\NrImageOptimize\\Processor` when
-    a visitor first requests the ``/processed/`` URL.
--   **In bulk from the CLI.** The :ref:`nr:image:optimize
-    <usage-cli-optimize>` and :ref:`nr:image:analyze
-    <usage-cli-analyze>` commands iterate the FAL index to
-    operate on an entire installation.
+**On upload**
+    A PSR-14 event listener runs lossless optimization whenever a
+    file is added to or replaced in a FAL storage
+    (``AfterFileAddedEvent`` / ``AfterFileReplacedEvent``). The
+    listener delegates to the installed ``optipng`` / ``gifsicle``
+    / ``jpegoptim`` binaries.
 
-This combination reduces server load during content editing,
-keeps storage footprint small, and ensures that only images
-actually viewed by visitors pay the variant-generation cost.
+**On demand in the frontend**
+    A PSR-15 middleware intercepts every request that starts with
+    ``/processed/`` and delegates to the
+    :php:class:`~Netresearch\\NrImageOptimize\\Processor`. The
+    processor parses the URL, loads the original via
+    `Intervention Image <https://image.intervention.io/>`__,
+    produces a resized/recropped variant, optionally writes a
+    matching WebP and AVIF sidecar, and streams the best result
+    back to the client. Variants are cached on disk and served
+    with long-lived HTTP caching headers.
+
+**In bulk from the CLI**
+    Two Symfony Console commands iterate the FAL index:
+    :ref:`nr:image:optimize <usage-cli-optimize>` compresses every
+    eligible file, :ref:`nr:image:analyze <usage-cli-analyze>`
+    reports optimization potential as a fast heuristic without
+    touching any file.
+
+All three layers share a common
+:php:class:`~Netresearch\\NrImageOptimize\\Service\\ImageOptimizer`
+service for tool resolution and process orchestration.
 
 ..  _introduction-features:
 
 Features
 ========
 
--   **Automatic optimization on upload.** Compresses newly
-    added or replaced images in place without re-encoding.
-    Storages, offline drivers, and unsupported extensions are
-    handled transparently.
--   **Bulk CLI commands.** ``nr:image:optimize`` walks the FAL
-    index and compresses eligible images.
-    ``nr:image:analyze`` reports optimization potential
-    without modifying files (fast heuristic -- no binaries
-    invoked).
--   **Lazy image processing.** Variants are optimized only
-    when a visitor first requests them.
--   **Modern format support.** Automatic WebP and AVIF
-    conversion with fallback to original formats.
--   **Responsive images.** Built-in ``SourceSetViewHelper``
-    for ``srcset`` and ``sizes`` generation.
--   **Render modes.** Choose between ``cover`` and ``fit``
-    resize strategies.
--   **Width-based srcset.** Optional responsive ``srcset``
-    with configurable width variants and ``sizes`` attribute.
+-   **Automatic optimization on upload.** In-place lossless
+    compression without re-encoding. Unsupported extensions,
+    offline storages, and missing binaries are handled
+    transparently -- the listener never raises.
+-   **Bulk CLI commands.** Streaming iteration over ``sys_file``
+    keeps memory usage flat on large installations. Progress bar
+    with cumulative savings.
+-   **On-demand variant generation.** Variants are produced only
+    when a visitor first requests them through the ``/processed/``
+    URL.
+-   **Next-gen format support.** Automatic WebP and AVIF sidecar
+    generation with Accept-header-driven content negotiation and
+    ``skipWebP`` / ``skipAvif`` opt-outs.
+-   **Responsive images.**
+    :php:class:`~Netresearch\\NrImageOptimize\\ViewHelpers\\SourceSetViewHelper`
+    emits ``<img>`` tags with density-based or width-based
+    ``srcset`` + ``sizes``.
+-   **Render modes.** Choose between ``cover`` and ``fit`` resize
+    strategies per URL.
 -   **Fetch priority.** Native ``fetchpriority`` attribute
-    support for Core Web Vitals optimization.
--   **Middleware-based processing.** Lightweight frontend
-    middleware intercepts ``/processed/`` requests.
--   **Backend maintenance module.** View statistics, check
-    system requirements, and clear processed images.
--   **Powered by Intervention Image.** Uses the
-    `Intervention Image <https://image.intervention.io/>`__
-    library for reliable image manipulation.
+    support for Core Web Vitals (LCP) tuning.
+-   **PSR-14 extension points.**
+    :php:class:`~Netresearch\\NrImageOptimize\\Event\\ImageProcessedEvent`
+    and
+    :php:class:`~Netresearch\\NrImageOptimize\\Event\\VariantServedEvent`
+    let integrators observe the pipeline.
+-   **Driver abstraction.** Imagick is preferred when the
+    extension is loaded; GD is used as a fallback. The
+    ``ImageReaderInterface`` adapter (see
+    :ref:`developer-image-manager`) hides the Intervention
+    Image v3/v4 API difference.
+-   **Backend maintenance module.** View statistics about
+    processed images, check prerequisites, and clear the cache
+    from the TYPO3 backend.
+-   **Security.** Path traversal is blocked at URL parsing time,
+    quality and dimension values are clamped to safe ranges,
+    PSR-7 responses replace direct ``header()`` / ``exit`` calls.
 
 ..  _introduction-requirements:
 
@@ -72,16 +93,17 @@ Requirements
 
 -   PHP 8.2, 8.3, 8.4, or 8.5.
 -   TYPO3 13.4 or 14.
--   Intervention Image library 3.11+ (installed automatically
-    via Composer).
+-   Imagick **or** GD PHP extension.
+-   Intervention Image 3.11+ (installed automatically via
+    Composer).
 
 ..  _introduction-optional-binaries:
 
 Optional optimizer binaries
 ===========================
 
-On-upload and CLI optimization only compress files when a
-matching binary is available:
+The on-upload listener and the CLI commands only compress files
+when a matching binary is available in ``$PATH``:
 
 ``optipng``
     Lossless PNG compression.
@@ -92,12 +114,14 @@ matching binary is available:
 ``jpegoptim``
     Lossless (default) or lossy JPEG compression.
 
-The extension discovers these binaries through ``$PATH``. You
-can override the resolved path per binary via the
-``OPTIPNG_BIN``, ``GIFSICLE_BIN``, and ``JPEGOPTIM_BIN``
-environment variables. A set-but-invalid override is treated
-as authoritative: the tool is reported unavailable rather
-than silently falling back to ``$PATH``.
+Paths can be pinned per binary via the ``OPTIPNG_BIN``,
+``GIFSICLE_BIN``, and ``JPEGOPTIM_BIN`` environment variables. A
+set-but-invalid override is treated as authoritative: the tool
+is reported unavailable rather than silently falling back to
+``$PATH``. ``$PATH`` lookups also verify ``is_executable()``.
+
+See :ref:`installation-optional-binaries` for package-manager
+snippets.
 
 ..  _introduction-recommended-extensions:
 
@@ -106,5 +130,5 @@ Recommended extensions
 
 `imageoptimizer <https://github.com/christophlehmann/imageoptimizer>`__
     Alternative TYPO3 image optimization extension that
-    integrates a broader set of external binaries with the
-    core image processing pipeline.
+    integrates a broader set of external binaries with the core
+    image processing pipeline.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _introduction:
 
@@ -11,30 +11,50 @@ Introduction
 What does it do?
 ================
 
-The |extension_name| extension (|extension_key|) optimizes images
-in TYPO3 on demand. Instead of processing every image at upload
-time, images are converted and resized lazily when first
-requested through the ``/processed/`` URL path.
+The *Image Optimization for TYPO3* extension (``nr_image_optimize``) compresses
+images in TYPO3 on three layers:
 
-This approach reduces server load during content editing and
-ensures that only images actually viewed by visitors are
-processed.
+-   **On upload.** A PSR-14 event listener runs lossless
+    optimization when a file is added to, or replaced in, a
+    FAL storage (via ``optipng``, ``gifsicle``,
+    ``jpegoptim``).
+-   **On demand in the frontend.** Resized and re-encoded
+    variants are produced lazily by the
+    :php:class:`~Netresearch\\NrImageOptimize\\Processor` when
+    a visitor first requests the ``/processed/`` URL.
+-   **In bulk from the CLI.** The :ref:`nr:image:optimize
+    <usage-cli-optimize>` and :ref:`nr:image:analyze
+    <usage-cli-analyze>` commands iterate the FAL index to
+    operate on an entire installation.
+
+This combination reduces server load during content editing,
+keeps storage footprint small, and ensures that only images
+actually viewed by visitors pay the variant-generation cost.
 
 ..  _introduction-features:
 
 Features
 ========
 
--   **Lazy image processing.** Images are optimized only when
-    a visitor first requests them.
+-   **Automatic optimization on upload.** Compresses newly
+    added or replaced images in place without re-encoding.
+    Storages, offline drivers, and unsupported extensions are
+    handled transparently.
+-   **Bulk CLI commands.** ``nr:image:optimize`` walks the FAL
+    index and compresses eligible images.
+    ``nr:image:analyze`` reports optimization potential
+    without modifying files (fast heuristic -- no binaries
+    invoked).
+-   **Lazy image processing.** Variants are optimized only
+    when a visitor first requests them.
 -   **Modern format support.** Automatic WebP and AVIF
     conversion with fallback to original formats.
--   **Responsive images.** Built-in ``SourceSetViewHelper`` for
-    ``srcset`` and ``sizes`` generation.
+-   **Responsive images.** Built-in ``SourceSetViewHelper``
+    for ``srcset`` and ``sizes`` generation.
 -   **Render modes.** Choose between ``cover`` and ``fit``
     resize strategies.
--   **Width-based srcset.** Optional responsive ``srcset`` with
-    configurable width variants and ``sizes`` attribute.
+-   **Width-based srcset.** Optional responsive ``srcset``
+    with configurable width variants and ``sizes`` attribute.
 -   **Fetch priority.** Native ``fetchpriority`` attribute
     support for Core Web Vitals optimization.
 -   **Middleware-based processing.** Lightweight frontend
@@ -55,12 +75,36 @@ Requirements
 -   Intervention Image library 3.11+ (installed automatically
     via Composer).
 
+..  _introduction-optional-binaries:
+
+Optional optimizer binaries
+===========================
+
+On-upload and CLI optimization only compress files when a
+matching binary is available:
+
+``optipng``
+    Lossless PNG compression.
+
+``gifsicle``
+    Lossless GIF compression.
+
+``jpegoptim``
+    Lossless (default) or lossy JPEG compression.
+
+The extension discovers these binaries through ``$PATH``. You
+can override the resolved path per binary via the
+``OPTIPNG_BIN``, ``GIFSICLE_BIN``, and ``JPEGOPTIM_BIN``
+environment variables. A set-but-invalid override is treated
+as authoritative: the tool is reported unavailable rather
+than silently falling back to ``$PATH``.
+
 ..  _introduction-recommended-extensions:
 
 Recommended extensions
 ======================
 
 `imageoptimizer <https://github.com/christophlehmann/imageoptimizer>`__
-    Additional image optimization tooling that compresses
-    uploaded and processed images with external binaries of
-    your choice.
+    Alternative TYPO3 image optimization extension that
+    integrates a broader set of external binaries with the
+    core image processing pipeline.

--- a/Documentation/Maintenance/Index.rst
+++ b/Documentation/Maintenance/Index.rst
@@ -70,10 +70,13 @@ host in minutes.
 
     The page does not currently report on the ``optipng``,
     ``gifsicle``, or ``jpegoptim`` binaries used by the
-    on-upload listener and CLI commands. Run
-    :ref:`nr:image:analyze <usage-cli-analyze>` or check the
-    binaries manually on the host to verify their
-    availability.
+    on-upload listener and ``nr:image:optimize``. To verify
+    those, run ``nr:image:optimize --dry-run`` (see
+    :ref:`usage-cli-optimize`) -- it resolves every tool up
+    front and exits with an error listing the missing ones --
+    or check the binaries manually on the host.
+    ``nr:image:analyze`` is heuristic and never invokes
+    external tools, so it cannot be used for this check.
 
 ..  _maintenance-clear:
 

--- a/Documentation/Maintenance/Index.rst
+++ b/Documentation/Maintenance/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _maintenance:
 
@@ -6,8 +6,10 @@
 Maintenance
 ===========
 
-The extension provides a backend module accessible via
-:guilabel:`Admin Tools > Processed Images Maintenance`.
+The extension ships both a backend module and two CLI
+commands. The backend module is reachable via
+:guilabel:`Admin Tools > Processed Images Maintenance`. The
+CLI commands are documented in :ref:`usage-cli`.
 
 ..  _maintenance-overview:
 
@@ -33,8 +35,13 @@ Verify all technical prerequisites and tool availability:
     support).
 -   Composer dependencies (Intervention Image).
 -   TYPO3 version compatibility.
--   CLI tools (``magick``, ``convert``, ``identify``, ``gm``
-    -- optional).
+-   CLI tools (``magick``, ``convert``, ``identify``,
+    ``gm`` -- optional).
+
+The page does not currently report on ``optipng`` /
+``gifsicle`` / ``jpegoptim``; for those, run
+``nr:image:analyze`` (see :ref:`usage-cli-analyze`) or check
+the binaries manually on the host.
 
 ..  _maintenance-clear:
 
@@ -49,3 +56,26 @@ automatically when first accessed again.
     After clearing processed images, expect temporarily
     increased loading times on the frontend until images are
     regenerated on demand.
+
+..  _maintenance-cli:
+
+Command-line maintenance
+========================
+
+Two console commands complement the backend module:
+
+:ref:`nr:image:optimize <usage-cli-optimize>`
+    Lossless (or optionally lossy) bulk compression of every
+    PNG, GIF, and JPEG file in the FAL index.
+
+:ref:`nr:image:analyze <usage-cli-analyze>`
+    Fast heuristic report that estimates optimization
+    potential without touching files or running external
+    tools.
+
+..  tip::
+
+    Run ``nr:image:analyze`` first to decide whether the
+    optimization run is worth the I/O. Then schedule
+    ``nr:image:optimize`` as a periodic task (for example
+    through the TYPO3 scheduler or a cron job).

--- a/Documentation/Maintenance/Index.rst
+++ b/Documentation/Maintenance/Index.rst
@@ -6,56 +6,100 @@
 Maintenance
 ===========
 
-The extension ships both a backend module and two CLI
+The extension ships with both a backend module and two CLI
 commands. The backend module is reachable via
-:guilabel:`Admin Tools > Processed Images Maintenance`. The
-CLI commands are documented in :ref:`usage-cli`.
+:guilabel:`Admin Tools > Processed Images Maintenance`
+(access restricted to users with the ``systemMaintainer``
+role). The CLI commands are documented in :ref:`usage-cli`.
+
+..  _maintenance-access:
+
+Access control
+==============
+
+The backend module is registered under the :guilabel:`Admin
+Tools` parent with ``access: systemMaintainer``. Only TYPO3
+users in the ``systemMaintainer`` group (configured in
+``LocalConfiguration.php``) see it in the backend navigation.
 
 ..  _maintenance-overview:
 
 Overview
 ========
 
-View statistics about processed images:
+The :guilabel:`Overview` tab (``MaintenanceController::indexAction``)
+reports statistics about the processed-images directory:
 
--   File count and total size.
--   Directory count.
--   Largest files.
--   File type distribution.
+-   File count and total disk usage.
+-   Number of directories under ``/processed/``.
+-   The five largest files (name, size, last-modified timestamp).
+-   File-type distribution (JPEG / PNG / GIF / WebP / AVIF /
+    other).
+
+The stats are computed on demand by recursively walking the
+filesystem; no metadata is persisted to the database.
 
 ..  _maintenance-system-requirements:
 
 System requirements check
 =========================
 
-Verify all technical prerequisites and tool availability:
+The :guilabel:`System requirements` tab
+(``MaintenanceController::systemRequirementsAction``) verifies
+all technical prerequisites needed for successful variant
+generation:
 
--   PHP version and extensions (Imagick, GD).
--   ImageMagick / GraphicsMagick capabilities (WebP, AVIF
-    support).
--   Composer dependencies (Intervention Image).
--   TYPO3 version compatibility.
--   CLI tools (``magick``, ``convert``, ``identify``,
-    ``gm`` -- optional).
+-   PHP version and loaded extensions (``imagick``, ``gd``,
+    ``fileinfo``).
+-   ImageMagick / GraphicsMagick capabilities reported by
+    Imagick, in particular the ability to decode/encode WebP
+    and AVIF. If Imagick is not installed, the page falls
+    back to GD capabilities.
+-   Intervention Image installed version and the driver
+    selected at runtime.
+-   TYPO3 version.
+-   Availability of optional CLI helpers (``magick``,
+    ``convert``, ``identify``, ``gm``) -- none are strictly
+    required but may be useful for debugging.
 
-The page does not currently report on ``optipng`` /
-``gifsicle`` / ``jpegoptim``; for those, run
-``nr:image:analyze`` (see :ref:`usage-cli-analyze`) or check
-the binaries manually on the host.
+Each check is rendered as a pass/warning/fail row with a
+short explanation so an administrator can fix a misconfigured
+host in minutes.
+
+..  note::
+
+    The page does not currently report on the ``optipng``,
+    ``gifsicle``, or ``jpegoptim`` binaries used by the
+    on-upload listener and CLI commands. Run
+    :ref:`nr:image:analyze <usage-cli-analyze>` or check the
+    binaries manually on the host to verify their
+    availability.
 
 ..  _maintenance-clear:
 
 Clear processed images
 ======================
 
-Remove all on-demand generated images. Images are regenerated
-automatically when first accessed again.
+The :guilabel:`Clear processed images` tab
+(``MaintenanceController::clearProcessedImagesAction``)
+recursively deletes every file under the configured
+processed-images directory. A flash message reports the
+number of files removed and the disk space freed.
 
 ..  warning::
 
     After clearing processed images, expect temporarily
-    increased loading times on the frontend until images are
-    regenerated on demand.
+    increased frontend load -- each variant is re-created on
+    first request. Run the action during off-peak hours on
+    busy sites.
+
+..  tip::
+
+    ``nr:image:optimize`` only touches original files in
+    FAL storages; it does **not** clear the
+    ``/processed/`` directory. Use this action (or the
+    TYPO3 install tool's "Flush cache" entry) to discard
+    cached variants after an optimization run.
 
 ..  _maintenance-cli:
 

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -143,9 +143,12 @@ Paint (LCP) scores:
 Command-line tools
 ==================
 
-Both commands read the FAL index directly and honor storage
-access rules. They run safely in long-running shells --
-permission checks are disabled and restored per file.
+Both commands read the FAL index directly and process eligible
+image files (``image/jpeg``, ``image/gif``, ``image/png``) on
+online storages. Per-file storage permission evaluation is
+temporarily disabled and restored in a ``finally`` block so
+long-running CLI runs don't leak state across iterations or
+require a BE user context.
 
 ..  _usage-cli-optimize:
 
@@ -215,4 +218,4 @@ Options:
 
 ``--min-size``
     Skip files smaller than this many bytes (default
-    512 000). Prevents noise from already-tiny images.
+    512000). Prevents noise from already-tiny images.

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 ..  _usage:
 
@@ -7,7 +7,8 @@ Usage
 =====
 
 This chapter shows practical examples for integrating
-responsive images into your Fluid templates.
+responsive images into your Fluid templates and for operating
+the command-line tools that ship with the extension.
 
 ..  _usage-namespace:
 
@@ -136,3 +137,82 @@ Paint (LCP) scores:
                   height="1080"
                   fetchpriority="high"
     />
+
+..  _usage-cli:
+
+Command-line tools
+==================
+
+Both commands read the FAL index directly and honor storage
+access rules. They run safely in long-running shells --
+permission checks are disabled and restored per file.
+
+..  _usage-cli-optimize:
+
+Bulk optimize images
+--------------------
+
+The ``nr:image:optimize`` command compresses every eligible
+PNG, GIF, and JPEG file across all storages (or a restricted
+subset) using the installed optimizer binaries. The original
+file is replaced in place only when the tool produces a
+smaller result.
+
+..  code-block:: bash
+    :caption: Preview what would be processed
+
+    vendor/bin/typo3 nr:image:optimize --dry-run
+
+..  code-block:: bash
+    :caption: Compress storage 1 with lossy JPEG quality 85
+
+    vendor/bin/typo3 nr:image:optimize \
+        --storages=1 \
+        --jpeg-quality=85 \
+        --strip-metadata
+
+Options:
+
+``--dry-run``
+    Only analyze; do not modify files.
+
+``--storages``
+    Restrict to specific storage UIDs. Accepts repeated
+    occurrences or a comma-separated list.
+
+``--jpeg-quality``
+    Lossy JPEG quality 0--100. Omit for lossless JPEG
+    optimization.
+
+``--strip-metadata``
+    Remove EXIF and comments when the tool supports it.
+
+..  _usage-cli-analyze:
+
+Analyze optimization potential
+------------------------------
+
+The ``nr:image:analyze`` command estimates how much disk
+space could be saved by running ``nr:image:optimize`` or by
+downscaling oversized originals. It is purely heuristic --
+no external binaries are invoked, so it runs quickly even on
+large installations.
+
+..  code-block:: bash
+    :caption: Report potential for storage 1
+
+    vendor/bin/typo3 nr:image:analyze --storages=1
+
+Options:
+
+``--storages``
+    Restrict to specific storage UIDs.
+
+``--max-width`` / ``--max-height``
+    Target display box (default 2560 x 1440). Images larger
+    than this box are assumed to be downscaled and the
+    estimate factors in the area reduction.
+
+``--min-size``
+    Skip files smaller than this many bytes (default
+    512 000). Prevents noise from already-tiny images.

--- a/README.rst
+++ b/README.rst
@@ -4,28 +4,47 @@
     :target: https://github.com/netresearch/t3x-nr-image-optimize/blob/main/LICENSE
 ..  |ci| image:: https://github.com/netresearch/t3x-nr-image-optimize/actions/workflows/ci.yml/badge.svg
     :target: https://github.com/netresearch/t3x-nr-image-optimize/actions/workflows/ci.yml
+..  |codecov| image:: https://codecov.io/gh/netresearch/t3x-nr-image-optimize/branch/main/graph/badge.svg
+    :target: https://app.codecov.io/gh/netresearch/t3x-nr-image-optimize
 ..  |php| image:: https://img.shields.io/badge/PHP-8.2%20|%208.3%20|%208.4%20|%208.5-blue.svg
     :target: https://www.php.net/
 ..  |typo3| image:: https://img.shields.io/badge/TYPO3-13.4%20|%2014-orange.svg
     :target: https://typo3.org/
 
-|php| |typo3| |license| |ci| |release|
+|php| |typo3| |license| |ci| |codecov| |release|
 
 ================================
 Image Optimization for TYPO3
 ================================
 
-The ``nr_image_optimize`` extension provides on-demand image
-optimization for TYPO3. Images are processed lazily via
-middleware when first requested, with support for modern formats
-(WebP, AVIF), responsive ``srcset`` generation, and automatic
-format negotiation.
+The ``nr_image_optimize`` extension provides image optimization
+for TYPO3 on three layers:
+
+-   **On upload.** Lossless optimization runs automatically when
+    images are added to, or replaced in, a FAL storage (via
+    ``optipng``, ``gifsicle``, ``jpegoptim``).
+-   **On demand in the frontend.** Variants are processed lazily
+    when first requested through the ``/processed/`` URL, with
+    support for modern formats (WebP, AVIF), responsive
+    ``srcset`` generation, and automatic format negotiation.
+-   **In bulk from the CLI.** Two console commands iterate the
+    FAL index to optimize or report optimization potential on
+    the entire installation.
 
 Features
 ========
 
--   **Lazy image processing.** Images are optimized only when
-    a visitor first requests them.
+-   **Automatic optimization on upload.** PSR-14 event listener
+    compresses newly added or replaced images in place without
+    re-encoding. Storages, offline drivers, and unsupported
+    extensions are handled transparently.
+-   **Bulk CLI commands.** ``nr:image:optimize`` walks the FAL
+    index and compresses eligible images. ``nr:image:analyze``
+    reports optimization potential without modifying files
+    (heuristic, no binaries invoked).
+-   **Lazy frontend processing.** Variants are created only when
+    a visitor first requests them through the ``/processed/``
+    URL.
 -   **Modern format support.** Automatic WebP and AVIF
     conversion with fallback to original formats.
 -   **Responsive images.** Built-in ``SourceSetViewHelper``
@@ -49,12 +68,20 @@ Requirements
 -   Intervention Image library (installed via Composer
     automatically).
 
-Recommended extensions
-======================
+Optional (for on-upload and CLI optimization)
+---------------------------------------------
 
--   `imageoptimizer
-    <https://github.com/christophlehmann/imageoptimizer>`__
-    -- Optimize images with external binaries of your choice.
+Install one or more of the following binaries and make them
+available in ``$PATH`` to enable lossless compression:
+
+-   ``optipng`` -- for PNG files.
+-   ``gifsicle`` -- for GIF files.
+-   ``jpegoptim`` -- for JPEG files.
+
+Paths can be overridden per binary via the ``OPTIPNG_BIN``,
+``GIFSICLE_BIN``, and ``JPEGOPTIM_BIN`` environment variables.
+A set-but-invalid override is treated as authoritative (tool
+reported unavailable); there is no silent fallback to ``$PATH``.
 
 Installation
 ============
@@ -75,12 +102,94 @@ Manual installation
 2.  Upload to ``typo3conf/ext/``.
 3.  Activate the extension in the Extension Manager.
 
+Automatic optimization on upload
+================================
+
+After installation the PSR-14 event listener is active out of
+the box. Whenever an image is added or replaced on an online
+storage (for example via the backend file module or the
+REST API) the extension:
+
+1.  Normalizes the file extension (case-insensitive).
+2.  Checks whether an optimizer binary for that extension is
+    installed.
+3.  Runs the tool in place via the ``ImageOptimizer`` service.
+4.  Restores the storage's permission-evaluation state and
+    clears its re-entrancy guard before returning.
+
+No configuration is required. If no optimizer binary is
+available the listener silently skips the file.
+
+CLI commands
+============
+
+Bulk optimize existing images
+-----------------------------
+
+..  code-block:: bash
+
+    # Dry-run: report what would be processed.
+    vendor/bin/typo3 nr:image:optimize --dry-run
+
+    # Optimize all eligible images in storage 1 with lossy JPEG
+    # quality 85 and EXIF stripping.
+    vendor/bin/typo3 nr:image:optimize \
+        --storages=1 \
+        --jpeg-quality=85 \
+        --strip-metadata
+
+Supported options:
+
+``--dry-run``
+    Analyze only, do not modify files.
+
+``--storages``
+    Restrict to specific storage UIDs (comma-separated or
+    repeated).
+
+``--jpeg-quality``
+    Lossy JPEG quality 0--100. Omit for lossless optimization.
+
+``--strip-metadata``
+    Remove EXIF and comments when the tool supports it.
+
+Analyze optimization potential
+------------------------------
+
+..  code-block:: bash
+
+    vendor/bin/typo3 nr:image:analyze \
+        --storages=1 \
+        --max-width=2560 \
+        --max-height=1440 \
+        --min-size=512000
+
+The analyzer never invokes an external tool. It estimates
+savings from file size and resolution and reports how much
+disk space could be recovered by running
+``nr:image:optimize``.
+
+Supported options:
+
+``--storages``
+    Restrict to specific storage UIDs.
+
+``--max-width`` / ``--max-height``
+    Target display box. Images larger than this box are
+    assumed to be downscaled by ``nr:image:optimize`` and
+    the estimate factors in the area reduction.
+
+``--min-size``
+    Skip files smaller than this many bytes (default
+    512 000). Prevents reporting on already-tiny images.
+
 Configuration
 =============
 
 The extension works out of the box with sensible defaults.
-Images are automatically optimized when accessed via the
-``/processed/`` path.
+Images accessed via the ``/processed/`` path are automatically
+optimized by the frontend middleware; uploaded images are
+compressed by the event listener.
 
 ViewHelper usage
 ----------------
@@ -101,6 +210,9 @@ Supported parameters
 
 ``file``
     Image file resource.
+
+``path``
+    Pre-resolved image URI (alternative to ``file``).
 
 ``width``
     Target width in pixels.
@@ -156,6 +268,9 @@ Development and testing
     composer ci:test:php:phpstan  # Static analysis
     composer ci:test:php:unit     # PHPUnit tests
     composer ci:test:php:rector   # Code quality
+
+    # Dockerized test runner (also used by CI)
+    Build/Scripts/runTests.sh -s unit -p 8.4
 
 License
 =======

--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,44 @@ Supported parameters
     Native HTML ``fetchpriority`` attribute (``high``,
     ``low``, ``auto``).
 
+Variant URL format
+==================
+
+Processed variants are served from
+``/processed/<path>.<mode-config>.<ext>``. The mode config is a
+concatenation of any of ``w<n>``, ``h<n>``, ``q<n>``, ``m<n>``
+(width, height, quality 1--100, mode ``0`` = cover / ``1`` = fit).
+The processor decides at response time whether to serve the
+original, the ``.webp`` sidecar, or the ``.avif`` sidecar based on
+the ``Accept`` header and the ``skipWebP`` / ``skipAvif`` query
+flags. Path traversal sequences are rejected; ``w`` / ``h`` are
+clamped to 1--8192 and ``q`` to 1--100.
+
+Example: ``/processed/fileadmin/hero.w1200h800m0q85.jpg``.
+
+Extension points
+================
+
+Two PSR-14 events let integrators observe the on-demand
+pipeline:
+
+``ImageProcessedEvent``
+    Dispatched after a new variant has been written to disk.
+    Exposes source path, variant path, extension, dimensions,
+    quality, mode, and whether WebP / AVIF sidecars were
+    produced.
+
+``VariantServedEvent``
+    Dispatched immediately before the response body is
+    streamed. Reports whether the response was served from
+    disk cache (``fromCache``).
+
+Image driver selection is handled by ``ImageManagerFactory``:
+Imagick is preferred when the PHP extension is loaded, GD is
+used as a fallback. The version-agnostic ``ImageReaderInterface``
+hides the Intervention Image v3/v4 API difference so integrators
+can rely on a stable contract.
+
 Documentation
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ Supported options:
 
 ``--min-size``
     Skip files smaller than this many bytes (default
-    512 000). Prevents reporting on already-tiny images.
+    512000). Prevents reporting on already-tiny images.
 
 Configuration
 =============
@@ -198,53 +198,71 @@ ViewHelper usage
 
     {namespace nr=Netresearch\NrImageOptimize\ViewHelpers}
 
-    <nr:sourceSet file="{image}"
+    <nr:sourceSet path="{f:uri.image(image: image)}"
                   width="1200"
                   height="800"
-                  quality="85"
+                  alt="{image.properties.alternative}"
                   sizes="(max-width: 768px) 100vw, 50vw"
+                  responsiveSrcset="1"
     />
 
 Supported parameters
 --------------------
 
-``file``
-    Image file resource.
+``path`` (required)
+    Public path to the source image (e.g. ``/fileadmin/foo.jpg``).
+    Typically generated via ``f:uri.image()``.
 
-``path``
-    Pre-resolved image URI (alternative to ``file``).
+``width`` / ``height``
+    Base width/height in px for the rendered ``<img>``.
+    Defaults to ``0`` (auto from file / preserve aspect ratio).
 
-``width``
-    Target width in pixels.
+``set``
+    Responsive set in the form
+    ``{maxWidth: {width: int, height: int}}`` — emits per-breakpoint
+    ``<source>`` tags wrapped in a ``<picture>``.
 
-``height``
-    Target height in pixels.
+``alt`` / ``title``
+    HTML-escaped ``alt`` and ``title`` attributes.
 
-``quality``
-    JPEG/WebP quality (1--100).
-
-``sizes``
-    Responsive ``sizes`` attribute.
-
-``format``
-    Output format: ``auto``, ``webp``, ``avif``, ``jpg``,
-    ``png``.
+``class``
+    CSS classes for the ``<img>`` tag. Include ``lazyload`` to
+    switch to JS-based lazy loading (``data-src``/``data-srcset``).
 
 ``mode``
-    Render mode: ``cover`` (default) or ``fit``.
+    Render mode: ``cover`` (default, crop/fill) or ``fit``
+    (scale inside the box).
+
+``lazyload``
+    Add ``loading="lazy"`` (native lazy loading).
 
 ``responsiveSrcset``
     Enable width-based responsive ``srcset`` instead of
-    density-based ``2x``. Default: ``false``.
+    density-based 2x. Default: ``false``.
 
 ``widthVariants``
-    Width variants for responsive ``srcset``
-    (comma-separated string or array).
-    Default: ``480, 576, 640, 768, 992, 1200, 1800``.
+    Width variants for responsive ``srcset`` (comma-separated
+    string or array). Default:
+    ``480, 576, 640, 768, 992, 1200, 1800``.
+
+``sizes``
+    Responsive ``sizes`` attribute. Default:
+    ``auto, (min-width: 992px) 991px, 100vw``.
 
 ``fetchpriority``
     Native HTML ``fetchpriority`` attribute (``high``,
-    ``low``, ``auto``).
+    ``low``, or ``auto``).
+
+``attributes``
+    Extra HTML attributes merged into the rendered tag.
+
+..  note::
+
+    Quality and output format are not exposed as ViewHelper
+    arguments; they are baked into the ``/processed/`` URL
+    (``q<n>`` segment, source extension). Use
+    ``f:uri.image(image: image, additionalConfiguration: ...)``
+    to influence the generated path if needed.
 
 Variant URL format
 ==================


### PR DESCRIPTION
## Summary

Brings README and ``Documentation/`` back in sync with the **whole
extension**, not just the post-#28 delta. Previous docs were
already out of date on several long-standing features (events,
URL format, content negotiation, driver abstraction, backend
module internals).

## What's now documented

- **Three-layer architecture** (on-upload listener, on-demand
  middleware/processor, bulk CLI) with explicit cross-links
  between the layers in every page.
- **Variant URL format** -- the full
  ``/processed/<path>.<mode-config>.<ext>`` grammar with
  ``w<n>`` / ``h<n>`` / ``q<n>`` / ``m<n>`` segments and a
  worked example.
- **Variant negotiation** -- Accept-header-driven selection
  (AVIF > WebP > original) and the ``skipWebP`` / ``skipAvif``
  query opt-outs.
- **PSR-14 events** -- ``ImageProcessedEvent`` and
  ``VariantServedEvent`` with full property reference and a
  Services.yaml listener snippet.
- **Image driver selection** -- Imagick preferred, GD fallback,
  ``RuntimeException`` on neither. ``ImageReaderInterface`` /
  ``ImageManagerAdapter`` covering the Intervention Image v3/v4
  abstraction.
- **Processor limits and security** -- path traversal rejection,
  dimension clamping (1-8192), quality clamping (1-100),
  ``LockFactory`` behaviour, immutable cache headers.
- **Backend maintenance module** -- all three tabs (Overview,
  System requirements, Clear processed images) with their
  controller actions and the ``systemMaintainer`` access
  restriction.
- **On-upload listener** -- storage + identifier composite
  re-entrancy key, permission-state preservation, silent no-op
  when no binary is installed.
- **CLI commands** -- ``nr:image:optimize`` (dry-run, storage
  filter, lossy JPEG quality, metadata stripping) and
  ``nr:image:analyze`` (heuristic estimation without binary
  invocation).
- **Optional optimizer binaries** -- package-manager install
  snippets for ``optipng`` / ``gifsicle`` / ``jpegoptim`` plus
  the ``OPTIPNG_BIN`` / ``GIFSICLE_BIN`` / ``JPEGOPTIM_BIN``
  env override behaviour (set-but-invalid = authoritative, no
  ``PATH`` fallback, ``is_executable()`` verified).

## Rendering fixes

- Switch all RST include directives from ``..  include::``
  (two spaces -> parsed as a comment) to ``.. include::`` (one
  space -> directive syntax), matching TYPO3 core convention.
  Fixes ``No replacement was found for |extension_*|`` warnings.
- Simplify ``Documentation/Includes.rst.txt`` to the bare
  substitution block.
- Inline ``|extension_name|`` / ``|extension_key|`` at their
  two use sites; phpdoc-guides did not propagate them across
  the include boundary even with the correct syntax.
- Replace stale ``..  php:interface::`` directives with
  ``..  php:class::`` (phpdoc-guides cross-refs don't resolve
  between the two cleanly).
- Remove ``:php:method:`...Action``` refs that weren't backed
  by an explicit ``..  php:method::`` declaration.

## Verification

- ``scripts/validate_docs.sh`` - 0 warnings.
- ``scripts/render_docs.sh`` - 8 documents rendered with no
  warnings or errors.