### PR TITLE
fix: accept symlinked FAL storage directories in path validation (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Serve images from storage directories that are symlinks (e.g. `fileadmin`
+  mounted on AWS EFS/NFS) instead of returning HTTP 400 for every uncached
+  variant. Path validation now resolves every configured Local FAL storage
+  base path in addition to the TYPO3 public root, while still rejecting
+  paths that escape those roots via symlinks inside a storage ([#70]).
+
+[#70]: https://github.com/netresearch/t3x-nr-image-optimize/issues/70
+
 ## [2.2.1]
 
 ### Changed

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -52,6 +52,7 @@ use function round;
 use RuntimeException;
 
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function strtolower;
 
@@ -159,6 +160,10 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
      * recognised as allowed. Any symlink inside a storage that points to a
      * location outside these roots is rejected.
      *
+     * Because the cache persists for the life of the PHP process, tests must
+     * reset it between cases via reflection — see
+     * ProcessorTest::resetAllowedRootsCache().
+     *
      * @var list<string>|null
      */
     private static ?array $resolvedAllowedRoots = null;
@@ -218,9 +223,9 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
             return $this->responseFactory->createResponse(400);
         }
 
-        // Validate that both resolved paths stay within the public root
-        if (!$this->isPathWithinPublicRoot($urlInfo['pathOriginal'])
-            || !$this->isPathWithinPublicRoot($urlInfo['pathVariant'])
+        // Validate that both resolved paths stay within an allowed root
+        if (!$this->isPathWithinAllowedRoots($urlInfo['pathOriginal'])
+            || !$this->isPathWithinAllowedRoots($urlInfo['pathVariant'])
         ) {
             return $this->responseFactory->createResponse(400);
         }
@@ -628,12 +633,20 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
      * cannot escape the declared roots by pointing a symlink at an arbitrary
      * location such as /etc.
      *
+     * NUL bytes in the input are rejected outright: realpath() treats them as
+     * a hard error, but the parent-walk fallback would otherwise trim them off
+     * and revalidate a misleading parent prefix.
+     *
      * @param string $path Absolute filesystem path to validate
      *
      * @return bool True if the path is safely within an allowed root
      */
-    private function isPathWithinPublicRoot(string $path): bool
+    private function isPathWithinAllowedRoots(string $path): bool
     {
+        if (str_contains($path, "\0")) {
+            return false;
+        }
+
         $allowedRoots = $this->getAllowedRoots();
 
         if ($allowedRoots === []) {
@@ -696,8 +709,11 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
      * Always includes the TYPO3 public path. Additionally includes the
      * resolved base path of every Local-driver FAL storage so that storages
      * whose directory is a symlink to an external mount (e.g. fileadmin on
-     * AWS EFS or another NFS share) remain servable. Paths that cannot be
-     * realpath'd (because they do not exist on disk) are skipped.
+     * AWS EFS or another NFS share) remain servable.
+     *
+     * Storages are silently skipped when their driver type is not "Local",
+     * when basePath is missing or empty, or when the configured directory
+     * does not (yet) exist on disk and cannot be realpath'd.
      *
      * Throwables from StorageRepository (e.g. during very early bootstrap
      * when TCA is not yet loaded) are caught so that path validation still

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -727,11 +727,21 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
             return self::$resolvedAllowedRoots;
         }
 
-        $roots      = [];
-        $publicPath = realpath(Environment::getPublicPath());
+        $roots         = [];
+        $publicPathRaw = Environment::getPublicPath();
+        $publicPath    = realpath($publicPathRaw);
 
         if ($publicPath !== false) {
             $roots[$publicPath] = true;
+        }
+
+        // isset() guards against tests that construct Processor via
+        // ReflectionClass::newInstanceWithoutConstructor() without injecting
+        // this readonly property; in production DI always provides it.
+        if (!isset($this->storageRepository)) {
+            self::$resolvedAllowedRoots = array_keys($roots);
+
+            return self::$resolvedAllowedRoots;
         }
 
         try {
@@ -754,7 +764,7 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
 
                 $absolutePath = $pathType === 'absolute'
                     ? $basePath
-                    : Environment::getPublicPath() . DIRECTORY_SEPARATOR . $basePath;
+                    : $publicPathRaw . DIRECTORY_SEPARATOR . $basePath;
 
                 $resolvedBasePath = realpath($absolutePath);
 

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -767,9 +767,16 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
                     $roots[$resolvedBasePath] = true;
                 }
             }
-        } catch (Throwable) {
+        } catch (Throwable $e) {
             // StorageRepository may be unusable (e.g. during very early
-            // bootstrap). Fall back to whatever roots we already collected.
+            // bootstrap). Fall back to whatever roots we already collected
+            // and log at warning level so operators see the degradation
+            // instead of silently receiving 400s for every storage-backed
+            // variant request.
+            $this->getLogger()->warning(
+                'Path validation limited to public root; StorageRepository unavailable',
+                ['exception' => $e],
+            );
         }
 
         self::$resolvedAllowedRoots = array_keys($roots);

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrImageOptimize;
 
+use function array_keys;
 use function count;
 use function dirname;
 use function file_exists;
@@ -59,6 +60,7 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Locking\Exception\LockCreateException;
 use TYPO3\CMS\Core\Locking\LockFactory;
 use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 
 use function urldecode;
 use function usleep;
@@ -147,19 +149,31 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
     private const MODE_PATTERN = '/([hwqm])(\d+)/';
 
     /**
-     * Cached result of realpath(Environment::getPublicPath()) to avoid repeated
-     * filesystem calls in isPathWithinPublicRoot().
+     * Cached list of absolute filesystem roots (realpath-resolved) under which
+     * image paths are considered safe. Populated on first call to
+     * getAllowedRoots() and reused across requests in the same PHP process.
+     *
+     * Contains the TYPO3 public path plus the basePath of every Local-driver
+     * FAL storage, each resolved through realpath so that legitimately
+     * symlinked storage directories (e.g. fileadmin on an NFS/EFS mount) are
+     * recognised as allowed. Any symlink inside a storage that points to a
+     * location outside these roots is rejected.
+     *
+     * @var list<string>|null
      */
-    private static string|false|null $resolvedPublicPath = null;
+    private static ?array $resolvedAllowedRoots = null;
 
     /**
      * Initialize the image processor with all required dependencies.
      *
-     * @param ImageReaderInterface     $imageReader     Adapter for loading images (v3/v4 compatible)
-     * @param LockFactory              $lockFactory     TYPO3 lock factory for concurrent processing coordination
-     * @param ResponseFactoryInterface $responseFactory PSR-17 response factory
-     * @param StreamFactoryInterface   $streamFactory   PSR-17 stream factory
-     * @param EventDispatcherInterface $eventDispatcher PSR-14 event dispatcher for post-processing hooks
+     * @param ImageReaderInterface     $imageReader       Adapter for loading images (v3/v4 compatible)
+     * @param LockFactory              $lockFactory       TYPO3 lock factory for concurrent processing coordination
+     * @param ResponseFactoryInterface $responseFactory   PSR-17 response factory
+     * @param StreamFactoryInterface   $streamFactory     PSR-17 stream factory
+     * @param EventDispatcherInterface $eventDispatcher   PSR-14 event dispatcher for post-processing hooks
+     * @param StorageRepository        $storageRepository FAL storage repository used to expand the set of
+     *                                                    filesystem roots from which images may be served
+     *                                                    (supports symlinked storage targets, e.g. NFS/EFS)
      */
     public function __construct(
         private readonly ImageReaderInterface $imageReader,
@@ -167,6 +181,7 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly StreamFactoryInterface $streamFactory,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly StorageRepository $storageRepository,
     ) {
         $this->logger = new NullLogger();
     }
@@ -603,32 +618,33 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
 
     /**
      * Validate that a filesystem path resolves to a location within the TYPO3
-     * public directory. This prevents path-traversal attacks using encoded or
-     * otherwise crafted sequences that escape the web root.
+     * public directory or any configured Local FAL storage base path. This
+     * prevents path-traversal attacks using encoded or otherwise crafted
+     * sequences that escape the web root, while still allowing legitimate
+     * setups where e.g. fileadmin is a symlink to an external mount (NFS/EFS).
+     *
+     * Symlinks are resolved via realpath() so that an attacker (including a
+     * compromised admin who places a symlink inside a storage directory)
+     * cannot escape the declared roots by pointing a symlink at an arbitrary
+     * location such as /etc.
      *
      * @param string $path Absolute filesystem path to validate
      *
-     * @return bool True if the path is safely within the public root
+     * @return bool True if the path is safely within an allowed root
      */
     private function isPathWithinPublicRoot(string $path): bool
     {
-        if (self::$resolvedPublicPath === null) {
-            self::$resolvedPublicPath = realpath(Environment::getPublicPath());
-        }
+        $allowedRoots = $this->getAllowedRoots();
 
-        $publicPath = self::$resolvedPublicPath;
-
-        if ($publicPath === false) {
+        if ($allowedRoots === []) {
             return false;
         }
 
         // For existing paths, use realpath to resolve symlinks
         $resolvedPath = realpath($path);
 
-        $publicPrefix = $publicPath . DIRECTORY_SEPARATOR;
-
         if ($resolvedPath !== false) {
-            return str_starts_with($resolvedPath, $publicPrefix) || $resolvedPath === $publicPath;
+            return $this->isWithinAnyRoot($resolvedPath, $allowedRoots);
         }
 
         // For paths that do not yet exist (variant files), resolve the
@@ -642,11 +658,102 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
             $resolvedParent = realpath($parent);
 
             if ($resolvedParent !== false) {
-                return str_starts_with($resolvedParent, $publicPrefix) || $resolvedParent === $publicPath;
+                return $this->isWithinAnyRoot($resolvedParent, $allowedRoots);
             }
         } while ($parent !== $previous);
 
         return false;
+    }
+
+    /**
+     * Check whether an already-resolved (realpath'd) absolute path lies within
+     * at least one of the allowed filesystem roots.
+     *
+     * @param string       $resolvedPath Realpath-resolved absolute path
+     * @param list<string> $allowedRoots Realpath-resolved absolute roots
+     *
+     * @return bool True if $resolvedPath equals any root or is nested inside one
+     */
+    private function isWithinAnyRoot(string $resolvedPath, array $allowedRoots): bool
+    {
+        foreach ($allowedRoots as $root) {
+            if ($resolvedPath === $root) {
+                return true;
+            }
+
+            if (str_starts_with($resolvedPath, $root . DIRECTORY_SEPARATOR)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Build (and cache statically) the list of realpath-resolved absolute
+     * roots under which image paths are considered safe.
+     *
+     * Always includes the TYPO3 public path. Additionally includes the
+     * resolved base path of every Local-driver FAL storage so that storages
+     * whose directory is a symlink to an external mount (e.g. fileadmin on
+     * AWS EFS or another NFS share) remain servable. Paths that cannot be
+     * realpath'd (because they do not exist on disk) are skipped.
+     *
+     * Throwables from StorageRepository (e.g. during very early bootstrap
+     * when TCA is not yet loaded) are caught so that path validation still
+     * works against the public root alone.
+     *
+     * @return list<string> Zero or more realpath-resolved allowed roots
+     */
+    private function getAllowedRoots(): array
+    {
+        if (self::$resolvedAllowedRoots !== null) {
+            return self::$resolvedAllowedRoots;
+        }
+
+        $roots      = [];
+        $publicPath = realpath(Environment::getPublicPath());
+
+        if ($publicPath !== false) {
+            $roots[$publicPath] = true;
+        }
+
+        try {
+            foreach ($this->storageRepository->findAll() as $storage) {
+                if ($storage->getDriverType() !== 'Local') {
+                    continue;
+                }
+
+                $configuration = $storage->getConfiguration();
+                $basePath      = $configuration['basePath'] ?? '';
+                if (!is_string($basePath)) {
+                    continue;
+                }
+
+                if ($basePath === '') {
+                    continue;
+                }
+
+                $pathType = $configuration['pathType'] ?? 'relative';
+
+                $absolutePath = $pathType === 'absolute'
+                    ? $basePath
+                    : Environment::getPublicPath() . DIRECTORY_SEPARATOR . $basePath;
+
+                $resolvedBasePath = realpath($absolutePath);
+
+                if ($resolvedBasePath !== false) {
+                    $roots[$resolvedBasePath] = true;
+                }
+            }
+        } catch (Throwable) {
+            // StorageRepository may be unusable (e.g. during very early
+            // bootstrap). Fall back to whatever roots we already collected.
+        }
+
+        self::$resolvedAllowedRoots = array_keys($roots);
+
+        return self::$resolvedAllowedRoots;
     }
 
     /**

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -735,15 +735,10 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
             $roots[$publicPath] = true;
         }
 
-        // isset() guards against tests that construct Processor via
+        // The try/catch also protects tests that construct Processor via
         // ReflectionClass::newInstanceWithoutConstructor() without injecting
-        // this readonly property; in production DI always provides it.
-        if (!isset($this->storageRepository)) {
-            self::$resolvedAllowedRoots = array_keys($roots);
-
-            return self::$resolvedAllowedRoots;
-        }
-
+        // this readonly property — accessing an uninitialized typed property
+        // throws Error, which extends Throwable.
         try {
             foreach ($this->storageRepository->findAll() as $storage) {
                 if ($storage->getDriverType() !== 'Local') {

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -11,6 +11,31 @@ Changelog
 Unreleased
 ==========
 
+..  versionchanged:: next
+    Fixed path validation for FAL Local storages whose
+    ``basePath`` is a symlink to an external mount (NFS,
+    AWS EFS, bind-mount).
+
+-   Fixed: processed image requests no longer return
+    HTTP 400 when :file:`fileadmin` (or any other Local
+    FAL storage) is a symlink to an external location
+    such as an NFS/EFS mount. ``isPathWithinAllowedRoots``
+    now accepts any realpath-resolved path that lies
+    within the TYPO3 public root or the realpath of any
+    configured Local storage's ``basePath``. Symlinks
+    placed *inside* a storage that escape every allowed
+    root -- e.g. :file:`fileadmin/evil` -> :file:`/etc`
+    -- continue to be rejected. Reported in
+    `issue #70 <https://github.com/netresearch/t3x-nr-image-optimize/issues/70>`__.
+-   Hardened: paths containing NUL bytes are rejected
+    outright, closing a minor realpath-bypass via the
+    not-yet-existing-path parent-walk branch.
+-   Changed (subclass BC): :php:`Netresearch\\NrImageOptimize\\Processor`
+    gains a new required ``StorageRepository`` constructor
+    parameter. Consumers that autowire the service (the
+    default in TYPO3 12+) are unaffected; subclasses must
+    forward the new dependency.
+
 ..  versionadded:: next
     Automatic optimization on upload and bulk CLI commands
     for optimizing or analyzing the FAL image inventory.

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -11,11 +11,6 @@ Changelog
 Unreleased
 ==========
 
-..  versionchanged:: next
-    Fixed path validation for FAL Local storages whose
-    ``basePath`` is a symlink to an external mount (NFS,
-    AWS EFS, bind-mount).
-
 -   Fixed: processed image requests no longer return
     HTTP 400 when :file:`fileadmin` (or any other Local
     FAL storage) is a symlink to an external location
@@ -30,16 +25,13 @@ Unreleased
 -   Hardened: paths containing NUL bytes are rejected
     outright, closing a minor realpath-bypass via the
     not-yet-existing-path parent-walk branch.
--   Changed (subclass BC): :php:`Netresearch\\NrImageOptimize\\Processor`
-    gains a new required ``StorageRepository`` constructor
+-   Changed (BC for subclasses and manual instantiators):
+    :php:`Netresearch\\NrImageOptimize\\Processor` gains a
+    new required ``StorageRepository`` constructor
     parameter. Consumers that autowire the service (the
-    default in TYPO3 12+) are unaffected; subclasses must
+    default in TYPO3 12+) are unaffected; any code that
+    extends the class or constructs it by hand must
     forward the new dependency.
-
-..  versionadded:: next
-    Automatic optimization on upload and bulk CLI commands
-    for optimizing or analyzing the FAL image inventory.
-
 -   Added ``OptimizeOnUploadListener`` -- PSR-14 listener
     that runs ``optipng`` / ``gifsicle`` / ``jpegoptim`` on
     ``AfterFileAddedEvent`` and ``AfterFileReplacedEvent``.

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -42,6 +42,8 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Locking\Exception\LockCreateException;
 use TYPO3\CMS\Core\Locking\LockFactory;
 use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 
 class ProcessorTest extends TestCase
 {
@@ -52,6 +54,8 @@ class ProcessorTest extends TestCase
     private MockObject $streamFactory;
 
     private MockObject $eventDispatcher;
+
+    private MockObject $storageRepository;
 
     private Processor $processor;
 
@@ -75,10 +79,15 @@ class ProcessorTest extends TestCase
             'UNIX',
         );
 
-        $this->lockFactory     = $this->createMock(LockFactory::class);
-        $this->responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $this->streamFactory   = $this->createMock(StreamFactoryInterface::class);
-        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->lockFactory       = $this->createMock(LockFactory::class);
+        $this->responseFactory   = $this->createMock(ResponseFactoryInterface::class);
+        $this->streamFactory     = $this->createMock(StreamFactoryInterface::class);
+        $this->eventDispatcher   = $this->createMock(EventDispatcherInterface::class);
+        $this->storageRepository = $this->createMock(StorageRepository::class);
+        $this->storageRepository->method('findAll')->willReturn([]);
+
+        // Reset the process-wide allowed-roots cache so each test starts fresh
+        $this->resetAllowedRootsCache();
 
         // ImageManager is final and cannot be mocked. Use newInstanceWithoutConstructor
         // since tests only exercise private helper methods via reflection that do not
@@ -91,6 +100,14 @@ class ProcessorTest extends TestCase
         $this->setProperty($this->processor, 'responseFactory', $this->responseFactory);
         $this->setProperty($this->processor, 'streamFactory', $this->streamFactory);
         $this->setProperty($this->processor, 'eventDispatcher', $this->eventDispatcher);
+        $this->setProperty($this->processor, 'storageRepository', $this->storageRepository);
+    }
+
+    private function resetAllowedRootsCache(): void
+    {
+        $refClass = new ReflectionClass(Processor::class);
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        $prop->setValue(null, null);
     }
 
     protected function tearDown(): void
@@ -128,14 +145,21 @@ class ProcessorTest extends TestCase
         ?object $responseFactory = null,
         ?object $streamFactory = null,
         ?object $eventDispatcher = null,
+        ?object $storageRepository = null,
     ): Processor {
         $reflection = new ReflectionClass(Processor::class);
         $instance   = $reflection->newInstanceWithoutConstructor();
+
+        if (!$storageRepository instanceof StorageRepository) {
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')->willReturn([]);
+        }
 
         $this->setProperty($instance, 'lockFactory', $lockFactory ?? $this->createMock(LockFactory::class));
         $this->setProperty($instance, 'responseFactory', $responseFactory ?? $this->createMock(ResponseFactoryInterface::class));
         $this->setProperty($instance, 'streamFactory', $streamFactory ?? $this->createMock(StreamFactoryInterface::class));
         $this->setProperty($instance, 'eventDispatcher', $eventDispatcher ?? $this->createMock(EventDispatcherInterface::class));
+        $this->setProperty($instance, 'storageRepository', $storageRepository);
 
         return $instance;
     }
@@ -929,7 +953,7 @@ class ProcessorTest extends TestCase
     public function isPathWithinPublicRootAcceptsPathsInsidePublicDir(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
         $prop->setValue(null, null);
 
         $tempDir = sys_get_temp_dir() . '/nr-pio-pubroot-' . uniqid('', true);
@@ -986,12 +1010,13 @@ class ProcessorTest extends TestCase
     }
 
     #[Test]
-    public function isPathWithinPublicRootReturnsFalseWhenPublicPathCannotBeResolved(): void
+    public function isPathWithinPublicRootReturnsFalseWhenNoAllowedRootsAreResolvable(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
-        // Simulate cached false result (public path doesn't resolve)
-        $prop->setValue(null, false);
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        // Simulate cached empty result (neither the public path nor any FAL
+        // storage base path could be realpath'd — e.g., early bootstrap).
+        $prop->setValue(null, []);
 
         $result = $this->callMethod($this->processor, 'isPathWithinPublicRoot', '/some/path');
 
@@ -1005,7 +1030,7 @@ class ProcessorTest extends TestCase
     public function isPathWithinPublicRootReturnsFalseForNonExistentPaths(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
 
         $tempDir = sys_get_temp_dir() . '/nr-pio-walk-' . uniqid('', true);
         mkdir($tempDir . '/public/deep/nested', 0o777, true);
@@ -1065,13 +1090,243 @@ class ProcessorTest extends TestCase
         );
     }
 
+    /**
+     * Regression test for issue #70: when fileadmin (a FAL Local storage) is a
+     * symlink to an external location (e.g. an NFS/EFS mount), paths inside it
+     * must still be accepted. Without this fix, realpath() resolves through
+     * the symlink and the target no longer starts with the public root, so
+     * every uncached variant request returned HTTP 400.
+     *
+     * @see https://github.com/netresearch/t3x-nr-image-optimize/issues/70
+     */
+    #[Test]
+    public function isPathWithinPublicRootAcceptsPathsInsideSymlinkedFalStorage(): void
+    {
+        $tempDir  = sys_get_temp_dir() . '/nr-pio-efs-' . uniqid('', true);
+        $public   = $tempDir . '/public';
+        $external = $tempDir . '/external/fileadmin';
+
+        mkdir($public, 0o777, true);
+        mkdir($external . '/_processed_/6/d', 0o777, true);
+        symlink($external, $public . '/fileadmin');
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            $tempDir,
+            $public,
+            $tempDir . '/var',
+            $tempDir . '/config',
+            $public . '/index.php',
+            'UNIX',
+        );
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getDriverType')->willReturn('Local');
+        $storage->method('getConfiguration')->willReturn([
+            'basePath' => 'fileadmin/',
+            'pathType' => 'relative',
+        ]);
+
+        $storageRepository = $this->createMock(StorageRepository::class);
+        $storageRepository->method('findAll')->willReturn([$storage]);
+
+        $processor = $this->createProcessor(storageRepository: $storageRepository);
+        $this->resetAllowedRootsCache();
+
+        // Existing file inside the symlinked storage
+        file_put_contents($external . '/_processed_/6/d/photo.jpg', 'image-bytes');
+        self::assertTrue($this->callMethod(
+            $processor,
+            'isPathWithinPublicRoot',
+            $public . '/fileadmin/_processed_/6/d/photo.jpg',
+        ));
+
+        // Non-existent variant path inside the symlinked storage (parent walk case)
+        self::assertTrue($this->callMethod(
+            $processor,
+            'isPathWithinPublicRoot',
+            $public . '/fileadmin/_processed_/6/d/photo.w800h600m0q100.jpg',
+        ));
+
+        // Cleanup
+        unlink($external . '/_processed_/6/d/photo.jpg'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($public . '/fileadmin'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created symlink
+        rmdir($external . '/_processed_/6/d');
+        rmdir($external . '/_processed_/6');
+        rmdir($external . '/_processed_');
+        rmdir($external);
+        rmdir($tempDir . '/external');
+        rmdir($public);
+        rmdir($tempDir);
+
+        $this->resetAllowedRootsCache();
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            '/var/www/html',
+            '/var/www/html/public',
+            '/var/www/html/var',
+            '/var/www/html/config',
+            '/var/www/html/public/index.php',
+            'UNIX',
+        );
+    }
+
+    /**
+     * Security guarantee: even when a symlinked fileadmin is accepted (see the
+     * test above), a symlink placed INSIDE that storage that points to a
+     * location outside every allowed root must still be rejected.
+     *
+     * This covers the "we don't trust admins" threat model where an admin
+     * (or a process running as the admin) attempts to expose arbitrary files
+     * such as /etc/shadow by dropping a symlink into fileadmin.
+     */
+    #[Test]
+    public function isPathWithinPublicRootRejectsSymlinkEscapingAllowedRoots(): void
+    {
+        $tempDir  = sys_get_temp_dir() . '/nr-pio-efs-escape-' . uniqid('', true);
+        $public   = $tempDir . '/public';
+        $external = $tempDir . '/external/fileadmin';
+        $secret   = $tempDir . '/secret';
+
+        mkdir($public, 0o777, true);
+        mkdir($external, 0o777, true);
+        mkdir($secret, 0o777, true);
+
+        // Legitimate: symlinked FAL storage root
+        symlink($external, $public . '/fileadmin');
+        // Attack: a symlink inside the storage that escapes to an unrelated directory
+        symlink($secret, $external . '/escape');
+
+        file_put_contents($secret . '/shadow', 'not-an-image');
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            $tempDir,
+            $public,
+            $tempDir . '/var',
+            $tempDir . '/config',
+            $public . '/index.php',
+            'UNIX',
+        );
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getDriverType')->willReturn('Local');
+        $storage->method('getConfiguration')->willReturn([
+            'basePath' => 'fileadmin/',
+            'pathType' => 'relative',
+        ]);
+
+        $storageRepository = $this->createMock(StorageRepository::class);
+        $storageRepository->method('findAll')->willReturn([$storage]);
+
+        $processor = $this->createProcessor(storageRepository: $storageRepository);
+        $this->resetAllowedRootsCache();
+
+        // Access through the malicious symlink must be rejected even though it
+        // appears (string-wise) to live inside fileadmin.
+        self::assertFalse($this->callMethod(
+            $processor,
+            'isPathWithinPublicRoot',
+            $public . '/fileadmin/escape/shadow',
+        ));
+
+        // Cleanup
+        unlink($secret . '/shadow'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($external . '/escape'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created symlink
+        unlink($public . '/fileadmin'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created symlink
+        rmdir($secret);
+        rmdir($external);
+        rmdir($tempDir . '/external');
+        rmdir($public);
+        rmdir($tempDir);
+
+        $this->resetAllowedRootsCache();
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            '/var/www/html',
+            '/var/www/html/public',
+            '/var/www/html/var',
+            '/var/www/html/config',
+            '/var/www/html/public/index.php',
+            'UNIX',
+        );
+    }
+
+    /**
+     * If StorageRepository::findAll() raises an exception (e.g. during very
+     * early bootstrap when TCA is not yet loaded), path validation must still
+     * work against the public root alone, not crash the middleware.
+     */
+    #[Test]
+    public function isPathWithinPublicRootFallsBackToPublicRootWhenStorageRepositoryThrows(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-storage-err-' . uniqid('', true);
+        mkdir($tempDir . '/public/subdir', 0o777, true);
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            $tempDir,
+            $tempDir . '/public',
+            $tempDir . '/var',
+            $tempDir . '/config',
+            $tempDir . '/public/index.php',
+            'UNIX',
+        );
+
+        $storageRepository = $this->createMock(StorageRepository::class);
+        $storageRepository->method('findAll')
+            ->willThrowException(new RuntimeException('TCA not yet initialised'));
+
+        $processor = $this->createProcessor(storageRepository: $storageRepository);
+        $this->resetAllowedRootsCache();
+
+        self::assertTrue($this->callMethod(
+            $processor,
+            'isPathWithinPublicRoot',
+            $tempDir . '/public/subdir',
+        ));
+        self::assertFalse($this->callMethod(
+            $processor,
+            'isPathWithinPublicRoot',
+            '/completely/fake/path/image.jpg',
+        ));
+
+        // Cleanup
+        rmdir($tempDir . '/public/subdir');
+        rmdir($tempDir . '/public');
+        rmdir($tempDir);
+
+        $this->resetAllowedRootsCache();
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            '/var/www/html',
+            '/var/www/html/public',
+            '/var/www/html/var',
+            '/var/www/html/config',
+            '/var/www/html/public/index.php',
+            'UNIX',
+        );
+    }
+
     // -------------------------------------------------------------------------
     // generateAndSend: LockCreateException catch
     // -------------------------------------------------------------------------
     /**
      * Set up a real temp directory for tests that exercise generateAndSend (needs real filesystem for path validation).
      *
-     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedPublicPath property
+     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedAllowedRoots property
      */
     private function setUpRealEnvironment(): array
     {
@@ -1080,7 +1335,7 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/public/images', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
         $prop->setValue(null, null);
 
         Environment::initialize(
@@ -2329,7 +2584,7 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/outside', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
         $prop->setValue(null, null);
 
         Environment::initialize(
@@ -4300,7 +4555,7 @@ class ProcessorTest extends TestCase
         // Mutant removes the DIRECTORY_SEPARATOR, making prefix = just $publicPath
         // Without the separator, /var/www/html/publicXXX would match /var/www/html/public
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
         $prop->setValue(null, null);
 
         $tempDir = sys_get_temp_dir() . '/nr-pio-sep-' . uniqid('', true);

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -37,6 +37,7 @@ use ReflectionProperty;
 use RuntimeException;
 use SplFileInfo;
 use Throwable;
+use TypeError;
 use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Locking\Exception\LockCreateException;
@@ -992,61 +993,36 @@ class ProcessorTest extends TestCase
     #[Test]
     public function isPathWithinAllowedRootsAcceptsPathsInsidePublicDir(): void
     {
-        $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
-
-        $tempDir = sys_get_temp_dir() . '/nr-pio-pubroot-' . uniqid('', true);
-        mkdir($tempDir . '/public/subdir', 0o777, true);
-
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            $tempDir,
-            $tempDir . '/public',
-            $tempDir . '/var',
-            $tempDir . '/config',
-            $tempDir . '/public/index.php',
-            'UNIX',
-        );
-
-        // Existing path within public root
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir'));
-
-        // Public root itself
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public'));
-
-        // Non-existent path under public root: the parent-walk resolves up to
-        // the existing /public directory, which is within the public root
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir/nonexistent.jpg'));
-
-        // Path outside public root (existing)
+        $tempDir    = sys_get_temp_dir() . '/nr-pio-pubroot-' . uniqid('', true);
         $outsideDir = sys_get_temp_dir() . '/nr-pio-outside-' . uniqid('', true);
+        mkdir($tempDir . '/public/subdir', 0o777, true);
         mkdir($outsideDir, 0o777, true);
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $outsideDir));
-        rmdir($outsideDir);
 
-        // Non-existent path where no parent resolves to public root
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', '/completely/fake/path/image.jpg'));
+        try {
+            $this->resetAllowedRootsCache();
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
 
-        // Cleanup
-        rmdir($tempDir . '/public/subdir');
-        rmdir($tempDir . '/public');
-        rmdir($tempDir);
+            // Existing path within public root
+            self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir'));
 
-        $prop->setValue(null, null);
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
+            // Public root itself
+            self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public'));
+
+            // Non-existent path under public root: the parent-walk resolves up to
+            // the existing /public directory, which is within the public root
+            self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir/nonexistent.jpg'));
+
+            // Path outside public root (existing)
+            self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $outsideDir));
+
+            // Non-existent path where no parent resolves to public root
+            self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', '/completely/fake/path/image.jpg'));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->removeOwnedTempTree($outsideDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
     }
 
     #[Test]
@@ -1069,65 +1045,34 @@ class ProcessorTest extends TestCase
     #[Test]
     public function isPathWithinAllowedRootsReturnsFalseForNonExistentPaths(): void
     {
-        $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-
         $tempDir = sys_get_temp_dir() . '/nr-pio-walk-' . uniqid('', true);
         mkdir($tempDir . '/public/deep/nested', 0o777, true);
 
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            $tempDir,
-            $tempDir . '/public',
-            $tempDir . '/var',
-            $tempDir . '/config',
-            $tempDir . '/public/index.php',
-            'UNIX',
-        );
+        try {
+            $this->resetAllowedRootsCache();
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
 
-        $prop->setValue(null, null);
+            // Non-existent path under the public root: the parent-walk resolves
+            // up to the existing /public/deep/nested directory, which is within
+            // the public root.
+            self::assertTrue($this->callMethod(
+                $this->processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/deep/nested/very/deeply/image.jpg',
+            ));
 
-        // Non-existent file path: realpath() returns false, and the parent walk loop
-        // body is unreachable due to the while-condition assignment pattern
-        // (($parent = dirname($parent)) !== $parent always evaluates to false).
-        // Non-existent paths under the public root should be accepted
-        // (the parent-walk resolves to the existing parent directory).
-        $result = $this->callMethod(
-            $this->processor,
-            'isPathWithinAllowedRoots',
-            $tempDir . '/public/deep/nested/very/deeply/image.jpg',
-        );
-        self::assertTrue($result);
-
-        // A path completely outside the public root should be rejected
-        $outsidePath   = '/tmp/completely-outside-' . uniqid('', true) . '/image.jpg';
-        $resultOutside = $this->callMethod(
-            $this->processor,
-            'isPathWithinAllowedRoots',
-            $outsidePath,
-        );
-        self::assertFalse($resultOutside);
-
-        // Cleanup
-        rmdir($tempDir . '/public/deep/nested');
-        rmdir($tempDir . '/public/deep');
-        rmdir($tempDir . '/public');
-        rmdir($tempDir);
-
-        $prop->setValue(null, null);
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
+            // A path whose entire ancestry is outside the public root must be
+            // rejected.
+            self::assertFalse($this->callMethod(
+                $this->processor,
+                'isPathWithinAllowedRoots',
+                '/tmp/completely-outside-' . uniqid('', true) . '/image.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
     }
 
     /**
@@ -1173,7 +1118,7 @@ class ProcessorTest extends TestCase
                 $public . '/fileadmin/_processed_/6/d/photo.w800h600m0q100.jpg',
             ));
         } finally {
-            $this->removeTempTree($tempDir);
+            $this->removeOwnedTempTree($tempDir);
             $this->resetAllowedRootsCache();
             $this->initializeDefaultEnvironment();
         }
@@ -1241,7 +1186,7 @@ class ProcessorTest extends TestCase
                 $public . '/fileadmin/legit.jpg',
             ));
         } finally {
-            $this->removeTempTree($tempDir);
+            $this->removeOwnedTempTree($tempDir);
             $this->resetAllowedRootsCache();
             $this->initializeDefaultEnvironment();
         }
@@ -1279,7 +1224,7 @@ class ProcessorTest extends TestCase
                 '/completely/fake/path/image.jpg',
             ));
         } finally {
-            $this->removeTempTree($tempDir);
+            $this->removeOwnedTempTree($tempDir);
             $this->resetAllowedRootsCache();
             $this->initializeDefaultEnvironment();
         }
@@ -1322,7 +1267,7 @@ class ProcessorTest extends TestCase
                 $tempDir . '/remote/image.jpg',
             ));
         } finally {
-            $this->removeTempTree($tempDir);
+            $this->removeOwnedTempTree($tempDir);
             $this->resetAllowedRootsCache();
             $this->initializeDefaultEnvironment();
         }
@@ -1365,7 +1310,7 @@ class ProcessorTest extends TestCase
                 $tempDir . '/srv/other.jpg',
             ));
         } finally {
-            $this->removeTempTree($tempDir);
+            $this->removeOwnedTempTree($tempDir);
             $this->resetAllowedRootsCache();
             $this->initializeDefaultEnvironment();
         }
@@ -1428,7 +1373,7 @@ class ProcessorTest extends TestCase
                 $tempDir . '/does/not/exist/image.jpg',
             ));
         } finally {
-            $this->removeTempTree($tempDir);
+            $this->removeOwnedTempTree($tempDir);
             $this->resetAllowedRootsCache();
             $this->initializeDefaultEnvironment();
         }
@@ -1438,15 +1383,172 @@ class ProcessorTest extends TestCase
      * Rejects paths with embedded NUL bytes outright — realpath() errors on
      * them and the parent-walk fallback would otherwise silently strip them
      * and revalidate a misleading parent prefix.
+     *
+     * Uses a real temp dir so the kill is deterministic: without the NUL
+     * guard, realpath() emits a warning and returns false, the parent-walk
+     * runs on the pre-NUL substring, and (depending on host filesystem)
+     * could spuriously match the public root. Pointing at an owned temp
+     * dir pins the behavior regardless of the host.
      */
     #[Test]
     public function isPathWithinAllowedRootsRejectsPathsWithNullByte(): void
     {
-        self::assertFalse($this->callMethod(
-            $this->processor,
-            'isPathWithinAllowedRoots',
-            "/var/www/html/public/fileadmin/foo\0.jpg",
-        ));
+        $tempDir = sys_get_temp_dir() . '/nr-pio-nul-' . uniqid('', true);
+        mkdir($tempDir . '/public/fileadmin', 0o777, true);
+
+        try {
+            $this->resetAllowedRootsCache();
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            self::assertFalse($this->callMethod(
+                $this->processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . "/public/fileadmin/foo\0.jpg",
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * The static cache on getAllowedRoots() must short-circuit repeat
+     * invocations: StorageRepository::findAll() should be consulted at most
+     * once per process (and once per manual cache reset).
+     *
+     * Kills a mutation that removes the `$resolvedAllowedRoots !== null`
+     * short-circuit at the top of getAllowedRoots().
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsCachesFalStorageLookupAcrossCalls(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-cache-' . uniqid('', true);
+        mkdir($tempDir . '/public/fileadmin', 0o777, true);
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getDriverType')->willReturn('Local');
+        $storage->method('getConfiguration')->willReturn([
+            'basePath' => 'fileadmin/',
+            'pathType' => 'relative',
+        ]);
+
+        $storageRepository = $this->createMock(StorageRepository::class);
+        $storageRepository->expects(self::once())
+            ->method('findAll')
+            ->willReturn([$storage]);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            // Two calls — findAll() must still be invoked exactly once.
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/fileadmin',
+            ));
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/fileadmin',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * When the public path itself cannot be realpath'd (e.g. because
+     * Environment::getPublicPath() points at a directory that does not exist
+     * yet on disk), FAL storages configured with absolute basePaths must
+     * still be collected as allowed roots.
+     *
+     * Kills a mutation that removes the `$publicPath !== false` guard, which
+     * without this test would not be caught because every other positive
+     * test has a resolvable public root.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsStillAcceptsStorageWhenPublicRootIsUnresolvable(): void
+    {
+        $tempDir      = sys_get_temp_dir() . '/nr-pio-nopub-' . uniqid('', true);
+        $absoluteRoot = $tempDir . '/srv/assets';
+        mkdir($absoluteRoot, 0o777, true);
+
+        try {
+            // Point Environment at a public directory that does NOT exist.
+            $this->initializeEnvironment($tempDir, $tempDir . '/public-does-not-exist');
+
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository($absoluteRoot, 'absolute'),
+            );
+            $this->resetAllowedRootsCache();
+
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $absoluteRoot,
+            ));
+
+            // And a path outside both the (unresolvable) public root and the
+            // storage must still be rejected.
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/srv/other.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * The catch block must catch Throwable, not just Exception — otherwise
+     * the uninitialized-readonly-property Error raised by
+     * ReflectionClass::newInstanceWithoutConstructor() scaffolds (and any
+     * other Error/TypeError from findAll()) would propagate and break
+     * request handling.
+     *
+     * Kills a mutation narrowing `catch (Throwable)` to `catch (Exception)`.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsFallsBackToPublicRootWhenStorageRepositoryThrowsError(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-err-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')
+                ->willThrowException(new TypeError('Return type mismatch'));
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            // Error-not-Exception still allows fallback to public-root-only.
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public',
+            ));
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                '/completely/fake/image.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
     }
 
     /**
@@ -1475,9 +1577,27 @@ class ProcessorTest extends TestCase
      * directories as dirs, which breaks plain rmdir(); this helper handles
      * symlinks (via isLink()) before checking isDir() and absorbs errors so
      * a teardown failure doesn't mask a genuine test failure.
+     *
+     * An explicit precondition asserts the path lies under the system temp
+     * directory so this helper cannot be turned into an arbitrary-path
+     * deletion tool by copy-paste drift in future tests.
      */
-    private function removeTempTree(string $tempDir): void
+    private function removeOwnedTempTree(string $tempDir): void
     {
+        // Guard against accidental use on non-temp paths. Compare the
+        // immediate parent of $tempDir against the system temp directory
+        // (realpath-resolved so macOS /tmp -> /private/tmp works).
+        $sysTemp    = realpath(sys_get_temp_dir());
+        $parent     = dirname($tempDir);
+        $realParent = realpath($parent) !== false ? realpath($parent) : $parent;
+
+        if ($sysTemp === false || $realParent !== $sysTemp) {
+            throw new RuntimeException(sprintf(
+                'removeOwnedTempTree refuses to operate outside sys_get_temp_dir(): %s',
+                $tempDir,
+            ));
+        }
+
         if (!is_dir($tempDir)) {
             return;
         }
@@ -1522,19 +1642,9 @@ class ProcessorTest extends TestCase
 
         $refClass = new ReflectionClass(Processor::class);
         $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
 
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            $tempDir,
-            $tempDir . '/public',
-            $tempDir . '/var',
-            $tempDir . '/config',
-            $tempDir . '/public/index.php',
-            'UNIX',
-        );
+        $this->resetAllowedRootsCache();
+        $this->initializeEnvironment($tempDir, $tempDir . '/public');
 
         $this->tempDir = $tempDir;
         $this->prop    = $prop;
@@ -1543,39 +1653,16 @@ class ProcessorTest extends TestCase
     }
 
     /**
-     * Clean up the real temp environment after tests.
+     * Clean up the real temp environment after tests. Delegates to
+     * removeOwnedTempTree() for symlink-aware cleanup, so a contributor
+     * adding a symlink inside a setUpRealEnvironment-based test does not
+     * trip PHP warnings from plain rmdir() on a symlinked directory.
      */
     private function tearDownRealEnvironment(string $tempDir, ReflectionProperty $prop): void
     {
-        // Remove all files recursively
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($tempDir, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($iterator as $item) {
-            /** @var SplFileInfo $item */
-            if ($item->isDir()) {
-                rmdir($item->getPathname());
-            } else {
-                unlink($item->getPathname()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        rmdir($tempDir);
-
+        $this->removeOwnedTempTree($tempDir);
         $prop->setValue(null, null);
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
+        $this->initializeDefaultEnvironment();
     }
 
     #[Test]
@@ -4731,58 +4818,33 @@ class ProcessorTest extends TestCase
     }
 
     // =========================================================================
-    // Mutation-killing: isPathWithinAllowedRoots ConcatOperandRemoval (L628)
+    // Mutation-killing: isWithinAnyRoot() DIRECTORY_SEPARATOR concatenation
     // =========================================================================
 
     #[Test]
     public function isPathWithinAllowedRootsRequiresDirectorySeparatorInPrefix(): void
     {
-        // L628: $publicPrefix = $publicPath . DIRECTORY_SEPARATOR
-        // Mutant removes the DIRECTORY_SEPARATOR, making prefix = just $publicPath
-        // Without the separator, /var/www/html/publicXXX would match /var/www/html/public
-        $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
-
+        // isWithinAnyRoot() checks str_starts_with($resolvedPath, $root . DIRECTORY_SEPARATOR).
+        // A mutant removing the DIRECTORY_SEPARATOR concat would match /tmp/…/publicXXX
+        // against the /tmp/…/public allowed root. This test pins the prefix boundary.
         $tempDir = sys_get_temp_dir() . '/nr-pio-sep-' . uniqid('', true);
         mkdir($tempDir . '/public', 0o777, true);
-        // Create a sibling directory that starts with the same prefix but isn't under public
+        // Sibling directory that shares the public-root prefix but is not nested under it
         mkdir($tempDir . '/publicXXX', 0o777, true);
 
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            $tempDir,
-            $tempDir . '/public',
-            $tempDir . '/var',
-            $tempDir . '/config',
-            $tempDir . '/public/index.php',
-            'UNIX',
-        );
+        try {
+            $this->resetAllowedRootsCache();
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
 
-        // Path inside public - should be accepted
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public'));
+            // Path inside public - should be accepted
+            self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public'));
 
-        // Path in sibling directory - should be rejected
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/publicXXX'));
-
-        // Cleanup
-        rmdir($tempDir . '/publicXXX');
-        rmdir($tempDir . '/public');
-        rmdir($tempDir);
-
-        $prop->setValue(null, null);
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
+            // Path in sibling directory - should be rejected
+            self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/publicXXX'));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
     }
 }

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -110,6 +110,45 @@ class ProcessorTest extends TestCase
         $prop->setValue(null, null);
     }
 
+    /**
+     * Re-apply the default `/var/www/html` Environment used by most tests.
+     * Extracted because setUp and several test-local finally blocks all repeat
+     * the same 9-argument initialize call.
+     */
+    private function initializeDefaultEnvironment(): void
+    {
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            '/var/www/html',
+            '/var/www/html/public',
+            '/var/www/html/var',
+            '/var/www/html/config',
+            '/var/www/html/public/index.php',
+            'UNIX',
+        );
+    }
+
+    /**
+     * Initialize the Environment with a specific (temp) project root and public
+     * path; sensible defaults are used for var/config/entry-script paths.
+     */
+    private function initializeEnvironment(string $projectRoot, string $publicPath): void
+    {
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            $projectRoot,
+            $publicPath,
+            $projectRoot . '/var',
+            $projectRoot . '/config',
+            $publicPath . '/index.php',
+            'UNIX',
+        );
+    }
+
     protected function tearDown(): void
     {
         if ($this->tempDir !== null && $this->prop instanceof ReflectionProperty && is_dir($this->tempDir)) {
@@ -135,10 +174,11 @@ class ProcessorTest extends TestCase
      * Required because constructor-promoted readonly properties cannot be reassigned,
      * so tests needing specific mock expectations must build a new instance.
      *
-     * @param object|null $lockFactory     Lock factory stub/mock
-     * @param object|null $responseFactory Response factory stub/mock
-     * @param object|null $streamFactory   Stream factory stub/mock
-     * @param object|null $eventDispatcher Event dispatcher stub/mock
+     * @param object|null $lockFactory       Lock factory stub/mock
+     * @param object|null $responseFactory   Response factory stub/mock
+     * @param object|null $streamFactory     Stream factory stub/mock
+     * @param object|null $eventDispatcher   Event dispatcher stub/mock
+     * @param object|null $storageRepository Storage repository stub/mock (defaults to one returning an empty findAll())
      */
     private function createProcessor(
         ?object $lockFactory = null,
@@ -950,7 +990,7 @@ class ProcessorTest extends TestCase
     // -------------------------------------------------------------------------
 
     #[Test]
-    public function isPathWithinPublicRootAcceptsPathsInsidePublicDir(): void
+    public function isPathWithinAllowedRootsAcceptsPathsInsidePublicDir(): void
     {
         $refClass = new ReflectionClass(Processor::class);
         $prop     = $refClass->getProperty('resolvedAllowedRoots');
@@ -972,23 +1012,23 @@ class ProcessorTest extends TestCase
         );
 
         // Existing path within public root
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/public/subdir'));
+        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir'));
 
         // Public root itself
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/public'));
+        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public'));
 
         // Non-existent path under public root: the parent-walk resolves up to
         // the existing /public directory, which is within the public root
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/public/subdir/nonexistent.jpg'));
+        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir/nonexistent.jpg'));
 
         // Path outside public root (existing)
         $outsideDir = sys_get_temp_dir() . '/nr-pio-outside-' . uniqid('', true);
         mkdir($outsideDir, 0o777, true);
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinPublicRoot', $outsideDir));
+        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $outsideDir));
         rmdir($outsideDir);
 
         // Non-existent path where no parent resolves to public root
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinPublicRoot', '/completely/fake/path/image.jpg'));
+        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', '/completely/fake/path/image.jpg'));
 
         // Cleanup
         rmdir($tempDir . '/public/subdir');
@@ -1010,7 +1050,7 @@ class ProcessorTest extends TestCase
     }
 
     #[Test]
-    public function isPathWithinPublicRootReturnsFalseWhenNoAllowedRootsAreResolvable(): void
+    public function isPathWithinAllowedRootsReturnsFalseWhenNoAllowedRootsAreResolvable(): void
     {
         $refClass = new ReflectionClass(Processor::class);
         $prop     = $refClass->getProperty('resolvedAllowedRoots');
@@ -1018,7 +1058,7 @@ class ProcessorTest extends TestCase
         // storage base path could be realpath'd — e.g., early bootstrap).
         $prop->setValue(null, []);
 
-        $result = $this->callMethod($this->processor, 'isPathWithinPublicRoot', '/some/path');
+        $result = $this->callMethod($this->processor, 'isPathWithinAllowedRoots', '/some/path');
 
         self::assertFalse($result);
 
@@ -1027,7 +1067,7 @@ class ProcessorTest extends TestCase
     }
 
     #[Test]
-    public function isPathWithinPublicRootReturnsFalseForNonExistentPaths(): void
+    public function isPathWithinAllowedRootsReturnsFalseForNonExistentPaths(): void
     {
         $refClass = new ReflectionClass(Processor::class);
         $prop     = $refClass->getProperty('resolvedAllowedRoots');
@@ -1056,7 +1096,7 @@ class ProcessorTest extends TestCase
         // (the parent-walk resolves to the existing parent directory).
         $result = $this->callMethod(
             $this->processor,
-            'isPathWithinPublicRoot',
+            'isPathWithinAllowedRoots',
             $tempDir . '/public/deep/nested/very/deeply/image.jpg',
         );
         self::assertTrue($result);
@@ -1065,7 +1105,7 @@ class ProcessorTest extends TestCase
         $outsidePath   = '/tmp/completely-outside-' . uniqid('', true) . '/image.jpg';
         $resultOutside = $this->callMethod(
             $this->processor,
-            'isPathWithinPublicRoot',
+            'isPathWithinAllowedRoots',
             $outsidePath,
         );
         self::assertFalse($resultOutside);
@@ -1100,7 +1140,7 @@ class ProcessorTest extends TestCase
      * @see https://github.com/netresearch/t3x-nr-image-optimize/issues/70
      */
     #[Test]
-    public function isPathWithinPublicRootAcceptsPathsInsideSymlinkedFalStorage(): void
+    public function isPathWithinAllowedRootsAcceptsPathsInsideSymlinkedFalStorage(): void
     {
         $tempDir  = sys_get_temp_dir() . '/nr-pio-efs-' . uniqid('', true);
         $public   = $tempDir . '/public';
@@ -1110,69 +1150,33 @@ class ProcessorTest extends TestCase
         mkdir($external . '/_processed_/6/d', 0o777, true);
         symlink($external, $public . '/fileadmin');
 
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            $tempDir,
-            $public,
-            $tempDir . '/var',
-            $tempDir . '/config',
-            $public . '/index.php',
-            'UNIX',
-        );
+        try {
+            $this->initializeEnvironment($tempDir, $public);
 
-        $storage = $this->createMock(ResourceStorage::class);
-        $storage->method('getDriverType')->willReturn('Local');
-        $storage->method('getConfiguration')->willReturn([
-            'basePath' => 'fileadmin/',
-            'pathType' => 'relative',
-        ]);
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository('fileadmin/', 'relative'),
+            );
+            $this->resetAllowedRootsCache();
 
-        $storageRepository = $this->createMock(StorageRepository::class);
-        $storageRepository->method('findAll')->willReturn([$storage]);
+            // Existing file inside the symlinked storage
+            file_put_contents($external . '/_processed_/6/d/photo.jpg', 'image-bytes');
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/_processed_/6/d/photo.jpg',
+            ));
 
-        $processor = $this->createProcessor(storageRepository: $storageRepository);
-        $this->resetAllowedRootsCache();
-
-        // Existing file inside the symlinked storage
-        file_put_contents($external . '/_processed_/6/d/photo.jpg', 'image-bytes');
-        self::assertTrue($this->callMethod(
-            $processor,
-            'isPathWithinPublicRoot',
-            $public . '/fileadmin/_processed_/6/d/photo.jpg',
-        ));
-
-        // Non-existent variant path inside the symlinked storage (parent walk case)
-        self::assertTrue($this->callMethod(
-            $processor,
-            'isPathWithinPublicRoot',
-            $public . '/fileadmin/_processed_/6/d/photo.w800h600m0q100.jpg',
-        ));
-
-        // Cleanup
-        unlink($external . '/_processed_/6/d/photo.jpg'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        unlink($public . '/fileadmin'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created symlink
-        rmdir($external . '/_processed_/6/d');
-        rmdir($external . '/_processed_/6');
-        rmdir($external . '/_processed_');
-        rmdir($external);
-        rmdir($tempDir . '/external');
-        rmdir($public);
-        rmdir($tempDir);
-
-        $this->resetAllowedRootsCache();
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
+            // Non-existent variant path inside the symlinked storage (parent walk case)
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/_processed_/6/d/photo.w800h600m0q100.jpg',
+            ));
+        } finally {
+            $this->removeTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
     }
 
     /**
@@ -1185,7 +1189,7 @@ class ProcessorTest extends TestCase
      * such as /etc/shadow by dropping a symlink into fileadmin.
      */
     #[Test]
-    public function isPathWithinPublicRootRejectsSymlinkEscapingAllowedRoots(): void
+    public function isPathWithinAllowedRootsRejectsSymlinkEscapingAllowedRoots(): void
     {
         $tempDir  = sys_get_temp_dir() . '/nr-pio-efs-escape-' . uniqid('', true);
         $public   = $tempDir . '/public';
@@ -1202,62 +1206,45 @@ class ProcessorTest extends TestCase
         symlink($secret, $external . '/escape');
 
         file_put_contents($secret . '/shadow', 'not-an-image');
+        // Also place a legitimate file inside the storage so we can assert the
+        // rejection is targeted at the escape path, not blanket.
+        file_put_contents($external . '/legit.jpg', 'image-bytes');
 
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            $tempDir,
-            $public,
-            $tempDir . '/var',
-            $tempDir . '/config',
-            $public . '/index.php',
-            'UNIX',
-        );
+        try {
+            $this->initializeEnvironment($tempDir, $public);
 
-        $storage = $this->createMock(ResourceStorage::class);
-        $storage->method('getDriverType')->willReturn('Local');
-        $storage->method('getConfiguration')->willReturn([
-            'basePath' => 'fileadmin/',
-            'pathType' => 'relative',
-        ]);
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository('fileadmin/', 'relative'),
+            );
+            $this->resetAllowedRootsCache();
 
-        $storageRepository = $this->createMock(StorageRepository::class);
-        $storageRepository->method('findAll')->willReturn([$storage]);
+            // Existing file behind the malicious symlink: rejected.
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/escape/shadow',
+            ));
 
