### PR TITLE
fix: backport symlinked FAL storage path validation (#70) to v12-4-x

### DIFF
--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -23,7 +23,9 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Locking\Exception\LockCreateException;
 use TYPO3\CMS\Core\Locking\LockFactory;
 use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 
+use function array_keys;
 use function count;
 use function dirname;
 use function error_log;
@@ -43,6 +45,7 @@ use function preg_match_all;
 use function realpath;
 use function round;
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function strtolower;
 use function urldecode;
@@ -130,24 +133,41 @@ class Processor
     private const MODE_PATTERN = '/([hwqm])(\d+)/';
 
     /**
-     * Cached result of realpath(Environment::getPublicPath()) to avoid repeated
-     * filesystem calls in isPathWithinPublicRoot().
+     * Cached list of absolute filesystem roots (realpath-resolved) under which
+     * image paths are considered safe. Populated on first call to
+     * getAllowedRoots() and reused across requests in the same PHP process.
+     *
+     * Contains the TYPO3 public path plus the basePath of every Local-driver
+     * FAL storage, each resolved through realpath so that legitimately
+     * symlinked storage directories (e.g. fileadmin on an NFS/EFS mount) are
+     * recognised as allowed. Any symlink inside a storage that points to a
+     * location outside these roots is rejected.
+     *
+     * Because the cache persists for the life of the PHP process, tests must
+     * reset it between cases via reflection — see
+     * ProcessorTest::resetAllowedRootsCache().
+     *
+     * @var list<string>|null
      */
-    private static string|false|null $resolvedPublicPath = null;
+    private static ?array $resolvedAllowedRoots = null;
 
     /**
      * Initialize the image processor with all required dependencies.
      *
-     * @param ImageManager             $imageManager    Intervention Image manager used to read/encode images
-     * @param LockFactory              $lockFactory     TYPO3 lock factory for concurrent processing coordination
-     * @param ResponseFactoryInterface $responseFactory PSR-17 response factory
-     * @param StreamFactoryInterface   $streamFactory   PSR-17 stream factory
+     * @param ImageManager             $imageManager      Intervention Image manager used to read/encode images
+     * @param LockFactory              $lockFactory       TYPO3 lock factory for concurrent processing coordination
+     * @param ResponseFactoryInterface $responseFactory   PSR-17 response factory
+     * @param StreamFactoryInterface   $streamFactory     PSR-17 stream factory
+     * @param StorageRepository        $storageRepository FAL storage repository used to expand the set of
+     *                                                    filesystem roots from which images may be served
+     *                                                    (supports symlinked storage targets, e.g. NFS/EFS)
      */
     public function __construct(
         private readonly ImageManager $imageManager,
         private readonly LockFactory $lockFactory,
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly StreamFactoryInterface $streamFactory,
+        private readonly StorageRepository $storageRepository,
     ) {
     }
 
@@ -183,9 +203,9 @@ class Processor
             return $this->responseFactory->createResponse(400);
         }
 
