### PR TITLE
ci: suppress Opengrep unlink-use findings with justifications

### DIFF
--- a/Classes/Service/ImageOptimizer.php
+++ b/Classes/Service/ImageOptimizer.php
@@ -113,7 +113,7 @@ final class ImageOptimizer
 
             return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $after, 'tool' => $tool['name']];
         } finally {
-            @unlink($localPath);
+            @unlink($localPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- @unlink() of TYPO3 FAL temporary local copy from getForLocalProcessing(true) in finally block; not a user-supplied path
         }
     }
 
@@ -194,7 +194,7 @@ final class ImageOptimizer
 
             return ['optimized' => false, 'savedBytes' => 0, 'before' => $before, 'after' => $after, 'tool' => $tool['name']];
         } finally {
-            @unlink($localPath);
+            @unlink($localPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- @unlink() of TYPO3 FAL temporary local copy from getForLocalProcessing(true) in finally block; not a user-supplied path
         }
     }
 
@@ -356,7 +356,7 @@ final class ImageOptimizer
                 'tool'       => null,
             ];
         } finally {
-            @unlink($localPath);
+            @unlink($localPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- @unlink() of TYPO3 FAL temporary local copy from getForLocalProcessing(true) in finally block; not a user-supplied path
         }
     }
 }

--- a/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+++ b/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
@@ -492,9 +492,9 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         foreach ($items as $item) {
             /** @var SplFileInfo $item */
             if ($item->isDir()) {
-                @rmdir($item->getRealPath());
+                @rmdir($item->getPathname());
             } else {
-                @unlink($item->getRealPath()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+                @unlink($item->getPathname()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+++ b/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
@@ -313,8 +313,8 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         // Content-Length header present
         self::assertNotEmpty($response->getHeaderLine('Content-Length'));
 
-        unlink($variantFile);
-        unlink($originalFile);
+        unlink($variantFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($originalFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -335,9 +335,9 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('image/avif', $response->getHeaderLine('Content-Type'));
 
-        unlink($variantFile . '.avif');
-        unlink($variantFile);
-        unlink($originalFile);
+        unlink($variantFile . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($variantFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($originalFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -358,9 +358,9 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('image/webp', $response->getHeaderLine('Content-Type'));
 
-        unlink($variantFile . '.webp');
-        unlink($variantFile);
-        unlink($originalFile);
+        unlink($variantFile . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($variantFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($originalFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // ──────────────────────────────────────────────────
@@ -384,7 +384,7 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         $etag = $response->getHeaderLine('ETag');
         self::assertMatchesRegularExpression('/^"[a-f0-9]{32}"$/', $etag, 'ETag should be a quoted MD5 hash.');
 
-        unlink($testFile);
+        unlink($testFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -404,7 +404,7 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         $lastModified = $response->getHeaderLine('Last-Modified');
         self::assertStringContainsString('GMT', $lastModified);
 
-        unlink($testFile);
+        unlink($testFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // ──────────────────────────────────────────────────
@@ -494,7 +494,7 @@ class ProcessingMiddlewareRoutingTest extends TestCase
             if ($item->isDir()) {
                 @rmdir($item->getRealPath());
             } else {
-                @unlink($item->getRealPath());
+                @unlink($item->getRealPath()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Unit/Command/AnalyzeImagesCommandTest.php
+++ b/Tests/Unit/Command/AnalyzeImagesCommandTest.php
@@ -78,7 +78,7 @@ class AnalyzeImagesCommandTest extends TestCase
 
         foreach ($this->tempFiles as $path) {
             if (is_file($path)) {
-                @unlink($path);
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Unit/Command/OptimizeImagesCommandTest.php
+++ b/Tests/Unit/Command/OptimizeImagesCommandTest.php
@@ -85,7 +85,7 @@ class OptimizeImagesCommandTest extends TestCase
 
         foreach ($this->tempFiles as $path) {
             if (is_file($path)) {
-                @unlink($path);
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Unit/Controller/MaintenanceControllerTest.php
+++ b/Tests/Unit/Controller/MaintenanceControllerTest.php
@@ -87,7 +87,7 @@ class MaintenanceControllerTest extends TestCase
             if ($item->isDir()) {
                 rmdir($item->getPathname());
             } else {
-                unlink($item->getPathname());
+                unlink($item->getPathname()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Unit/EventListener/OptimizeOnUploadListenerTest.php
+++ b/Tests/Unit/EventListener/OptimizeOnUploadListenerTest.php
@@ -91,7 +91,7 @@ class OptimizeOnUploadListenerTest extends TestCase
 
         foreach ($this->tempFiles as $path) {
             if (is_file($path)) {
-                @unlink($path);
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -431,7 +431,7 @@ class ProcessorTest extends TestCase
         self::assertTrue($this->callMethod($this->processor, 'hasVariantFor', $base, 'webp'));
         self::assertFalse($this->callMethod($this->processor, 'hasVariantFor', $base, 'avif'));
 
-        unlink($webp);
+        unlink($webp); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -529,8 +529,8 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.avif');
-        unlink($base . '.webp');
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -551,7 +551,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.webp');
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -572,7 +572,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -606,7 +606,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -642,9 +642,9 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.avif');
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -828,7 +828,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -872,8 +872,8 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -895,7 +895,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -917,8 +917,8 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -1117,7 +1117,7 @@ class ProcessorTest extends TestCase
             if ($item->isDir()) {
                 rmdir($item->getPathname());
             } else {
-                unlink($item->getPathname());
+                unlink($item->getPathname()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
@@ -1330,7 +1330,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -1542,7 +1542,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.webp');
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -1563,7 +1563,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -1886,11 +1886,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -1961,11 +1961,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2036,11 +2036,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2106,11 +2106,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2183,11 +2183,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2251,11 +2251,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2367,8 +2367,8 @@ class ProcessorTest extends TestCase
         self::assertSame($response400, $result);
 
         // Cleanup
-        unlink($symlinkPath);
-        unlink($tempDir . '/outside/photo.jpg');
+        unlink($symlinkPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($tempDir . '/outside/photo.jpg'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/outside');
         rmdir($tempDir . '/public/processed');
         rmdir($tempDir . '/public');
@@ -2622,11 +2622,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2714,11 +2714,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -3150,11 +3150,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -3285,7 +3285,7 @@ class ProcessorTest extends TestCase
         self::assertInstanceOf(ResponseInterface::class, $result);
         self::assertSame($avifResponse, $result);
 
-        unlink($base . '.avif');
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3315,7 +3315,7 @@ class ProcessorTest extends TestCase
         self::assertInstanceOf(ResponseInterface::class, $result);
         self::assertSame($webpResponse, $result);
 
-        unlink($base . '.webp');
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3344,7 +3344,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($primaryResponse, $result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // =========================================================================
@@ -3440,11 +3440,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed/deep');
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
@@ -3530,7 +3530,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.avif');
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3562,7 +3562,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.webp');
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3583,7 +3583,7 @@ class ProcessorTest extends TestCase
 
         self::assertInstanceOf(ResponseInterface::class, $result);
 
-        unlink($base . '.avif');
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3604,7 +3604,7 @@ class ProcessorTest extends TestCase
 
         self::assertInstanceOf(ResponseInterface::class, $result);
 
-        unlink($base . '.webp');
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3638,8 +3638,8 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.avif');
-        unlink($base);
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3673,8 +3673,8 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3703,7 +3703,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame('image/jpeg', $capturedHeaders['Content-Type']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3730,7 +3730,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame('application/octet-stream', $capturedHeaders['Content-Type']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // =========================================================================
@@ -3761,7 +3761,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame('public, max-age=31536000, immutable', $capturedHeaders['Cache-Control']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3788,7 +3788,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame((string) filesize($base), $capturedHeaders['Content-Length']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3815,7 +3815,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame('image/webp', $capturedHeaders['Content-Type']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3847,7 +3847,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($expectedLastModified, $capturedHeaders['Last-Modified']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3887,7 +3887,7 @@ class ProcessorTest extends TestCase
         $inner = substr($capturedHeaders['ETag'], 1, -1);
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $inner);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -3921,7 +3921,7 @@ class ProcessorTest extends TestCase
         // Last-Modified must contain the date (not just ' GMT')
         self::assertNotSame(' GMT', $capturedHeaders['Last-Modified']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // =========================================================================
@@ -4210,8 +4210,8 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.avif');
-        unlink($base);
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -4245,8 +4245,8 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // =========================================================================
@@ -4286,7 +4286,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame('image/png', $capturedHeaders['Content-Type']);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // =========================================================================

--- a/Tests/Unit/Service/ImageManagerAdapterTest.php
+++ b/Tests/Unit/Service/ImageManagerAdapterTest.php
@@ -56,7 +56,7 @@ class ImageManagerAdapterTest extends TestCase
             self::assertSame(2, $image->width());
             self::assertSame(3, $image->height());
         } finally {
-            unlink($tmpFile);
+            unlink($tmpFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         }
     }
 

--- a/Tests/Unit/Service/ImageManagerFactoryTest.php
+++ b/Tests/Unit/Service/ImageManagerFactoryTest.php
@@ -48,7 +48,7 @@ class ImageManagerFactoryTest extends TestCase
             self::assertSame(1, $image->width());
             self::assertSame(1, $image->height());
         } finally {
-            unlink($tmpFile);
+            unlink($tmpFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         }
     }
 

--- a/Tests/Unit/Service/ImageOptimizerTest.php
+++ b/Tests/Unit/Service/ImageOptimizerTest.php
@@ -78,7 +78,7 @@ class ImageOptimizerTest extends TestCase
 
         foreach ($this->tempFiles as $path) {
             if (is_file($path)) {
-                @unlink($path);
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Unit/Service/SystemRequirementsServiceTest.php
+++ b/Tests/Unit/Service/SystemRequirementsServiceTest.php
@@ -83,7 +83,7 @@ class SystemRequirementsServiceTest extends TestCase
                     chmod($item->getPathname(), 0o644);
                 }
 
-                unlink($item->getPathname());
+                unlink($item->getPathname()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
@@ -466,7 +466,7 @@ class SystemRequirementsServiceTest extends TestCase
             self::assertSame('FakeCmd 1.2.3', $result['version']);
         } finally {
             putenv('PATH=' . $origPath);
-            unlink($script);
+            unlink($script); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             rmdir($binDir);
         }
     }
@@ -498,7 +498,7 @@ class SystemRequirementsServiceTest extends TestCase
             self::assertSame('FakeCmd 2.0.0', $result['version']);
         } finally {
             putenv('PATH=' . $origPath);
-            unlink($script);
+            unlink($script); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             rmdir($binDir);
         }
     }
@@ -525,7 +525,7 @@ class SystemRequirementsServiceTest extends TestCase
             self::assertNull($result['version']);
         } finally {
             putenv('PATH=' . $origPath);
-            unlink($script);
+            unlink($script); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             rmdir($binDir);
         }
     }
@@ -557,7 +557,7 @@ class SystemRequirementsServiceTest extends TestCase
             self::assertSame('Trimmed 3.0.0', $result['version']);
         } finally {
             putenv('PATH=' . $origPath);
-            unlink($script);
+            unlink($script); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             rmdir($binDir);
         }
     }
@@ -589,7 +589,7 @@ class SystemRequirementsServiceTest extends TestCase
             self::assertSame('Version 4.0', $result['version']);
         } finally {
             putenv('PATH=' . $origPath);
-            unlink($script);
+            unlink($script); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             rmdir($binDir);
         }
     }
@@ -625,7 +625,7 @@ class SystemRequirementsServiceTest extends TestCase
         self::assertSame('1.2.3', $result);
 
         // Cleanup
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -650,7 +650,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'test/package');
         self::assertSame('v1.0.0', $result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -673,7 +673,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'lock/package');
         self::assertSame('2.0.0', $result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -695,7 +695,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'dev/package');
         self::assertSame('3.0.0', $result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -723,8 +723,8 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'missing/package');
         self::assertNull($result);
 
-        unlink($vendorDir . '/installed.json');
-        unlink($projectPath . '/composer.lock');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -749,7 +749,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'flat/package');
         self::assertSame('4.0.0', $result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -866,7 +866,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromInstalledJson', 'any/package');
         self::assertNull($result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -884,7 +884,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromInstalledJson', 'any/package');
         self::assertNull($result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -915,7 +915,7 @@ class SystemRequirementsServiceTest extends TestCase
 
         // Restore permissions before cleanup
         chmod($file, 0o644);
-        unlink($file);
+        unlink($file); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
 
@@ -936,7 +936,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'any/package');
         self::assertNull($result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -949,7 +949,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'any/package');
         self::assertNull($result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -975,7 +975,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'any/package');
 
         chmod($file, 0o644);
-        unlink($file);
+        unlink($file); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
 
         self::assertNull($result);
     }
@@ -994,7 +994,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'missing/package');
         self::assertNull($result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -1326,7 +1326,7 @@ class SystemRequirementsServiceTest extends TestCase
         }
 
         // Cleanup
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -1363,7 +1363,7 @@ class SystemRequirementsServiceTest extends TestCase
         self::assertNull($result, 'Must return null when file is unreadable');
 
         chmod($file, 0o644);
-        unlink($file);
+        unlink($file); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -1381,7 +1381,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromInstalledJson', 'any/package');
         self::assertNull($result, 'Must return null when JSON data is not an array');
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -1413,7 +1413,7 @@ class SystemRequirementsServiceTest extends TestCase
         self::assertNull($result, 'Must return null when composer.lock is unreadable');
 
         chmod($file, 0o644);
-        unlink($file);
+        unlink($file); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -1425,7 +1425,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'any/package');
         self::assertNull($result, 'Must return null when JSON is not array');
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -1498,7 +1498,7 @@ class SystemRequirementsServiceTest extends TestCase
         // Should find a version (either from InstalledVersions or the file)
         self::assertNotNull($version, 'Should find version from InstalledVersions or installed.json fallback');
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -1528,7 +1528,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromInstalledJson', 'test/package');
         self::assertNull($result, 'Non-string version should return null');
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -1553,7 +1553,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'test/package');
         self::assertSame('2.0.0', $result, 'Should skip non-array packages key and find in packages-dev');
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -1635,7 +1635,7 @@ class SystemRequirementsServiceTest extends TestCase
             self::assertSame('StderrCmd 1.0.0', $result['version']);
         } finally {
             putenv('PATH=' . $origPath);
-            unlink($script);
+            unlink($script); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             rmdir($binDir);
         }
     }
@@ -1674,7 +1674,7 @@ class SystemRequirementsServiceTest extends TestCase
             self::assertSame('PathTrim 2.0.0', $result['version']);
         } finally {
             putenv('PATH=' . $origPath);
-            unlink($script);
+            unlink($script); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             rmdir($binDir);
         }
     }
@@ -1717,7 +1717,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromInstalledJson', 'test/pkg');
         self::assertSame('1.0.0', $result, 'Found package must return version string');
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -1755,7 +1755,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'test/pkg');
         self::assertSame('3.0.0', $result, 'Found package must return exact version string');
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------

--- a/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
@@ -400,7 +400,7 @@ class SourceSetViewHelperTest extends TestCase
 
         self::assertSame($expected, $result);
 
-        unlink($absolutePath);
+        unlink($absolutePath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         @rmdir($directory);
     }
 
@@ -1553,7 +1553,7 @@ class SourceSetViewHelperTest extends TestCase
         // Must contain w2h1 (width=2, height=1), not w1h1 or w2h2
         self::assertStringContainsString('w2h1', $result);
 
-        unlink($absolutePath);
+        unlink($absolutePath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         @rmdir($directory);
     }
 
@@ -1806,7 +1806,7 @@ class SourceSetViewHelperTest extends TestCase
         self::assertStringContainsString('w100h0', $result);
         self::assertStringNotContainsString('w2h1', $result);
 
-        unlink($absolutePath);
+        unlink($absolutePath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         @rmdir($directory);
     }
 
@@ -1847,7 +1847,7 @@ class SourceSetViewHelperTest extends TestCase
         self::assertStringContainsString('w0h100', $result);
         self::assertStringNotContainsString('w2h1', $result);
 
-        unlink($absolutePath);
+        unlink($absolutePath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         @rmdir($directory);
     }
 


### PR DESCRIPTION
## Summary

Restores green CI after the shared security workflow enabled Opengrep SAST in blocking mode on 2026-04-18 ([typo3-ci-workflows#51](https://github.com/netresearch/typo3-ci-workflows/pull/51), [#53](https://github.com/netresearch/typo3-ci-workflows/pull/53)). The \`php.lang.security.unlink-use.unlink-use\` rule flags all 122 \`unlink()\` call sites across the codebase as WARNING+ findings, so the Monday cron run on 2026-04-20 failed.

All 122 sites are legitimate and now carry inline rule-specific \`// nosemgrep\` pragmas with short justifications.

## Triage breakdown

| Category | Count | Justification |
|---|---:|---|
| Production — \`Classes/Service/ImageOptimizer.php\` | 3 | \`@unlink()\` in \`finally\` blocks deletes the temporary local copy produced by \`\$file->getForLocalProcessing(true)\`. Path comes from TYPO3 FAL, not user input. |
| Tests — teardown of self-created fixtures | 119 | Clean up fixture files the test itself just created in a temp directory. Not security-sensitive. |

The rule stays enforced for any new \`unlink()\` of untrusted input.

## Verification

\`\`\`
opengrep scan --config auto --error --severity WARNING .
# Total findings: 0
\`\`\`

## Test plan

- [x] PHP syntax check passes on all modified files
- [x] Local Opengrep scan reports 0 findings
- [ ] CI turns green on this PR