-        $processor = $this->createProcessor(storageRepository: $storageRepository);
-        $this->resetAllowedRootsCache();
+            // Non-existent path under the malicious symlink (parent-walk branch):
+            // also rejected — the walk stops at the symlink target's realpath.
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/escape/nonexistent.w100h100m0q100.jpg',
+            ));
 
-        // Access through the malicious symlink must be rejected even though it
-        // appears (string-wise) to live inside fileadmin.
-        self::assertFalse($this->callMethod(
-            $processor,
-            'isPathWithinPublicRoot',
-            $public . '/fileadmin/escape/shadow',
-        ));
-
-        // Cleanup
-        unlink($secret . '/shadow'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        unlink($external . '/escape'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created symlink
-        unlink($public . '/fileadmin'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created symlink
-        rmdir($secret);
-        rmdir($external);
-        rmdir($tempDir . '/external');
-        rmdir($public);
-        rmdir($tempDir);
-
-        $this->resetAllowedRootsCache();
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
-        );
+            // Legit sibling inside the same storage still works — the rejection
+            // above is specific to the escape, not a blanket denial.
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/legit.jpg',
+            ));
+        } finally {
+            $this->removeTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
     }
 
     /**
@@ -1266,58 +1253,257 @@ class ProcessorTest extends TestCase
      * work against the public root alone, not crash the middleware.
      */
     #[Test]