-        // Validate that both resolved paths stay within the public root
-        if (!$this->isPathWithinPublicRoot($urlInfo['pathOriginal'])
-            || !$this->isPathWithinPublicRoot($urlInfo['pathVariant'])
+        // Validate that both resolved paths stay within an allowed root
+        if (!$this->isPathWithinAllowedRoots($urlInfo['pathOriginal'])
+            || !$this->isPathWithinAllowedRoots($urlInfo['pathVariant'])
         ) {
             return $this->responseFactory->createResponse(400);
         }
@@ -519,32 +539,41 @@ class Processor
 
     /**
      * Validate that a filesystem path resolves to a location within the TYPO3
-     * public directory. This prevents path-traversal attacks using encoded or
-     * otherwise crafted sequences that escape the web root.
+     * public directory or any configured Local FAL storage base path. This
+     * prevents path-traversal attacks using encoded or otherwise crafted
+     * sequences that escape the web root, while still allowing legitimate
+     * setups where e.g. fileadmin is a symlink to an external mount (NFS/EFS).
+     *
+     * Symlinks are resolved via realpath() so that an attacker (including a
+     * compromised admin who places a symlink inside a storage directory)
+     * cannot escape the declared roots by pointing a symlink at an arbitrary
+     * location such as /etc.
+     *
+     * NUL bytes in the input are rejected outright: realpath() treats them as
+     * a hard error, but the parent-walk fallback would otherwise trim them off
+     * and revalidate a misleading parent prefix.
      *
      * @param string $path Absolute filesystem path to validate
      *
-     * @return bool True if the path is safely within the public root
+     * @return bool True if the path is safely within an allowed root
      */
-    private function isPathWithinPublicRoot(string $path): bool
+    private function isPathWithinAllowedRoots(string $path): bool
     {
-        if (self::$resolvedPublicPath === null) {
-            self::$resolvedPublicPath = realpath(Environment::getPublicPath());
+        if (str_contains($path, "\0")) {
+            return false;
         }
 
-        $publicPath = self::$resolvedPublicPath;
+        $allowedRoots = $this->getAllowedRoots();
 
-        if ($publicPath === false) {
+        if ($allowedRoots === []) {
             return false;
         }
 
         // For existing paths, use realpath to resolve symlinks
         $resolvedPath = realpath($path);
 
-        $publicPrefix = $publicPath . DIRECTORY_SEPARATOR;
-
         if ($resolvedPath !== false) {
-            return str_starts_with($resolvedPath, $publicPrefix) || $resolvedPath === $publicPath;
+            return $this->isWithinAnyRoot($resolvedPath, $allowedRoots);
         }
 
         // For paths that do not yet exist (variant files), resolve the
@@ -558,11 +587,116 @@ class Processor
             $resolvedParent = realpath($parent);
 
             if ($resolvedParent !== false) {
-                return str_starts_with($resolvedParent, $publicPrefix) || $resolvedParent === $publicPath;
+                return $this->isWithinAnyRoot($resolvedParent, $allowedRoots);
             }
         } while ($parent !== $previous);
 
         return false;
+    }
+
+    /**
+     * Check whether an already-resolved (realpath'd) absolute path lies within
+     * at least one of the allowed filesystem roots.
+     *
+     * @param string       $resolvedPath Realpath-resolved absolute path
+     * @param list<string> $allowedRoots Realpath-resolved absolute roots
+     *
+     * @return bool True if $resolvedPath equals any root or is nested inside one
+     */
+    private function isWithinAnyRoot(string $resolvedPath, array $allowedRoots): bool
+    {
+        foreach ($allowedRoots as $root) {
+            if ($resolvedPath === $root) {
+                return true;
+            }
+
+            if (str_starts_with($resolvedPath, $root . DIRECTORY_SEPARATOR)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Build (and cache statically) the list of realpath-resolved absolute
+     * roots under which image paths are considered safe.
+     *
+     * Always includes the TYPO3 public path. Additionally includes the
+     * resolved base path of every Local-driver FAL storage so that storages
+     * whose directory is a symlink to an external mount (e.g. fileadmin on
+     * AWS EFS or another NFS share) remain servable.
+     *
+     * Storages are silently skipped when their driver type is not "Local",
+     * when basePath is missing or empty, or when the configured directory
+     * does not (yet) exist on disk and cannot be realpath'd.
+     *
+     * Throwables from StorageRepository (e.g. during very early bootstrap
+     * when TCA is not yet loaded) are caught so that path validation still
+     * works against the public root alone. The catch is intentionally broad
+     * so uninitialized-readonly-property Errors raised in tests that build
+     * Processor via newInstanceWithoutConstructor() are handled as well.
+     *
+     * @return list<string> Zero or more realpath-resolved allowed roots
+     */
+    private function getAllowedRoots(): array
+    {
+        if (self::$resolvedAllowedRoots !== null) {
+            return self::$resolvedAllowedRoots;
+        }
+
+        $roots         = [];
+        $publicPathRaw = Environment::getPublicPath();
+        $publicPath    = realpath($publicPathRaw);
+
+        if ($publicPath !== false) {
+            $roots[$publicPath] = true;
+        }
+
+        try {
+            foreach ($this->storageRepository->findAll() as $storage) {
+                if ($storage->getDriverType() !== 'Local') {
+                    continue;
+                }
+
+                $configuration = $storage->getConfiguration();
+                $basePath      = $configuration['basePath'] ?? '';
+
+                if (!is_string($basePath)) {
+                    continue;
+                }
+
+                if ($basePath === '') {
+                    continue;
+                }
+
+                $pathType = $configuration['pathType'] ?? 'relative';
+
+                $absolutePath = $pathType === 'absolute'
+                    ? $basePath
+                    : $publicPathRaw . DIRECTORY_SEPARATOR . $basePath;
+
+                $resolvedBasePath = realpath($absolutePath);
+
+                if ($resolvedBasePath !== false) {
+                    $roots[$resolvedBasePath] = true;
+                }
+            }
+        } catch (Throwable $e) {
+            // StorageRepository may be unusable (e.g. during very early
+            // bootstrap). Fall back to whatever roots we already collected
+            // and log at warning level so operators see the degradation
+            // instead of silently receiving 400s for every storage-backed
+            // variant request.
+            error_log(sprintf(
+                'nr_image_optimize: path validation limited to public root; StorageRepository unavailable: %s',
+                $e->getMessage(),
+            ));
+        }
+
+        self::$resolvedAllowedRoots = array_keys($roots);
+
+        return self::$resolvedAllowedRoots;
     }
 
     /**

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -6,6 +6,34 @@
 Changelog
 =========
 
+..  _changelog-unreleased:
+
+Unreleased
+==========
+
+-   Fixed: processed image requests no longer return
+    HTTP 400 when :file:`fileadmin` (or any other Local
+    FAL storage) is a symlink to an external location
+    such as an NFS/EFS mount. ``isPathWithinAllowedRoots``
+    now accepts any realpath-resolved path that lies
+    within the TYPO3 public root or the realpath of any
+    configured Local storage's ``basePath``. Symlinks
+    placed *inside* a storage that escape every allowed
+    root -- e.g. :file:`fileadmin/evil` -> :file:`/etc`
+    -- continue to be rejected. Backport of the fix on
+    ``main``, reported in
+    `issue #70 <https://github.com/netresearch/t3x-nr-image-optimize/issues/70>`__.
+-   Hardened: paths containing NUL bytes are rejected
+    outright, closing a minor realpath-bypass via the
+    not-yet-existing-path parent-walk branch.
+-   Changed (BC for subclasses and manual instantiators):
+    :php:`Netresearch\\NrImageOptimize\\Processor` gains a
+    new required ``StorageRepository`` constructor
+    parameter. Consumers that autowire the service (the
+    default in TYPO3 12+) are unaffected; any code that
+    extends the class or constructs it by hand must
+    forward the new dependency.
+
 ..  _changelog-1-1-0:
 
 1.1.0

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -33,19 +33,26 @@ use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 use RuntimeException;
+use SplFileInfo;
+use TypeError;
 use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Locking\Exception\LockCreateException;
 use TYPO3\CMS\Core\Locking\LockFactory;
 use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
 
 use function dirname;
 use function file_put_contents;
 use function glob;
 use function ini_set;
+use function is_dir;
 use function md5;
 use function mkdir;
+use function realpath;
 use function rmdir;
+use function sprintf;
 use function symlink;
 use function sys_get_temp_dir;
 use function touch;
@@ -60,6 +67,8 @@ class ProcessorTest extends TestCase
     private MockObject $responseFactory;
 
     private MockObject $streamFactory;
+
+    private MockObject $storageRepository;
 
     private Processor $processor;
 
@@ -79,9 +88,14 @@ class ProcessorTest extends TestCase
             'UNIX',
         );
 
-        $this->lockFactory     = $this->createMock(LockFactory::class);
-        $this->responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $this->streamFactory   = $this->createMock(StreamFactoryInterface::class);
+        $this->lockFactory       = $this->createMock(LockFactory::class);
+        $this->responseFactory   = $this->createMock(ResponseFactoryInterface::class);
+        $this->streamFactory     = $this->createMock(StreamFactoryInterface::class);
+        $this->storageRepository = $this->createMock(StorageRepository::class);
+        $this->storageRepository->method('findAll')->willReturn([]);
+
+        // Reset the process-wide allowed-roots cache so each test starts fresh
+        $this->resetAllowedRootsCache();
 
         // ImageManager is final and cannot be mocked. Use newInstanceWithoutConstructor
         // since tests only exercise private helper methods via reflection that do not
@@ -93,6 +107,7 @@ class ProcessorTest extends TestCase
         $this->setProperty($this->processor, 'lockFactory', $this->lockFactory);
         $this->setProperty($this->processor, 'responseFactory', $this->responseFactory);
         $this->setProperty($this->processor, 'streamFactory', $this->streamFactory);
+        $this->setProperty($this->processor, 'storageRepository', $this->storageRepository);
     }
 
     private function setProperty(object $object, string $property, mixed $value): void
@@ -102,27 +117,149 @@ class ProcessorTest extends TestCase
         $prop->setValue($object, $value);
     }
 
+    private function resetAllowedRootsCache(): void
+    {
+        $refClass = new ReflectionClass(Processor::class);
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        $prop->setValue(null, null);
+    }
+
+    /**
+     * Re-apply the default `/var/www/html` Environment used by most tests.
+     */
+    private function initializeDefaultEnvironment(): void
+    {
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            '/var/www/html',
+            '/var/www/html/public',
+            '/var/www/html/var',
+            '/var/www/html/config',
+            '/var/www/html/public/index.php',
+            'UNIX',
+        );
+    }
+
+    /**
+     * Initialize the Environment with a specific (temp) project root and public
+     * path; sensible defaults are used for var/config/entry-script paths.
+     */
+    private function initializeEnvironment(string $projectRoot, string $publicPath): void
+    {
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            $projectRoot,
+            $publicPath,
+            $projectRoot . '/var',
+            $projectRoot . '/config',
+            $publicPath . '/index.php',
+            'UNIX',
+        );
+    }
+
+    /**
+     * Build a StorageRepository mock that exposes one Local storage with the
+     * given basePath and pathType.
+     */
+    private function createLocalStorageRepository(string $basePath, string $pathType): StorageRepository
+    {
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getDriverType')->willReturn('Local');
+        $storage->method('getConfiguration')->willReturn([
+            'basePath' => $basePath,
+            'pathType' => $pathType,
+        ]);
+
+        $storageRepository = $this->createMock(StorageRepository::class);
+        $storageRepository->method('findAll')->willReturn([$storage]);
+
+        return $storageRepository;
+    }
+
+    /**
+     * Best-effort recursive cleanup of a temp-dir tree that may contain
+     * symlinks. Handles symlinks (via isLink()) before checking isDir() so
+     * plain rmdir() on a symlinked directory does not error. Absorbs errors
+     * so a teardown failure doesn't mask a genuine test failure.
+     *
+     * An explicit precondition asserts the path lies under the system temp
+     * directory so this helper cannot be turned into an arbitrary-path
+     * deletion tool by copy-paste drift in future tests.
+     */
+    private function removeOwnedTempTree(string $tempDir): void
+    {
+        $sysTemp    = realpath(sys_get_temp_dir());
+        $parent     = dirname($tempDir);
+        $realParent = realpath($parent) !== false ? realpath($parent) : $parent;
+
+        if ($sysTemp === false || $realParent !== $sysTemp) {
+            throw new RuntimeException(sprintf(
+                'removeOwnedTempTree refuses to operate outside sys_get_temp_dir(): %s',
+                $tempDir,
+            ));
+        }
+
+        if (!is_dir($tempDir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                $tempDir,
+                RecursiveDirectoryIterator::SKIP_DOTS,
+            ),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            $path = $item->getPathname();
+
+            if ($item->isLink()) {
+                @unlink($path);
+            } elseif ($item->isDir()) {
+                @rmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($tempDir);
+    }
+
     /**
      * Create a fresh Processor with specific dependencies injected via reflection.
      *
      * Required because constructor-promoted readonly properties cannot be reassigned,
      * so tests needing specific mock expectations must build a new instance.
      *
-     * @param object|null $lockFactory     Lock factory stub/mock
-     * @param object|null $responseFactory Response factory stub/mock
-     * @param object|null $streamFactory   Stream factory stub/mock
+     * @param object|null $lockFactory       Lock factory stub/mock
+     * @param object|null $responseFactory   Response factory stub/mock
+     * @param object|null $streamFactory     Stream factory stub/mock
+     * @param object|null $storageRepository Storage repository stub/mock (defaults to one returning an empty findAll())
      */
     private function createProcessor(
         ?object $lockFactory = null,
         ?object $responseFactory = null,
         ?object $streamFactory = null,
+        ?object $storageRepository = null,
     ): Processor {
         $reflection = new ReflectionClass(Processor::class);
         $instance   = $reflection->newInstanceWithoutConstructor();
 
+        if (!$storageRepository instanceof StorageRepository) {
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')->willReturn([]);
+        }
+
         $this->setProperty($instance, 'lockFactory', $lockFactory ?? $this->createMock(LockFactory::class));
         $this->setProperty($instance, 'responseFactory', $responseFactory ?? $this->createMock(ResponseFactoryInterface::class));
         $this->setProperty($instance, 'streamFactory', $streamFactory ?? $this->createMock(StreamFactoryInterface::class));
+        $this->setProperty($instance, 'storageRepository', $storageRepository);
 
         return $instance;
     }
@@ -904,10 +1041,10 @@ class ProcessorTest extends TestCase
     // -------------------------------------------------------------------------
 
     #[Test]
-    public function isPathWithinPublicRootAcceptsPathsInsidePublicDir(): void
+    public function isPathWithinAllowedRootsAcceptsPathsInsidePublicDir(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
         $prop->setValue(null, null);
 
         $tempDir = sys_get_temp_dir() . '/nr-pio-pubroot-' . uniqid('', true);
@@ -926,23 +1063,23 @@ class ProcessorTest extends TestCase
         );
 
         // Existing path within public root
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/public/subdir'));
+        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir'));
 
         // Public root itself
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/public'));
+        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public'));
 
         // Non-existent path under public root: the parent-walk resolves up to
         // the existing /public directory, which is within the public root
-        self::assertTrue($this->callMethod($this->processor, 'isPathWithinPublicRoot', $tempDir . '/public/subdir/nonexistent.jpg'));
+        self::assertTrue($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $tempDir . '/public/subdir/nonexistent.jpg'));
 
         // Path outside public root (existing)
         $outsideDir = sys_get_temp_dir() . '/nr-pio-outside-' . uniqid('', true);
         mkdir($outsideDir, 0o777, true);
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinPublicRoot', $outsideDir));
+        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', $outsideDir));
         rmdir($outsideDir);
 
         // Non-existent path where no parent resolves to public root
-        self::assertFalse($this->callMethod($this->processor, 'isPathWithinPublicRoot', '/completely/fake/path/image.jpg'));
+        self::assertFalse($this->callMethod($this->processor, 'isPathWithinAllowedRoots', '/completely/fake/path/image.jpg'));
 
         // Cleanup
         rmdir($tempDir . '/public/subdir');
@@ -964,14 +1101,15 @@ class ProcessorTest extends TestCase
     }
 
     #[Test]
-    public function isPathWithinPublicRootReturnsFalseWhenPublicPathCannotBeResolved(): void
+    public function isPathWithinAllowedRootsReturnsFalseWhenNoAllowedRootsAreResolvable(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
-        // Simulate cached false result (public path doesn't resolve)
-        $prop->setValue(null, false);
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        // Simulate cached empty result (neither the public path nor any FAL
+        // storage base path could be realpath'd — e.g., early bootstrap).
+        $prop->setValue(null, []);
 
-        $result = $this->callMethod($this->processor, 'isPathWithinPublicRoot', '/some/path');
+        $result = $this->callMethod($this->processor, 'isPathWithinAllowedRoots', '/some/path');
 
         self::assertFalse($result);
 
@@ -980,10 +1118,10 @@ class ProcessorTest extends TestCase
     }
 
     #[Test]
-    public function isPathWithinPublicRootReturnsFalseForNonExistentPaths(): void
+    public function isPathWithinAllowedRootsReturnsFalseForNonExistentPaths(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
 
         $tempDir = sys_get_temp_dir() . '/nr-pio-walk-' . uniqid('', true);
         mkdir($tempDir . '/public/deep/nested', 0o777, true);
@@ -1009,7 +1147,7 @@ class ProcessorTest extends TestCase
         // (the parent-walk resolves to the existing parent directory).
         $result = $this->callMethod(
             $this->processor,
-            'isPathWithinPublicRoot',
+            'isPathWithinAllowedRoots',
             $tempDir . '/public/deep/nested/very/deeply/image.jpg',
         );
         self::assertTrue($result);
@@ -1018,7 +1156,7 @@ class ProcessorTest extends TestCase
         $outsidePath   = '/tmp/completely-outside-' . uniqid('', true) . '/image.jpg';
         $resultOutside = $this->callMethod(
             $this->processor,
-            'isPathWithinPublicRoot',
+            'isPathWithinAllowedRoots',
             $outsidePath,
         );
         self::assertFalse($resultOutside);
@@ -1043,13 +1181,441 @@ class ProcessorTest extends TestCase
         );
     }
 
+    /**
+     * Regression test for issue #70: when fileadmin (a FAL Local storage) is a
+     * symlink to an external location (e.g. an NFS/EFS mount), paths inside it
+     * must still be accepted. Without this fix, realpath() resolves through
+     * the symlink and the target no longer starts with the public root, so
+     * every uncached variant request returned HTTP 400.
+     *
+     * @see https://github.com/netresearch/t3x-nr-image-optimize/issues/70
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsAcceptsPathsInsideSymlinkedFalStorage(): void
+    {
+        $tempDir  = sys_get_temp_dir() . '/nr-pio-efs-' . uniqid('', true);
+        $public   = $tempDir . '/public';
+        $external = $tempDir . '/external/fileadmin';
+
+        mkdir($public, 0o777, true);
+        mkdir($external . '/_processed_/6/d', 0o777, true);
+        symlink($external, $public . '/fileadmin');
+
+        try {
+            $this->initializeEnvironment($tempDir, $public);
+
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository('fileadmin/', 'relative'),
+            );
+            $this->resetAllowedRootsCache();
+
+            file_put_contents($external . '/_processed_/6/d/photo.jpg', 'image-bytes');
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/_processed_/6/d/photo.jpg',
+            ));
+
+            // Non-existent variant path (parent-walk branch)
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/_processed_/6/d/photo.w800h600m0q100.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Security guarantee: even when a symlinked fileadmin is accepted, a
+     * symlink placed INSIDE that storage that points to a location outside
+     * every allowed root must still be rejected.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsRejectsSymlinkEscapingAllowedRoots(): void
+    {
+        $tempDir  = sys_get_temp_dir() . '/nr-pio-efs-escape-' . uniqid('', true);
+        $public   = $tempDir . '/public';
+        $external = $tempDir . '/external/fileadmin';
+        $secret   = $tempDir . '/secret';
+
+        mkdir($public, 0o777, true);
+        mkdir($external, 0o777, true);
+        mkdir($secret, 0o777, true);
+
+        symlink($external, $public . '/fileadmin');
+        symlink($secret, $external . '/escape');
+
+        file_put_contents($secret . '/shadow', 'not-an-image');
+        file_put_contents($external . '/legit.jpg', 'image-bytes');
+
+        try {
+            $this->initializeEnvironment($tempDir, $public);
+
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository('fileadmin/', 'relative'),
+            );
+            $this->resetAllowedRootsCache();
+
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/escape/shadow',
+            ));
+
+            // Non-existent path under the malicious symlink (parent-walk)
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/escape/nonexistent.w100h100m0q100.jpg',
+            ));
+
+            // Legit sibling inside the same storage still works
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $public . '/fileadmin/legit.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * If StorageRepository::findAll() raises an exception (e.g. during early
+     * bootstrap when TCA is not yet loaded), path validation must still work
+     * against the public root alone, not crash the middleware.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsFallsBackToPublicRootWhenStorageRepositoryThrows(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-storage-err-' . uniqid('', true);
+        mkdir($tempDir . '/public/subdir', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')
+                ->willThrowException(new RuntimeException('TCA not yet initialised'));
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/subdir',
+            ));
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                '/completely/fake/path/image.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Storages with a non-Local driver (e.g. remote) must be skipped by
+     * getAllowedRoots() — their basePath is not a disk path.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsSkipsNonLocalDriverStorages(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-nonlocal-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+        mkdir($tempDir . '/remote', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $storage = $this->createMock(ResourceStorage::class);
+            $storage->method('getDriverType')->willReturn('S3');
+            $storage->method('getConfiguration')->willReturn([
+                'basePath' => $tempDir . '/remote',
+                'pathType' => 'absolute',
+            ]);
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')->willReturn([$storage]);
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/remote/image.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Local storages configured with pathType=absolute expose a disk directory
+     * outside the public root — paths inside such a storage must be accepted.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsResolvesAbsolutePathTypeStorage(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-absolute-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+        mkdir($tempDir . '/srv/assets', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository(
+                    $tempDir . '/srv/assets',
+                    'absolute',
+                ),
+            );
+            $this->resetAllowedRootsCache();
+
+            file_put_contents($tempDir . '/srv/assets/photo.jpg', 'image-bytes');
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/srv/assets/photo.jpg',
+            ));
+
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/srv/other.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Storages with unusable basePath (missing on disk, empty string, or
+     * non-string) must be silently skipped — public root still works.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsSkipsStoragesWithUnusableBasePath(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-badbase-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $missing = $this->createMock(ResourceStorage::class);
+            $missing->method('getDriverType')->willReturn('Local');
+            $missing->method('getConfiguration')->willReturn([
+                'basePath' => $tempDir . '/does/not/exist',
+                'pathType' => 'absolute',
+            ]);
+
+            $empty = $this->createMock(ResourceStorage::class);
+            $empty->method('getDriverType')->willReturn('Local');
+            $empty->method('getConfiguration')->willReturn([
+                'basePath' => '',
+                'pathType' => 'relative',
+            ]);
+
+            $nonString = $this->createMock(ResourceStorage::class);
+            $nonString->method('getDriverType')->willReturn('Local');
+            $nonString->method('getConfiguration')->willReturn([
+                'basePath' => null,
+                'pathType' => 'relative',
+            ]);
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')
+                ->willReturn([$missing, $empty, $nonString]);
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public',
+            ));
+
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/does/not/exist/image.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * Rejects paths with embedded NUL bytes — realpath() errors on them and
+     * the parent-walk fallback would otherwise silently strip them.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsRejectsPathsWithNullByte(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-nul-' . uniqid('', true);
+        mkdir($tempDir . '/public/fileadmin', 0o777, true);
+
+        try {
+            $this->resetAllowedRootsCache();
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            self::assertFalse($this->callMethod(
+                $this->processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . "/public/fileadmin/foo\0.jpg",
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * The static cache must short-circuit repeat invocations —
+     * StorageRepository::findAll() should be consulted once per process.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsCachesFalStorageLookupAcrossCalls(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-cache-' . uniqid('', true);
+        mkdir($tempDir . '/public/fileadmin', 0o777, true);
+
+        $storage = $this->createMock(ResourceStorage::class);
+        $storage->method('getDriverType')->willReturn('Local');
+        $storage->method('getConfiguration')->willReturn([
+            'basePath' => 'fileadmin/',
+            'pathType' => 'relative',
+        ]);
+
+        $storageRepository = $this->createMock(StorageRepository::class);
+        $storageRepository->expects(self::once())
+            ->method('findAll')
+            ->willReturn([$storage]);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/fileadmin',
+            ));
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/fileadmin',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * When public path itself cannot be realpath'd, FAL storages configured
+     * with absolute basePaths must still be collected as allowed roots.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsStillAcceptsStorageWhenPublicRootIsUnresolvable(): void
+    {
+        $tempDir      = sys_get_temp_dir() . '/nr-pio-nopub-' . uniqid('', true);
+        $absoluteRoot = $tempDir . '/srv/assets';
+        mkdir($absoluteRoot, 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public-does-not-exist');
+
+            $processor = $this->createProcessor(
+                storageRepository: $this->createLocalStorageRepository($absoluteRoot, 'absolute'),
+            );
+            $this->resetAllowedRootsCache();
+
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $absoluteRoot,
+            ));
+
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/srv/other.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
+     * The catch must catch Throwable, not just Exception — otherwise
+     * Error/TypeError from findAll() would propagate and break request
+     * handling (including the uninitialized-readonly-property path).
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsFallsBackToPublicRootWhenStorageRepositoryThrowsError(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-err-' . uniqid('', true);
+        mkdir($tempDir . '/public', 0o777, true);
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $storageRepository = $this->createMock(StorageRepository::class);
+            $storageRepository->method('findAll')
+                ->willThrowException(new TypeError('Return type mismatch'));
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public',
+            ));
+            self::assertFalse($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                '/completely/fake/image.jpg',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
     // -------------------------------------------------------------------------
     // generateAndSend: LockCreateException catch
     // -------------------------------------------------------------------------
     /**
      * Set up a real temp directory for tests that exercise generateAndSend (needs real filesystem for path validation).
      *
-     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedPublicPath property
+     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedAllowedRoots property
      */
     private function setUpRealEnvironment(): array
     {
@@ -1058,7 +1624,7 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/public/images', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
         $prop->setValue(null, null);
 
         Environment::initialize(
@@ -1116,7 +1682,7 @@ class ProcessorTest extends TestCase
     {
         ['tempDir' => $tempDir, 'prop' => $prop] = $this->setUpRealEnvironment();
 
-        // Both pathOriginal and pathVariant must exist for isPathWithinPublicRoot to pass
+        // Both pathOriginal and pathVariant must exist for isPathWithinAllowedRoots to pass
         file_put_contents($tempDir . '/public/images/photo.jpg', 'original');
         file_put_contents($tempDir . '/public/processed/images/photo.w100h50m0q80.jpg', 'variant');
 
@@ -1130,7 +1696,7 @@ class ProcessorTest extends TestCase
         // Since the variant file exists, serveCachedVariant will be called first
         // and will return a response before lock is attempted.
         // To test the LockCreateException, we need the variant NOT to exist.
-        // But then isPathWithinPublicRoot fails. So we test LockCreateException
+        // But then isPathWithinAllowedRoots fails. So we test LockCreateException
         // directly via acquireLockWithRetry test instead.
         // Here we demonstrate that the cached variant short-circuits.
         $responseFactory = $this->createMock(ResponseFactoryInterface::class);
@@ -1405,7 +1971,7 @@ class ProcessorTest extends TestCase
         // Create only a WebP cached variant (no avif)
         $variantPath = $tempDir . '/public/processed/images/photo.w100h50m0q80.jpg';
         file_put_contents($variantPath . '.webp', 'cached-webp-data');
-        // Need the variant path to exist for isPathWithinPublicRoot
+        // Need the variant path to exist for isPathWithinAllowedRoots
         file_put_contents($variantPath, 'placeholder');
         file_put_contents($tempDir . '/public/images/photo.jpg', 'original');
 
@@ -2325,7 +2891,7 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/outside', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedPublicPath');
+        $prop     = $refClass->getProperty('resolvedAllowedRoots');
         $prop->setValue(null, null);
 
         Environment::initialize(


### PR DESCRIPTION
## Explain the details

Backport of #71 (merge 80b6065) to the v12-4-x maintenance branch.

Fixes #70 on the TYPO3 12 line.

In 1.1.0 `Processor::isPathWithinPublicRoot()` (now `isPathWithinAllowedRoots()`) started using `realpath()` to resolve image paths and compared them against the TYPO3 public root. When `fileadmin` (or any other FAL Local storage) is a **symlink** to an external location — e.g. AWS EFS or another NFS mount inside a Docker named volume — `realpath()` follows the symlink and the resolved target no longer starts with the public-root prefix, so **every uncached variant request returns HTTP 400**.

### Approach (unchanged from #71)

Widen the allowed-root set from "TYPO3 public root only" to "public root + realpath of every Local-driver FAL storage `basePath`" (supports both `relative` and `absolute` pathType). Still uses `realpath()` so the security invariant holds: symlinks inside a storage that escape to unrelated directories (e.g. `fileadmin/evil → /etc`) are rejected.

Additional hardening carried over from the main-branch fix:

- NUL-byte paths rejected outright (realpath errors on them; parent-walk would otherwise silently strip them).
- StorageRepository failures fall back to public-root-only with an `error_log` warning so operators see the degradation instead of silent 400s.
- Method renamed `isPathWithinPublicRoot` → `isPathWithinAllowedRoots`.

### Adjustments vs. the main-branch fix

- v12-4-x `Processor` has no `LoggerAwareInterface` yet; the fallback uses `error_log()`, matching existing error-log patterns in that file.
- Constructor signature on v12-4-x has 4 params (no `EventDispatcherInterface`, no `ImageReaderInterface`); `StorageRepository` is added as a 5th required dependency.

## Test plan (required)

**10 new unit tests** (all in `Tests/Unit/ProcessorTest.php`, all with try/finally fixture cleanup):

- `AcceptsPathsInsideSymlinkedFalStorage` — regression for #70.
- `RejectsSymlinkEscapingAllowedRoots` — security invariant.
- `FallsBackToPublicRootWhenStorageRepositoryThrows` — RuntimeException fallback.
- `FallsBackToPublicRootWhenStorageRepositoryThrowsError` — TypeError/Error fallback (pins `catch (Throwable)` contract).
- `SkipsNonLocalDriverStorages` — S3-style driver skipped.
- `ResolvesAbsolutePathTypeStorage` — absolute basePath branch.
- `SkipsStoragesWithUnusableBasePath` — missing / empty / non-string basePath.
- `RejectsPathsWithNullByte` — NUL guard.
- `CachesFalStorageLookupAcrossCalls` — static cache short-circuit.
- `StillAcceptsStorageWhenPublicRootIsUnresolvable` — `$publicPath !== false` branch.

Plus the existing path-validation tests continue to pass after the rename.

Local checks (`composer ci:test:php:*`):

- [x] `ci:test:php:unit` — 252 tests, 582 assertions pass
- [x] `ci:test:php:cgl` — clean
- [x] `ci:test:php:rector` — clean
- [x] `ci:test:php:lint` — clean
- [x] `ci:test:php:phpstan` — no errors

## Closing issues

Closes #70

## Checklist

- [x] CI checks pass (`composer ci:test`)
- [x] Tests added or updated for the change
- [x] CHANGELOG.md regenerated at release time (not manually edited)
- [x] Documentation updated — `Documentation/Changelog/Index.rst` Unreleased entry