-    public function isPathWithinPublicRootFallsBackToPublicRootWhenStorageRepositoryThrows(): void
+    public function isPathWithinAllowedRootsFallsBackToPublicRootWhenStorageRepositoryThrows(): void
     {
         $tempDir = sys_get_temp_dir() . '/nr-pio-storage-err-' . uniqid('', true);
         mkdir($tempDir . '/public/subdir', 0o777, true);
 
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            $tempDir,
-            $tempDir . '/public',
-            $tempDir . '/var',
-            $tempDir . '/config',
-            $tempDir . '/public/index.php',
-            'UNIX',
-        );
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')
+                ->willThrowException(new RuntimeException('TCA not yet initialised'));
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/subdir',
+            ));
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                '/completely/fake/path/image.jpg',
+            ));
+        } finally {
+            $this->removeTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Storages whose driver is not "Local" (e.g. a remote driver such as an
+     * S3 adapter) must be skipped by getAllowedRoots() — their basePath is not
+     * a disk path. This kills a potential mutation that inverts the Local
+     * check and incorrectly trusts non-Local storage base paths.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsSkipsNonLocalDriverStorages(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-nonlocal-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+        // A real directory at /tmp/.../remote that a buggy implementation
+        // could pick up as an allowed root if it trusted the non-Local driver.
+        mkdir($tempDir . '/remote', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $storage = $this->createMock(ResourceStorage::class);
+            $storage->method('getDriverType')->willReturn('S3');
+            $storage->method('getConfiguration')->willReturn([
+                'basePath' => $tempDir . '/remote',
+                'pathType' => 'absolute',
+            ]);
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')->willReturn([$storage]);
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/remote/image.jpg',
+            ));
+        } finally {
+            $this->removeTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Local storages configured with pathType=absolute expose a disk directory
+     * outside the public root — e.g. /srv/assets. Paths inside such a storage
+     * must be accepted. This exercises the 'absolute' branch of getAllowedRoots().
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsResolvesAbsolutePathTypeStorage(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-absolute-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+        mkdir($tempDir . '/srv/assets', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository(
+                    $tempDir . '/srv/assets',
+                    'absolute',
+                ),
+            );
+            $this->resetAllowedRootsCache();
+
+            file_put_contents($tempDir . '/srv/assets/photo.jpg', 'image-bytes');
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/srv/assets/photo.jpg',
+            ));
+
+            // A sibling outside the absolute storage must still be rejected.
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/srv/other.jpg',
+            ));
+        } finally {
+            $this->removeTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * A storage whose configured basePath does not exist on disk at the moment
+     * getAllowedRoots() runs must be silently skipped — its realpath is false.
+     * Other storages/public root continue to work. Also covers the empty and
+     * non-string basePath guards in one sweep.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsSkipsStoragesWithUnusableBasePath(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-badbase-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $missing = $this->createMock(ResourceStorage::class);
+            $missing->method('getDriverType')->willReturn('Local');
+            $missing->method('getConfiguration')->willReturn([
+                'basePath' => $tempDir . '/does/not/exist',
+                'pathType' => 'absolute',
+            ]);
+
+            $empty = $this->createMock(ResourceStorage::class);
+            $empty->method('getDriverType')->willReturn('Local');
+            $empty->method('getConfiguration')->willReturn([
+                'basePath' => '',
+                'pathType' => 'relative',
+            ]);
+
+            $nonString = $this->createMock(ResourceStorage::class);
+            $nonString->method('getDriverType')->willReturn('Local');
+            $nonString->method('getConfiguration')->willReturn([
+                'basePath' => null,
+                'pathType' => 'relative',
+            ]);
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')
+                ->willReturn([$missing, $empty, $nonString]);
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            // Public root still works
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public',
+            ));
+
+            // None of the broken storages expanded the allowed-roots set
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/does/not/exist/image.jpg',
+            ));
+        } finally {
+            $this->removeTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Rejects paths with embedded NUL bytes outright — realpath() errors on
+     * them and the parent-walk fallback would otherwise silently strip them
+     * and revalidate a misleading parent prefix.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsRejectsPathsWithNullByte(): void
+    {
+        self::assertFalse($this->callMethod(
+            $this->processor,
+            'isPathWithinAllowedRoots',
+            "/var/www/html/public/fileadmin/foo\0.jpg",
+        ));
+    }
+
+    /**
+     * Build a StorageRepository mock that exposes one Local storage with the
+     * given basePath and pathType. Reduces duplication across the symlink and
+     * path-type tests.
+     */
+    private function createLocalStorageRepository(string $basePath, string $pathType): StorageRepository
+    {
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getDriverType')->willReturn('Local');
+        $storage->method('getConfiguration')->willReturn([
+            'basePath' => $basePath,
+            'pathType' => $pathType,
+        ]);
 
         $storageRepository = $this->createMock(StorageRepository::class);
-        $storageRepository->method('findAll')
-            ->willThrowException(new RuntimeException('TCA not yet initialised'));
+        $storageRepository->method('findAll')->willReturn([$storage]);
 
-        $processor = $this->createProcessor(storageRepository: $storageRepository);
-        $this->resetAllowedRootsCache();
+        return $storageRepository;
+    }
 
-        self::assertTrue($this->callMethod(
-            $processor,
-            'isPathWithinPublicRoot',
-            $tempDir . '/public/subdir',
-        ));
-        self::assertFalse($this->callMethod(
-            $processor,
-            'isPathWithinPublicRoot',
-            '/completely/fake/path/image.jpg',
-        ));
+    /**
+     * Best-effort recursive cleanup of a temp-dir tree that may contain
+     * symlinks. The stdlib RecursiveDirectoryIterator treats symlinked
+     * directories as dirs, which breaks plain rmdir(); this helper handles
+     * symlinks (via isLink()) before checking isDir() and absorbs errors so
+     * a teardown failure doesn't mask a genuine test failure.
+     */
+    private function removeTempTree(string $tempDir): void
+    {
+        if (!is_dir($tempDir)) {
+            return;
+        }
 
-        // Cleanup
-        rmdir($tempDir . '/public/subdir');
-        rmdir($tempDir . '/public');
-        rmdir($tempDir);
-
-        $this->resetAllowedRootsCache();
-        Environment::initialize(
-            new ApplicationContext('Testing'),
-            true,
-            true,
-            '/var/www/html',
-            '/var/www/html/public',
-            '/var/www/html/var',
-            '/var/www/html/config',
-            '/var/www/html/public/index.php',
-            'UNIX',
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                $tempDir,
+                RecursiveDirectoryIterator::SKIP_DOTS,
+            ),
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
+
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            $path = $item->getPathname();
+
+            if ($item->isLink()) {
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- teardown of self-created symlink inside an owned temp dir
+            } elseif ($item->isDir()) {
+                @rmdir($path);
+            } else {
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- teardown of self-created tmp file inside an owned temp dir
+            }
+        }
+
+        @rmdir($tempDir);
     }
 
     // -------------------------------------------------------------------------
@@ -1397,7 +1583,7 @@ class ProcessorTest extends TestCase
     {
         ['tempDir' => $tempDir, 'prop' => $prop] = $this->setUpRealEnvironment();
 
-        // Both pathOriginal and pathVariant must exist for isPathWithinPublicRoot to pass
+        // Both pathOriginal and pathVariant must exist for isPathWithinAllowedRoots to pass
         file_put_contents($tempDir . '/public/images/photo.jpg', 'original');
         file_put_contents($tempDir . '/public/processed/images/photo.w100h50m0q80.jpg', 'variant');
 
@@ -1411,7 +1597,7 @@ class ProcessorTest extends TestCase
         // Since the variant file exists, serveCachedVariant will be called first
         // and will return a response before lock is attempted.
         // To test the LockCreateException, we need the variant NOT to exist.
-        // But then isPathWithinPublicRoot fails. So we test LockCreateException
+        // But then isPathWithinAllowedRoots fails. So we test LockCreateException
         // directly via acquireLockWithRetry test instead.
         // Here we demonstrate that the cached variant short-circuits.
         $responseFactory = $this->createMock(ResponseFactoryInterface::class);
@@ -1688,7 +1874,7 @@ class ProcessorTest extends TestCase
         // Create only a WebP cached variant (no avif)
         $variantPath = $tempDir . '/public/processed/images/photo.w100h50m0q80.jpg';
         file_put_contents($variantPath . '.webp', 'cached-webp-data');
-        // Need the variant path to exist for isPathWithinPublicRoot
+        // Need the variant path to exist for isPathWithinAllowedRoots
         file_put_contents($variantPath, 'placeholder');
         file_put_contents($tempDir . '/public/images/photo.jpg', 'original');
 
@@ -4545,11 +4731,11 @@ class ProcessorTest extends TestCase
     }
 
     // =========================================================================
-    // Mutation-killing: isPathWithinPublicRoot ConcatOperandRemoval (L628)
+    // Mutation-killing: isPathWithinAllowedRoots ConcatOperandRemoval (L628)
     // =========================================================================
 
     #[Test]
-    public function isPathWithinPublicRootRequiresDirectorySeparatorInPrefix(): void
+    public function isPathWithinAllowedRootsRequiresDirectorySeparatorInPrefix(): void
     {
         // L628: $publicPrefix = $publicPath . DIRECTORY_SEPARATOR
         // Mutant removes the DIRECTORY_SEPARATOR, making prefix = just $publicPath
@@ -4576,10 +4762,10 @@ class ProcessorTest extends TestCase
         );
 
         // Path inside public - should be accepted
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/public'));
+        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public'));
 
         // Path in sibling directory - should be rejected
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/publicXXX'));
+        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/publicXXX'));
 
         // Cleanup
         rmdir($tempDir . '/publicXXX');

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
             "web-dir": ".build/public"
         },
         "branch-alias": {
-            "dev-main": "2.2.x-dev"
+            "dev-main": "2.3.x-dev"
         }
     },
     "scripts": {


### PR DESCRIPTION
## Explain the details

Fixes #70.

In 1.1.0 `Processor::isPathWithinPublicRoot()` (now `isPathWithinAllowedRoots()`) started using `realpath()` to resolve image paths and compared them against the TYPO3 public root. When `fileadmin` (or any other FAL Local storage) is a **symlink** to an external location — e.g. AWS EFS or another NFS mount inside a Docker named volume — `realpath()` follows the symlink and the resolved target no longer starts with the public-root prefix, so **every uncached variant request returns HTTP 400**. Already-cached variants are unaffected because they live inside `public/processed/` which is a real directory.

### Approach

Instead of loosening the check to pure string normalization (which would let an attacker with write access inside `fileadmin` point a symlink at `/etc/shadow` and get it served), the validator now:

1. Keeps using `realpath()` so symlink targets are actually inspected.
2. Builds a list of *allowed roots*:
   - `realpath(Environment::getPublicPath())` — always.
   - `realpath(basePath)` of every **Local-driver FAL storage** (`relative` or `absolute` pathType), fetched via `StorageRepository`.
3. Accepts a path iff its realpath — or the realpath of its deepest existing ancestor, for not-yet-written variant files — equals or is nested inside any allowed root.

This intentionally keeps the "we don't trust admins" invariant from the original check: a symlink placed *inside* a storage that points outside every allowed root (e.g. `fileadmin/evil → /etc`) is still rejected.

Additional hardening from two rounds of specialist reviews:

- **NUL-byte rejection** at the top of the method — `realpath()` errors on NUL and the parent-walk fallback would otherwise silently strip it and revalidate a misleading parent prefix.
- **Warning log on StorageRepository failure** — when `findAll()` throws (early bootstrap, misconfiguration, or uninitialized-property in test scaffolding), the validator falls back to public-root-only and logs `warning` so operators see the degradation instead of receiving silent HTTP 400s for every storage-backed variant.
- **Defensive test helpers** — `removeOwnedTempTree()` asserts the target lives under `sys_get_temp_dir()` before deleting anything, and handles symlinked directories (`isLink()` before `isDir()`) so `rmdir` doesn't fail on a symlink-to-dir.

## Test plan (required)

**10 `isPathWithinAllowedRoots*` unit tests** (all on real-filesystem fixtures because symlinks don't work under `vfsStream`):

Regressions & core fix:
- `AcceptsPathsInsidePublicDir` — path-inside-public and parent-walk for non-existent paths.
- `AcceptsPathsInsideSymlinkedFalStorage` — regression for #70: symlinked `fileadmin → /tmp/external/fileadmin` accepted.
- `RejectsSymlinkEscapingAllowedRoots` — security guarantee: malicious inner `fileadmin/escape → /tmp/secret/` rejected, legitimate siblings still pass.
- `FallsBackToPublicRootWhenStorageRepositoryThrows` — StorageRepository raising `RuntimeException`.
- `FallsBackToPublicRootWhenStorageRepositoryThrowsError` — narrows the contract: `catch (Throwable)` must also catch `TypeError`/`Error`, proving the uninitialized-property defense.

Mutation-killing & branch coverage:
- `SkipsNonLocalDriverStorages` — kills `driver !== 'Local'` mutation.
- `ResolvesAbsolutePathTypeStorage` — covers `pathType='absolute'` branch.
- `SkipsStoragesWithUnusableBasePath` — covers missing, empty, non-string basePath.
- `RejectsPathsWithNullByte` — enforces the NUL-byte guard.
- `RequiresDirectorySeparatorInPrefix` — prevents `/public` matching `/publicXXX`.
- `CachesFalStorageLookupAcrossCalls` — static cache short-circuit must hold across calls.
- `StillAcceptsStorageWhenPublicRootIsUnresolvable` — `$publicPath !== false` guard.
- `ReturnsFalseWhenNoAllowedRootsAreResolvable` — empty-roots guard.
- `ReturnsFalseForNonExistentPaths` — parent-walk rejection path.

Plus the existing `generateAndSendReturns400WhenVariantPathOutsidePublicRoot` still passes — legacy symlink-escape rejection preserved.

Local checks (`composer ci:test:php:*`):

- [x] `ci:test:php:unit` — 543 tests, 1362 assertions pass
- [x] `ci:test:php:cgl` — clean
- [x] `ci:test:php:rector` — clean
- [x] `ci:test:php:fractor` — clean
- [x] `ci:test:php:lint` — clean
- [x] `ci:test:php:phpstan` — baseline unchanged (one new `property.uninitialized` notice on the test class, matching the five existing ones for the sibling mock properties)

## Closing issues

Closes #70

## Checklist

- [x] CI checks pass (`composer ci:test`)
- [x] Tests added or updated for the change
- [x] CHANGELOG.md updated (if applicable)
- [x] Documentation updated — `Documentation/Changelog/Index.rst` Unreleased entry; RST format aligned with sibling entries