### PR TITLE
ci: migrate TYPO3_12 CI to shared workflow + drop PHP 8.1 (also fixes two production bugs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,18 @@ jobs:
       php-versions: '["8.2","8.3","8.4"]'
       typo3-versions: '["^12.0"]'
       upload-coverage: true
-      run-functional-tests: true
-      # Extension uses Intervention Image's Imagick driver; functional
-      # tests instantiate the service and therefore require imagick.
-      # gd is kept for the Intervention v3 fallback path the README
-      # documents.
+      # Extension uses Intervention Image's Imagick driver + GD fallback.
+      # imagick is required by any test that instantiates the image
+      # service via the real DI container (functional tests do, unit
+      # tests don't).
       php-extensions: intl, mbstring, xml, imagick, gd
+      # run-functional-tests stays off to match main. Enabling it with
+      # the current Tests/Functional/* suite produces HTTP 400 from the
+      # path-validation layer because the TYPO3 testing-framework
+      # instance layout is not recognised as an allowed root. This is
+      # a pre-existing issue that also affects main's functional tests
+      # when enabled — fix belongs in a separate test-code PR, not in
+      # this CI-migration work.
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       typo3-versions: '["^12.0"]'
       upload-coverage: true
       run-functional-tests: true
+      # Extension uses Intervention Image's Imagick driver; functional
+      # tests instantiate the service and therefore require imagick.
+      # gd is kept for the Intervention v3 fallback path the README
+      # documents.
+      php-extensions: intl, mbstring, xml, imagick, gd
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,7 @@ jobs:
       # service via the real DI container (functional tests do, unit
       # tests don't).
       php-extensions: intl, mbstring, xml, imagick, gd
-      # run-functional-tests stays off to match main. Enabling it with
-      # the current Tests/Functional/* suite produces HTTP 400 from the
-      # path-validation layer because the TYPO3 testing-framework
-      # instance layout is not recognised as an allowed root. This is
-      # a pre-existing issue that also affects main's functional tests
-      # when enabled — fix belongs in a separate test-code PR, not in
-      # this CI-migration work.
+      run-functional-tests: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       php-versions: '["8.2","8.3","8.4"]'
       typo3-versions: '["^12.0"]'
       upload-coverage: true
+      run-functional-tests: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,166 +2,77 @@ name: CI
 
 on:
   push:
-    # Only run for merge commits / direct pushes to the maintenance branch.
-    # PRs still get a single run via `pull_request` (otherwise every PR push
-    # would trigger both events and duplicate every job).
-    branches:
-      - TYPO3_12
+    branches: [TYPO3_12]
   pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: {}
 
 jobs:
-  tests:
-    name: Tests (PHP ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version:
-          - '8.1'
-          - '8.2'
-          - '8.3'
-          - '8.4'
-        include:
-          - php-version: '8.1'
-            typo3-version: '^12.0'
-          - php-version: '8.2'
-            typo3-version: '^12.0'
-          - php-version: '8.3'
-            typo3-version: '^12.0'
-          - php-version: '8.4'
-            typo3-version: '^12.0'
+  ci:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2","8.3","8.4"]'
+      typo3-versions: '["^12.0"]'
+      upload-coverage: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl, json, dom, curl, xml, zip, opcache, gd
-          tools: composer:v2
-          coverage: none
+  fuzz:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+    permissions:
+      contents: read
+    with:
+      phpunit-config: 'Build/FuzzTests.xml'
 
-      - name: Validate composer.json
-        run: composer validate --strict
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+    permissions:
+      contents: read
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+  codeql:
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
-      - name: Cache composer dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            composer-${{ runner.os }}-${{ matrix.php-version }}-
-            composer-${{ runner.os }}-
+  scorecard:
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
 
-      - name: Install dependencies
-        run: |
-          composer require typo3/cms-core:${{ matrix.typo3-version }} --no-update
-          composer update --prefer-dist --no-progress
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
 
-      - name: Run PHP CS Fixer
-        run: composer ci:test:php:cgl
+  pr-quality:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
 
-      - name: Run PHPLint
-        run: composer ci:test:php:lint
-
-      - name: Run PHPStan
-        run: composer ci:test:php:phpstan
-
-      - name: Run Rector
-        run: composer ci:test:php:rector
-
-  code-quality:
-    name: Code Quality
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
-        with:
-          php-version: '8.3'
-          extensions: mbstring, intl, json, dom, curl, xml, zip, opcache, gd
-          tools: composer:v2
-          coverage: xdebug
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: Run all tests
-        run: composer ci:test
-
-  compatibility-check:
-    name: PHP Compatibility Check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version:
-          - '8.1'
-          - '8.2'
-          - '8.3'
-          - '8.4'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl, json
-          tools: none
-          coverage: none
-
-      - name: Check PHP ${{ matrix.php-version }} syntax compatibility
-        run: |
-          echo "Checking PHP ${{ matrix.php-version }} compatibility..."
-          errors=0
-          
-          # Check Classes directory
-          if [ -d "Classes" ]; then
-            echo "Checking Classes directory..."
-            while IFS= read -r file; do
-              if ! php -l "$file" > /dev/null 2>&1; then
-                echo "Syntax error in: $file"
-                php -l "$file"
-                errors=$((errors + 1))
-              fi
-            done < <(find Classes -name "*.php" -type f)
-          fi
-          
-          # Check Configuration directory
-          if [ -d "Configuration" ]; then
-            echo "Checking Configuration directory..."
-            while IFS= read -r file; do
-              if ! php -l "$file" > /dev/null 2>&1; then
-                echo "Syntax error in: $file"
-                php -l "$file"
-                errors=$((errors + 1))
-              fi
-            done < <(find Configuration -name "*.php" -type f)
-          fi
-          
-          # Check root PHP files if they exist
-          for file in *.php; do
-            if [ -f "$file" ]; then
-              if ! php -l "$file" > /dev/null 2>&1; then
-                echo "Syntax error in: $file"
-                php -l "$file"
-                errors=$((errors + 1))
-              fi
-            fi
-          done
-          
-          if [ $errors -eq 0 ]; then
-            echo "✅ All PHP files are compatible with PHP ${{ matrix.php-version }}"
-          else
-            echo "❌ Found $errors file(s) with syntax errors"
-            exit 1
-          fi
+  labeler:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@ Welcome! This repository contains the TYPO3 extension **`nr_image_optimize`**, w
 
 ## Project Overview
 - **Purpose**: Serve processed variants of images (including WebP/AVIF fallbacks) and generate responsive `<img>` tags via Fluid ViewHelpers.
-- **Runtime**: TYPO3 12 (12.0–12.4.x) with PHP 8.1–8.4 and the Intervention Image library (Imagick driver). This is the TYPO3_12 maintenance branch; TYPO3 13.4 / 14 support lives on `main`.
+- **Runtime**: TYPO3 12 (12.0–12.4.x) with PHP 8.2–8.4 and the Intervention Image library (Imagick driver). This is the TYPO3_12 maintenance branch; TYPO3 13.4 / 14 support lives on `main`.
 - **Key Entry Points**:
     - `Classes/Processor.php`: parses `/processed/...` requests, applies resizing/cropping, encodes variants, and streams the response.
     - `Classes/Middleware/ProcessingMiddleware.php`: TYPO3 PSR-15 middleware that delegates matching requests to the processor.

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -31,13 +31,13 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR12'                          => true,
-        '@PER-CS2.0'                      => true,
+        '@PER-CS2x0'                      => true,
         '@Symfony'                        => true,
-        '@PHP80Migration'                 => true,
-        '@PHP81Migration'                 => true,
-        // Don't use PHP 8.2+ migration rules for compatibility
-        // '@PHP82Migration'              => true,
-        // '@PHP83Migration'              => true,
+        '@PHP8x0Migration'                => true,
+        '@PHP8x1Migration'                => true,
+        '@PHP8x2Migration'                => true,
+        // '@PHP8x3Migration'             => true,
+        // '@PHP8x4Migration'             => true,
 
         // Additional custom rules
         'declare_strict_types'            => true,

--- a/Build/FuzzTests.xml
+++ b/Build/FuzzTests.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd"
+         bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+         cacheDirectory="../.build/.phpunit.cache"
+         executionOrder="random"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Fuzz">
+            <directory>../Tests/Fuzz</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+    <source>
+        <include>
+            <directory>../Classes</directory>
+        </include>
+    </source>
+</phpunit>

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+
+#
+# TYPO3 Extension Test Runner for netresearch/nr-image-optimize
+#
+# Runs test suites and quality tools inside Docker containers using
+# ghcr.io/typo3/core-testing-* images. This ensures consistent environments
+# across local development and CI, including required PHP extensions
+# (GD, Imagick, etc.) that may not be available on the host.
+#
+# Based on the TYPO3 core runTests.sh pattern.
+#
+
+set -e
+
+# Extension root directory (two levels up from this script)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Network and container naming (per-run to avoid conflicts with concurrent runs)
+SUFFIX="$(date +%s%N)"
+NETWORK="nr-image-optimize-${SUFFIX}"
+
+# Defaults
+SUITE=""
+DBMS="sqlite"
+PHP_VERSION="8.4"
+EXTRA_TEST_OPTIONS=""
+XDEBUG=""
+UPDATE_IMAGES=""
+HELP=""
+
+# Container runtime: prefer docker, fall back to podman
+CONTAINER_BIN="docker"
+if ! command -v docker &>/dev/null; then
+    if command -v podman &>/dev/null; then
+        CONTAINER_BIN="podman"
+    else
+        echo "ERROR: Neither docker nor podman found in PATH." >&2
+        exit 1
+    fi
+fi
+
+# Detect non-TTY for CI environments
+CI_PARAMS=""
+if [ -t 0 ] && [ -t 1 ]; then
+    CI_PARAMS="-it"
+fi
+
+# Linux user handling to prevent root-owned files
+USERSET=""
+if [ "$(uname)" != "Darwin" ]; then
+    USERSET="--user $(id -u):$(id -g)"
+fi
+
+usage() {
+    cat << EOF
+TYPO3 Extension Test Runner — nr-image-optimize (Docker-based)
+
+Runs test suites and quality tools inside TYPO3 core-testing Docker containers.
+
+Usage: $(basename "$0") -s <suite> [options] [-- <extra-args>]
+
+Required:
+    -s <suite>      Test suite to run:
+                        unit          PHPUnit unit tests
+                        functional    PHPUnit functional tests
+                        acceptance    PHPUnit acceptance tests
+                        fuzz          PHPUnit fuzz/property-based tests
+                        mutation      Infection mutation testing (unit tests only)
+                        mutation-full Infection with unit+functional+acceptance tests
+                        lint          PHP syntax linting
+                        phpstan       PHPStan static analysis
+                        cgl           PHP-CS-Fixer (dry-run by default)
+                        cgl:fix       PHP-CS-Fixer (apply fixes)
+                        rector        Rector (dry-run by default)
+                        rector:fix    Rector (apply changes)
+                        fractor       Fractor (dry-run by default)
+                        fractor:fix   Fractor (apply changes)
+                        ci            Full CI suite (lint, cgl, phpstan, rector, fractor, unit)
+                        all           All tests and quality checks
+
+Options:
+    -p <version>    PHP version: 8.2, 8.3, 8.4, 8.5 (default: ${PHP_VERSION})
+    -d <dbms>       Database for functional tests:
+                        sqlite    (default) SQLite via pdo_sqlite
+                        mariadb   MariaDB 10
+                        mysql     MySQL 8.0
+                        postgres  PostgreSQL 16
+    -x              Enable Xdebug (for debugging test runs)
+    -u              Pull latest Docker images before running
+    -h              Show this help message
+
+    --              All arguments after -- are passed to the underlying tool
+                    (e.g., -- --filter=testMethodName for PHPUnit)
+
+Examples:
+    $(basename "$0") -s unit
+    $(basename "$0") -s functional -d mariadb
+    $(basename "$0") -s phpstan -p 8.3
+    $(basename "$0") -s cgl                    # dry-run (default)
+    $(basename "$0") -s cgl:fix                # apply fixes
+    $(basename "$0") -s unit -x                # with Xdebug
+    $(basename "$0") -s unit -- --filter=testFoo
+    $(basename "$0") -s ci
+    $(basename "$0") -s all -u                 # update images first
+
+EOF
+}
+
+# Parse options. Everything after -- goes to EXTRA_TEST_OPTIONS.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -s) SUITE="$2"; shift 2 ;;
+        -p) PHP_VERSION="$2"; shift 2 ;;
+        -d) DBMS="$2"; shift 2 ;;
+        -x) XDEBUG="yes"; shift ;;
+        -u) UPDATE_IMAGES="yes"; shift ;;
+        -h) HELP="yes"; shift ;;
+        --) shift; EXTRA_TEST_OPTIONS="$*"; break ;;
+        *)  echo "ERROR: Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [ "${HELP}" = "yes" ]; then
+    usage
+    exit 0
+fi
+
+if [ -z "${SUITE}" ]; then
+    echo "ERROR: Missing required -s <suite> argument." >&2
+    echo ""
+    usage
+    exit 1
+fi
+
+# Validate PHP version
+case "${PHP_VERSION}" in
+    8.2|8.3|8.4|8.5) ;;
+    *) echo "ERROR: Unsupported PHP version: ${PHP_VERSION}. Supported: 8.2, 8.3, 8.4, 8.5" >&2; exit 1 ;;
+esac
+
+# Validate DBMS
+case "${DBMS}" in
+    sqlite|mariadb|mysql|postgres) ;;
+    *) echo "ERROR: Unsupported database: ${DBMS}. Supported: sqlite, mariadb, mysql, postgres" >&2; exit 1 ;;
+esac
+
+# Docker images
+IMAGE_PHP="ghcr.io/typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
+IMAGE_ALPINE="docker.io/alpine:3.8"
+IMAGE_MARIADB="docker.io/mariadb:10"
+IMAGE_MYSQL="docker.io/mysql:8.0"
+IMAGE_POSTGRES="docker.io/postgres:16-alpine"
+
+# Update images if requested
+if [ "${UPDATE_IMAGES}" = "yes" ]; then
+    echo "Pulling latest Docker images..."
+    ${CONTAINER_BIN} pull "${IMAGE_PHP}"
+    case "${DBMS}" in
+        mariadb)  ${CONTAINER_BIN} pull "${IMAGE_MARIADB}" ;;
+        mysql)    ${CONTAINER_BIN} pull "${IMAGE_MYSQL}" ;;
+        postgres) ${CONTAINER_BIN} pull "${IMAGE_POSTGRES}" ;;
+    esac
+    echo ""
+fi
+
+# Common container parameters
+CONTAINER_COMMON_PARAMS="--rm ${CI_PARAMS} --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+
+# Xdebug environment
+XDEBUG_MODE=""
+XDEBUG_CONFIG=""
+if [ "${XDEBUG}" = "yes" ]; then
+    XDEBUG_MODE="-e XDEBUG_MODE=debug"
+    XDEBUG_CONFIG="client_host=host.docker.internal"
+fi
+
+SUITE_EXIT_CODE=0
+
+#
+# Wait for a TCP port inside the Docker network by running nc from an Alpine container.
+# Follows the TYPO3 core pattern.
+#
+waitFor() {
+    local HOST=${1}
+    local PORT=${2}
+    local TESTCOMMAND="
+        COUNT=0;
+        while ! nc -z ${HOST} ${PORT}; do
+            if [ \"\${COUNT}\" -gt 10 ]; then
+                echo \"Can not connect to ${HOST} port ${PORT}. Aborting.\";
+                exit 1;
+            fi;
+            sleep 1;
+            COUNT=\$((COUNT + 1));
+        done;
+    "
+    ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name wait-for-${SUFFIX} ${IMAGE_ALPINE} /bin/sh -c "${TESTCOMMAND}"
+    if [[ $? -gt 0 ]]; then
+        kill -SIGINT -$$
+    fi
+}
+
+#
+# Clean up containers attached to the test network and remove the network.
+#
+cleanUp() {
+    ATTACHED_CONTAINERS=$(${CONTAINER_BIN} ps --filter network=${NETWORK} --format='{{.Names}}' 2>/dev/null)
+    for ATTACHED_CONTAINER in ${ATTACHED_CONTAINERS}; do
+        ${CONTAINER_BIN} kill "${ATTACHED_CONTAINER}" >/dev/null 2>&1 || true
+    done
+    ${CONTAINER_BIN} network rm "${NETWORK}" 2>/dev/null || true
+}
+
+# Ensure cleanup on exit
+trap cleanUp EXIT
+
+# Create the Docker network (ignore error if it already exists)
+${CONTAINER_BIN} network create "${NETWORK}" 2>/dev/null || true
+
+# --- Suite execution ---
+
+case "${SUITE}" in
+    unit)
+        # shellcheck disable=SC2086
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name unit-${SUFFIX} \
+            ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" \
+            ${IMAGE_PHP} php .build/bin/phpunit -c Build/UnitTests.xml ${EXTRA_TEST_OPTIONS}
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    functional)
+        case "${DBMS}" in
+            sqlite)
+                # shellcheck disable=SC2086
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name functional-${SUFFIX} \
+                    ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" \
+                    -e typo3DatabaseDriver=pdo_sqlite \
+                    ${IMAGE_PHP} php .build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS}
+                SUITE_EXIT_CODE=$?
+                ;;
+            mariadb)
+                ${CONTAINER_BIN} run --rm ${CI_PARAMS} --name mariadb-func-${SUFFIX} --network ${NETWORK} \
+                    -d -e MYSQL_ROOT_PASSWORD=funcp \
+                    --tmpfs /var/lib/mysql/:rw,noexec,nosuid \
+                    ${IMAGE_MARIADB} >/dev/null
+                waitFor mariadb-func-${SUFFIX} 3306
+                # shellcheck disable=SC2086
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name functional-${SUFFIX} \
+                    ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" \
+                    -e typo3DatabaseDriver=mysqli \
+                    -e typo3DatabaseName=func_test \
+                    -e typo3DatabaseUsername=root \
+                    -e typo3DatabaseHost=mariadb-func-${SUFFIX} \
+                    -e typo3DatabasePassword=funcp \
+                    ${IMAGE_PHP} php .build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS}
+                SUITE_EXIT_CODE=$?
+                ;;
+            mysql)
+                ${CONTAINER_BIN} run --rm ${CI_PARAMS} --name mysql-func-${SUFFIX} --network ${NETWORK} \
+                    -d -e MYSQL_ROOT_PASSWORD=funcp \
+                    --tmpfs /var/lib/mysql/:rw,noexec,nosuid \
+                    ${IMAGE_MYSQL} >/dev/null
+                waitFor mysql-func-${SUFFIX} 3306
+                # shellcheck disable=SC2086
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name functional-${SUFFIX} \
+                    ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" \
+                    -e typo3DatabaseDriver=mysqli \
+                    -e typo3DatabaseName=func_test \
+                    -e typo3DatabaseUsername=root \
+                    -e typo3DatabaseHost=mysql-func-${SUFFIX} \
+                    -e typo3DatabasePassword=funcp \
+                    ${IMAGE_PHP} php .build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS}
+                SUITE_EXIT_CODE=$?
+                ;;
+            postgres)
+                ${CONTAINER_BIN} run --rm ${CI_PARAMS} --name postgres-func-${SUFFIX} --network ${NETWORK} \
+                    -d -e POSTGRES_PASSWORD=funcp -e POSTGRES_USER=funcu \
+                    --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid \
+                    ${IMAGE_POSTGRES} >/dev/null
+                waitFor postgres-func-${SUFFIX} 5432
+                # shellcheck disable=SC2086
+                ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name functional-${SUFFIX} \
+                    ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" \
+                    -e typo3DatabaseDriver=pdo_pgsql \
+                    -e typo3DatabaseName=bamboo \
+                    -e typo3DatabaseUsername=funcu \
+                    -e typo3DatabaseHost=postgres-func-${SUFFIX} \
+                    -e typo3DatabasePassword=funcp \
+                    ${IMAGE_PHP} php .build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS}
+                SUITE_EXIT_CODE=$?
+                ;;
+        esac
+        ;;
+
+    acceptance)
+        # shellcheck disable=SC2086
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name acceptance-${SUFFIX} \
+            ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" \
+            ${IMAGE_PHP} php .build/bin/phpunit -c Build/AcceptanceTests.xml ${EXTRA_TEST_OPTIONS}
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    fuzz)
+        # shellcheck disable=SC2086
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name fuzz-${SUFFIX} \
+            ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" \
+            ${IMAGE_PHP} php .build/bin/phpunit -c Build/FuzzTests.xml --no-coverage ${EXTRA_TEST_OPTIONS}
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    mutation)
+        # shellcheck disable=SC2086
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name mutation-${SUFFIX} \
+            -e XDEBUG_MODE=coverage \
+            ${IMAGE_PHP} php .build/bin/infection \
+            --configuration=infection.json5 --threads=4 --no-progress --show-mutations ${EXTRA_TEST_OPTIONS}
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    mutation-full)
+        # Mutation testing with unit + functional + acceptance tests.
+        # Uses the combined PHPUnit config (Build/Infection/phpunit.xml).
+        # shellcheck disable=SC2086
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name mutation-full-${SUFFIX} \
+            -e XDEBUG_MODE=coverage -e typo3DatabaseDriver=pdo_sqlite \
+            ${IMAGE_PHP} php .build/bin/infection \
+            --configuration=infection-full.json5 --threads=4 --no-progress --show-mutations ${EXTRA_TEST_OPTIONS}
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    lint)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name lint-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/phplint --configuration Build/.phplint.yml
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    phpstan)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name phpstan-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/phpstan analyse -c Build/phpstan.neon --memory-limit=-1
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    cgl)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name cgl-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/php-cs-fixer fix \
+            --dry-run --diff --verbose \
+            --config=Build/.php-cs-fixer.dist.php \
+            --cache-file .build/.php-cs-fixer.cache
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    cgl:fix)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name cgl-fix-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/php-cs-fixer fix \
+            --diff --verbose \
+            --config=Build/.php-cs-fixer.dist.php \
+            --cache-file .build/.php-cs-fixer.cache
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    rector)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name rector-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/rector process --config Build/rector.php --dry-run
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    rector:fix)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name rector-fix-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/rector process --config Build/rector.php
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    fractor)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name fractor-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/fractor process --config Build/fractor.php --dry-run
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    fractor:fix)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} ${USERSET} --name fractor-fix-${SUFFIX} \
+            ${IMAGE_PHP} php .build/bin/fractor process --config Build/fractor.php
+        SUITE_EXIT_CODE=$?
+        ;;
+
+    ci)
+        echo "=== CI Suite ==="
+        echo ""
+        for s in lint cgl phpstan rector fractor unit; do
+            echo "--- Running: ${s} ---"
+            "${BASH_SOURCE[0]}" -s "${s}" -p "${PHP_VERSION}" || SUITE_EXIT_CODE=$?
+            if [ ${SUITE_EXIT_CODE} -ne 0 ]; then
+                echo "FAILED: ${s} (exit code ${SUITE_EXIT_CODE})"
+                exit ${SUITE_EXIT_CODE}
+            fi
+            echo ""
+        done
+        echo "=== CI Suite completed ==="
+        ;;
+
+    all)
+        echo "=== Full Suite ==="
+        echo ""
+        for s in lint cgl phpstan rector fractor unit functional acceptance; do
+            echo "--- Running: ${s} ---"
+            "${BASH_SOURCE[0]}" -s "${s}" -p "${PHP_VERSION}" -d "${DBMS}" || SUITE_EXIT_CODE=$?
+            if [ ${SUITE_EXIT_CODE} -ne 0 ]; then
+                echo "FAILED: ${s} (exit code ${SUITE_EXIT_CODE})"
+                exit ${SUITE_EXIT_CODE}
+            fi
+            echo ""
+        done
+        echo "=== Full Suite completed ==="
+        ;;
+
+    *)
+        echo "ERROR: Unknown suite: ${SUITE}" >&2
+        echo ""
+        usage
+        exit 1
+        ;;
+esac
+
+exit ${SUITE_EXIT_CODE}

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -148,7 +148,7 @@ esac
 
 # Docker images
 IMAGE_PHP="ghcr.io/typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
-IMAGE_ALPINE="docker.io/alpine:3.8"
+IMAGE_ALPINE="docker.io/alpine:3.22"
 IMAGE_MARIADB="docker.io/mariadb:10"
 IMAGE_MYSQL="docker.io/mysql:8.0"
 IMAGE_POSTGRES="docker.io/postgres:16-alpine"

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1,16 +1,427 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Netresearch\\\\NrImageOptimize\\\\Controller\\\\MaintenanceController\\:\\:buildLargestFiles\\(\\) should return array\\<int, array\\{name\\: string, path\\: string, size\\: int, sizeHuman\\: string\\}\\> but returns array\\<int, array\\{name\\: string, path\\: string, size\\: int\\}\\>\\.$#"
-			count: 1
-			path: ../Classes/Controller/MaintenanceController.php
+			message: '#^Binary operation "\+\=" between \(float\|int\) and mixed results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 2
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
 
 		-
-			message: "#^Method Netresearch\\\\NrImageOptimize\\\\Controller\\\\MaintenanceController\\:\\:getDirectoryStats\\(\\) should return array\\{count\\: int, size\\: int, directories\\: int, largestFiles\\: array\\<int, array\\{name\\: string, path\\: string, size\\: int, sizeHuman\\: string\\}\\>, fileTypes\\: array\\<string, array\\{count\\: int, size\\: int, sizeHuman\\: string\\}\\>, oldestFile\\: array\\{name\\: string, mtime\\: int, date\\: string\\}\\|null, newestFile\\: array\\{name\\: string, mtime\\: int, date\\: string\\}\\|null\\} but returns array\\{count\\: int\\<0, max\\>, size\\: \\(float\\|int\\), directories\\: int\\<0, max\\>, largestFiles\\: array\\<int, array\\{name\\: string, path\\: string, size\\: int, sizeHuman\\: string\\}\\>, fileTypes\\: array\\<string, array\\{count\\: int\\<1, max\\>, size\\: \\(float\\|int\\)\\}\\>, oldestFile\\: array\\{name\\: string, mtime\\: int, date\\: string\\}\\|null, newestFile\\: array\\{name\\: string, mtime\\: int, date\\: string\\}\\|null\\}\\.$#"
+			message: '#^Cannot call method getExtension\(\) on mixed\.$#'
+			identifier: method.nonObject
 			count: 1
-			path: ../Classes/Controller/MaintenanceController.php
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between non\\-falsy\\-string and '' will always evaluate to false\\.$#"
+			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Cannot call method getMTime\(\) on mixed\.$#'
+			identifier: method.nonObject
 			count: 1
-			path: ../Classes/ViewHelpers/SourceSetViewHelper.php
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Cannot call method getPathname\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Cannot call method getSize\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Cannot call method isDir\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Cannot call method isFile\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Parameter \#1 \$files of method Netresearch\\NrImageOptimize\\Controller\\MaintenanceController\:\:buildLargestFiles\(\) expects list\<array\{name\: string, path\: string, size\: int\}\>, list\<array\{name\: mixed, path\: string, size\: mixed\}\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Parameter \#1 \$user of method TYPO3\\CMS\\Core\\Localization\\LanguageServiceFactory\:\:createFromUserPreferences\(\) expects TYPO3\\CMS\\Core\\Authentication\\AbstractUserAuthentication\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Parameter \#2 \$filename of method Netresearch\\NrImageOptimize\\Controller\\MaintenanceController\:\:updateTimestampRecord\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Parameter \#3 \$mtime of method Netresearch\\NrImageOptimize\\Controller\\MaintenanceController\:\:updateTimestampRecord\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+
+		-
+			message: '#^Method Netresearch\\NrImageOptimize\\Service\\SystemRequirementsService\:\:findVersionFromComposerLock\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+
+		-
+			message: '#^Method Netresearch\\NrImageOptimize\\Service\\SystemRequirementsService\:\:findVersionFromInstalledJson\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+
+		-
+			message: '#^Parameter \#2 \$current of method Netresearch\\NrImageOptimize\\Service\\SystemRequirementsService\:\:makeItem\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Method Netresearch\\NrImageOptimize\\ViewHelpers\\SourceSetViewHelper\:\:getArgPath\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Method Netresearch\\NrImageOptimize\\ViewHelpers\\SourceSetViewHelper\:\:getArgSet\(\) should return array\<array\<int\>\> but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Method Netresearch\\NrImageOptimize\\ViewHelpers\\SourceSetViewHelper\:\:getAttributes\(\) should return array\<string, bool\|float\|int\|string\> but returns array\<mixed, mixed\>\.$#'
+			identifier: return.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(mixed\)\: mixed\)\|null, Closure\(array\|bool\|float\|GMP\|int\|resource\|SimpleXMLElement\|string\|null, int\=\)\: int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Parameter \#1 \$num of function floor expects float\|int, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Parameter \#1 \$props of method Netresearch\\NrImageOptimize\\ViewHelpers\\SourceSetViewHelper\:\:filterEmptyAttributes\(\) expects array\<string, int\|string\|null\>, array\<string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-falsy\-string and '''' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+
+		-
+			message: '#^Cannot call method getHeaderLine\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Cannot call method getRealPath\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Cannot call method getStatusCode\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Cannot call method isDir\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Acceptance\\Middleware\\ProcessingMiddlewareRoutingTest has an uninitialized property \$publicPath\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Acceptance\\Middleware\\ProcessingMiddlewareRoutingTest has an uninitialized property \$responseFactory\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Acceptance\\Middleware\\ProcessingMiddlewareRoutingTest has an uninitialized property \$streamFactory\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Acceptance\\Middleware\\ProcessingMiddlewareRoutingTest has an uninitialized property \$tempDir\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Parameter \#1 \$directory of function rmdir expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Parameter \#1 \$filename of function unlink expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Parameter \#2 \$string of static method PHPUnit\\Framework\\Assert\:\:assertMatchesRegularExpression\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Acceptance\\ViewHelpers\\SourceSetViewHelperHtmlOutputTest has an uninitialized property \$viewHelper\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Acceptance/ViewHelpers/SourceSetViewHelperHtmlOutputTest.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Functional/ProcessorTest.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Fuzz/ProcessorFuzzTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Fuzz\\ProcessorFuzzTest has an uninitialized property \$processor\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Fuzz/ProcessorFuzzTest.php
+
+		-
+			message: '#^Parameter \#2 \$string of static method PHPUnit\\Framework\\Assert\:\:assertStringStartsWith\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Fuzz/ProcessorFuzzTest.php
+
+		-
+			message: '#^Parameter \#3 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Fuzz/ProcessorFuzzTest.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Cannot call method getPathname\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Cannot call method isDir\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\Controller\\MaintenanceControllerTest has an uninitialized property \$controller\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\Controller\\MaintenanceControllerTest has an uninitialized property \$tempDir\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_keys expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Parameter \#1 \$directory of function rmdir expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Parameter \#1 \$filename of function unlink expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: %currentWorkingDirectory%/Tests/Unit/Controller/MaintenanceControllerTest.php
+
+		-
+			message: '#^Cannot call method getPathname\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Cannot call method isDir\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\ProcessorTest has an uninitialized property \$lockFactory\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\ProcessorTest has an uninitialized property \$processor\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\ProcessorTest has an uninitialized property \$responseFactory\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\ProcessorTest has an uninitialized property \$storageRepository\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\ProcessorTest has an uninitialized property \$streamFactory\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Parameter \#1 \$directory of function rmdir expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Parameter \#1 \$filename of function unlink expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ProcessorTest.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: %currentWorkingDirectory%/Tests/Unit/Service/SystemRequirementsServiceTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\Service\\SystemRequirementsServiceTest has an uninitialized property \$service\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/Service/SystemRequirementsServiceTest.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_column expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: %currentWorkingDirectory%/Tests/Unit/Service/SystemRequirementsServiceTest.php
+
+		-
+			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
+			identifier: argument.type
+			count: 5
+			path: %currentWorkingDirectory%/Tests/Unit/Service/SystemRequirementsServiceTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of function in_array expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/Service/SystemRequirementsServiceTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
+			identifier: argument.type
+			count: 5
+			path: %currentWorkingDirectory%/Tests/Unit/Service/SystemRequirementsServiceTest.php
+
+		-
+			message: '#^Class Netresearch\\NrImageOptimize\\Tests\\Unit\\ViewHelpers\\SourceSetViewHelperTest has an uninitialized property \$viewHelper\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: %currentWorkingDirectory%/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -12,7 +12,12 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingCallableSignature: true
     checkUninitializedProperties: true
-    reportUnmatchedIgnoredErrors: true
+    # reportUnmatchedIgnoredErrors stays off on this branch while the
+    # 71-entry baseline is being reduced. Stale entries are silently
+    # tolerated instead of blocking CI — they will be pruned as the
+    # baseline shrinks in follow-up PRs. Main keeps it on because its
+    # baseline is empty.
+    reportUnmatchedIgnoredErrors: false
 
     paths:
         - %currentWorkingDirectory%/Classes/

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -1,29 +1,52 @@
 includes:
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/friendsoftypo3/phpstan-typo3/extension.neon
-    - %currentWorkingDirectory%/Build/phpstan-baseline.neon
+    - phpstan-baseline.neon
 
 parameters:
-    # You can currently choose from 10 levels (0 is the loosest and 9 is the strictest).
-    level: 8
+    # Level 10 (maximum strictness) — matches typo3-ci-workflows shared config
+    level: 10
 
-    # PHP Version to check against (PHP 8.1 as minimum target)
-    phpVersion: 80100
+    # PHP Version to check against (PHP 8.2 as minimum target on this branch)
+    phpVersion: 80200
+
+    treatPhpDocTypesAsCertain: false
+    inferPrivatePropertyTypeFromConstructor: true
+    checkMissingCallableSignature: true
+    checkUninitializedProperties: true
+    reportUnmatchedIgnoredErrors: true
 
     paths:
         - %currentWorkingDirectory%/Classes/
         - %currentWorkingDirectory%/Configuration/
         - %currentWorkingDirectory%/Resources/
+        - %currentWorkingDirectory%/Tests/
 
     excludePaths:
         - %currentWorkingDirectory%/.build/*
         - %currentWorkingDirectory%/ext_emconf.php
 
-    treatPhpDocTypesAsCertain: false
-    reportMaybesInPropertyPhpDocTypes: false
-    
-    # Standard checks that work with PHP 8.1+
-    checkGenericClassInNonGenericObjectType: true
-    checkMissingIterableValueType: true
-    reportUnmatchedIgnoredErrors: true
+    tmpDir: %currentWorkingDirectory%/.build/var/phpstan
+
+    ignoreErrors:
+        # --- Test infrastructure (from shared config) ---
+        - identifier: offsetAccess.nonOffsetAccessible
+          path: %currentWorkingDirectory%/Tests/Unit/*
+          reportUnmatched: false
+        - identifier: argument.type
+          path: %currentWorkingDirectory%/Tests/Unit/*
+          message: '#Parameter \#2 \$array of static method PHPUnit\\Framework\\Assert::#'
+          reportUnmatched: false
+        - identifier: cast.int
+          path: %currentWorkingDirectory%/Tests/Functional/*
+          reportUnmatched: false
+        - identifier: argument.type
+          path: %currentWorkingDirectory%/Tests/Functional/*
+          message: '#mixed#'
+          reportUnmatched: false
+        - identifier: assign.propertyType
+          path: %currentWorkingDirectory%/Tests/Functional/*
+          message: '#mixed#'
+          reportUnmatched: false
+        - identifier: method.nonObject
+          path: %currentWorkingDirectory%/Tests/Functional/*
+          message: '#mixed#'
+          reportUnmatched: false

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -34,8 +34,8 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->removeUnusedImports();
     $rectorConfig->disableParallel();
 
-    // Set PHP version to target (PHP 8.1 minimum for compatibility)
-    $rectorConfig->phpVersion(80100);
+    // Set PHP version to target (PHP 8.2 minimum on this branch)
+    $rectorConfig->phpVersion(80200);
 
     // Define what rule sets will be applied
     $rectorConfig->sets([
@@ -48,8 +48,8 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::STRICT_BOOLEANS,
         SetList::TYPE_DECLARATION,
 
-        // Only use PHP 8.1 features for maximum compatibility
-        LevelSetList::UP_TO_PHP_81,
+        // Only use PHP 8.2 features for maximum compatibility
+        LevelSetList::UP_TO_PHP_82,
 
         Typo3LevelSetList::UP_TO_TYPO3_12,
     ]);

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -310,7 +310,14 @@ class Processor
         $fileSize  = filesize($filePath);
         $fileMtime = filemtime($filePath);
 
-        if ($fileSize === false) {
+        // Treat 0-byte variant files as "not present" so buildOutputResponse's
+        // AVIF -> WebP -> primary fallback chain skips over them. Empty
+        // variant files occur when a driver silently writes nothing (most
+        // often: Imagick builds without AVIF encoder support leave an empty
+        // .avif next to a valid PNG). Returning that empty file to the
+        // client is strictly worse than falling back to the format that
+        // actually has pixels.
+        if ($fileSize === false || $fileSize === 0) {
             return null;
         }
 

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -566,6 +566,8 @@ class Processor
         $allowedRoots = $this->getAllowedRoots();
 
         if ($allowedRoots === []) {
+            error_log(sprintf('[nr_image_optimize DEBUG] isPathWithinAllowedRoots: path=%s  allowedRoots=EMPTY', $path));
+
             return false;
         }
 
@@ -573,7 +575,17 @@ class Processor
         $resolvedPath = realpath($path);
 
         if ($resolvedPath !== false) {
-            return $this->isWithinAnyRoot($resolvedPath, $allowedRoots);
+            $ok = $this->isWithinAnyRoot($resolvedPath, $allowedRoots);
+            if (!$ok) {
+                error_log(sprintf(
+                    '[nr_image_optimize DEBUG] isPathWithinAllowedRoots REJECTED: path=%s  realpath=%s  allowedRoots=%s',
+                    $path,
+                    $resolvedPath,
+                    implode(';', $allowedRoots),
+                ));
+            }
+
+            return $ok;
         }
 
         // For paths that do not yet exist (variant files), resolve the

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -271,22 +271,31 @@ class Processor
      */
     private function serveCachedVariant(string $pathVariant, string $extension): ?ResponseInterface
     {
-        // Prefer AVIF, then WebP, then the original format
-        if (!$this->isAvifImage($extension) && file_exists($pathVariant . '.avif')) {
-            return $this->buildFileResponse($pathVariant . '.avif', 'image/avif');
+        // Prefer AVIF, then WebP, then the original format. Each step falls
+        // through to the next when buildFileResponse returns null — which it
+        // does for missing AND for 0-byte files (see buildFileResponse). That
+        // matters when e.g. Imagick silently writes an empty .avif because
+        // the encoder isn't installed: we must not short-circuit on the empty
+        // file and skip a valid WebP/primary that's also on disk.
+        if (!$this->isAvifImage($extension)) {
+            $response = $this->buildFileResponse($pathVariant . '.avif', 'image/avif');
+
+            if ($response instanceof ResponseInterface) {
+                return $response;
+            }
         }
 
-        if (!$this->isWebpImage($extension) && file_exists($pathVariant . '.webp')) {
-            return $this->buildFileResponse($pathVariant . '.webp', 'image/webp');
+        if (!$this->isWebpImage($extension)) {
+            $response = $this->buildFileResponse($pathVariant . '.webp', 'image/webp');
+
+            if ($response instanceof ResponseInterface) {
+                return $response;
+            }
         }
 
-        if (file_exists($pathVariant)) {
-            $mimeType = self::EXTENSION_MIME_MAP[$extension] ?? 'application/octet-stream';
+        $mimeType = self::EXTENSION_MIME_MAP[$extension] ?? 'application/octet-stream';
 
-            return $this->buildFileResponse($pathVariant, $mimeType);
-        }
-
-        return null;
+        return $this->buildFileResponse($pathVariant, $mimeType);
     }
 
     /**

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -133,23 +133,26 @@ class Processor
     private const MODE_PATTERN = '/([hwqm])(\d+)/';
 
     /**
-     * Cached list of absolute filesystem roots (realpath-resolved) under which
-     * image paths are considered safe. Populated on first call to
-     * getAllowedRoots() and reused across requests in the same PHP process.
+     * Cached lists of absolute filesystem roots (realpath-resolved) under
+     * which image paths are considered safe, keyed by the TYPO3 public path
+     * that was in effect when each list was computed.
      *
-     * Contains the TYPO3 public path plus the basePath of every Local-driver
-     * FAL storage, each resolved through realpath so that legitimately
-     * symlinked storage directories (e.g. fileadmin on an NFS/EFS mount) are
-     * recognised as allowed. Any symlink inside a storage that points to a
-     * location outside these roots is rejected.
+     * Each entry contains the public path plus the basePath of every
+     * Local-driver FAL storage, each resolved through realpath so that
+     * legitimately symlinked storage directories (e.g. fileadmin on an
+     * NFS/EFS mount) are recognised as allowed. Any symlink inside a storage
+     * that points to a location outside these roots is rejected.
      *
-     * Because the cache persists for the life of the PHP process, tests must
-     * reset it between cases via reflection — see
-     * ProcessorTest::resetAllowedRootsCache().
+     * Keying by public path auto-invalidates the cache when the public path
+     * changes — matters for TYPO3 functional tests (each test instance has
+     * its own typo3temp/var/tests/functional-XXXX/ root) and long-running
+     * worker setups (FrankenPHP, swoole, RoadRunner) that might reinitialise
+     * Environment between handler invocations. In a normal HTTP request the
+     * public path is constant, so this degenerates to a single-entry cache.
      *
-     * @var list<string>|null
+     * @var array<string, list<string>>
      */
-    private static ?array $resolvedAllowedRoots = null;
+    private static array $resolvedAllowedRootsByPublicPath = [];
 
     /**
      * Initialize the image processor with all required dependencies.
@@ -566,8 +569,6 @@ class Processor
         $allowedRoots = $this->getAllowedRoots();
 
         if ($allowedRoots === []) {
-            error_log(sprintf('[nr_image_optimize DEBUG] isPathWithinAllowedRoots: path=%s  allowedRoots=EMPTY', $path));
-
             return false;
         }
 
@@ -575,17 +576,7 @@ class Processor
         $resolvedPath = realpath($path);
 
         if ($resolvedPath !== false) {
-            $ok = $this->isWithinAnyRoot($resolvedPath, $allowedRoots);
-            if (!$ok) {
-                error_log(sprintf(
-                    '[nr_image_optimize DEBUG] isPathWithinAllowedRoots REJECTED: path=%s  realpath=%s  allowedRoots=%s',
-                    $path,
-                    $resolvedPath,
-                    implode(';', $allowedRoots),
-                ));
-            }
-
-            return $ok;
+            return $this->isWithinAnyRoot($resolvedPath, $allowedRoots);
         }
 
         // For paths that do not yet exist (variant files), resolve the
@@ -653,13 +644,14 @@ class Processor
      */
     private function getAllowedRoots(): array
     {
-        if (self::$resolvedAllowedRoots !== null) {
-            return self::$resolvedAllowedRoots;
+        $publicPathRaw = Environment::getPublicPath();
+
+        if (isset(self::$resolvedAllowedRootsByPublicPath[$publicPathRaw])) {
+            return self::$resolvedAllowedRootsByPublicPath[$publicPathRaw];
         }
 
-        $roots         = [];
-        $publicPathRaw = Environment::getPublicPath();
-        $publicPath    = realpath($publicPathRaw);
+        $roots      = [];
+        $publicPath = realpath($publicPathRaw);
 
         if ($publicPath !== false) {
             $roots[$publicPath] = true;
@@ -706,9 +698,11 @@ class Processor
             ));
         }
 
-        self::$resolvedAllowedRoots = array_keys($roots);
+        $resolved = array_keys($roots);
 
-        return self::$resolvedAllowedRoots;
+        self::$resolvedAllowedRootsByPublicPath[$publicPathRaw] = $resolved;
+
+        return $resolved;
     }
 
     /**

--- a/Classes/Service/SystemRequirementsService.php
+++ b/Classes/Service/SystemRequirementsService.php
@@ -48,7 +48,7 @@ final class SystemRequirementsService
     /**
      * Minimum required PHP version.
      */
-    private const MIN_PHP_VERSION = '8.1.0';
+    private const MIN_PHP_VERSION = '8.2.0';
 
     /**
      * Minimum required TYPO3 version.

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -33,6 +33,11 @@ Unreleased
     default in TYPO3 12+) are unaffected; any code that
     extends the class or constructs it by hand must
     forward the new dependency.
+-   Changed (BC): dropped PHP 8.1 support. The TYPO3_12
+    maintenance branch now requires PHP 8.2 or newer
+    (TYPO3 v12 itself still supports PHP 8.1, but this
+    extension aligns with the ``netresearch/typo3-ci-workflows``
+    tooling which requires PHP 8.2+).
 
 ..  _changelog-1-1-0:
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -50,7 +50,7 @@ Features
 Requirements
 ============
 
--   PHP 8.1, 8.2, 8.3, or 8.4.
+-   PHP 8.2, 8.3, or 8.4.
 -   TYPO3 12.4.
 -   Intervention Image library 3.11+ (installed automatically
     via Composer).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TYPO3 Extension: nr_image_optimize
 
-[![PHP](https://img.shields.io/badge/PHP-8.1%20|%208.2%20|%208.3%20|%208.4-blue.svg)](https://www.php.net/)
+[![PHP](https://img.shields.io/badge/PHP-8.2%20|%208.3%20|%208.4-blue.svg)](https://www.php.net/)
 [![TYPO3](https://img.shields.io/badge/TYPO3-12-orange.svg)](https://typo3.org/)
 [![License](https://img.shields.io/badge/License-GPL%203.0-green.svg)](LICENSE)
 
@@ -17,7 +17,7 @@ Advanced image optimization extension for TYPO3 CMS that provides lazy image pro
 
 ## Requirements
 
-- PHP 8.1, 8.2, 8.3, or 8.4
+- PHP 8.2, 8.3, or 8.4
 - TYPO3 12.x
 - Intervention Image library (automatically installed via Composer)
 

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
     :target: https://github.com/netresearch/t3x-nr-image-optimize/blob/main/LICENSE
 ..  |ci| image:: https://github.com/netresearch/t3x-nr-image-optimize/actions/workflows/ci.yml/badge.svg
     :target: https://github.com/netresearch/t3x-nr-image-optimize/actions/workflows/ci.yml
-..  |php| image:: https://img.shields.io/badge/PHP-8.1%20|%208.2%20|%208.3%20|%208.4-blue.svg
+..  |php| image:: https://img.shields.io/badge/PHP-8.2%20|%208.3%20|%208.4-blue.svg
     :target: https://www.php.net/
 ..  |typo3| image:: https://img.shields.io/badge/TYPO3-12-orange.svg
     :target: https://typo3.org/
@@ -44,7 +44,7 @@ Features
 Requirements
 ============
 
--   PHP 8.1, 8.2, 8.3, or 8.4.
+-   PHP 8.2, 8.3, or 8.4.
 -   TYPO3 12.
 -   Intervention Image library (installed via Composer
     automatically).

--- a/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
+++ b/Tests/Acceptance/Middleware/ProcessingMiddlewareRoutingTest.php
@@ -304,8 +304,8 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         // Content-Length header present
         self::assertNotEmpty($response->getHeaderLine('Content-Length'));
 
-        unlink($variantFile);
-        unlink($originalFile);
+        unlink($variantFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($originalFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -326,9 +326,9 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('image/avif', $response->getHeaderLine('Content-Type'));
 
-        unlink($variantFile . '.avif');
-        unlink($variantFile);
-        unlink($originalFile);
+        unlink($variantFile . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($variantFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($originalFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -349,9 +349,9 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('image/webp', $response->getHeaderLine('Content-Type'));
 
-        unlink($variantFile . '.webp');
-        unlink($variantFile);
-        unlink($originalFile);
+        unlink($variantFile . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($variantFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($originalFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // ──────────────────────────────────────────────────
@@ -374,7 +374,7 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         $etag = $response->getHeaderLine('ETag');
         self::assertMatchesRegularExpression('/^"[a-f0-9]{32}"$/', $etag, 'ETag should be a quoted MD5 hash.');
 
-        unlink($testFile);
+        unlink($testFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -393,7 +393,7 @@ class ProcessingMiddlewareRoutingTest extends TestCase
         $lastModified = $response->getHeaderLine('Last-Modified');
         self::assertStringContainsString('GMT', $lastModified);
 
-        unlink($testFile);
+        unlink($testFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // ──────────────────────────────────────────────────
@@ -482,7 +482,7 @@ class ProcessingMiddlewareRoutingTest extends TestCase
             if ($item->isDir()) {
                 @rmdir($item->getRealPath());
             } else {
-                @unlink($item->getRealPath());
+                @unlink($item->getRealPath()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Functional/Middleware/ProcessingMiddlewareTest.php
+++ b/Tests/Functional/Middleware/ProcessingMiddlewareTest.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 namespace Netresearch\NrImageOptimize\Tests\Functional\Middleware;
 
 use Netresearch\NrImageOptimize\Middleware\ProcessingMiddleware;
+use Netresearch\NrImageOptimize\Processor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -26,6 +28,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * Functional tests for ProcessingMiddleware PSR-15 pipeline behavior.
  */
 #[CoversClass(ProcessingMiddleware::class)]
+#[UsesClass(Processor::class)]
 final class ProcessingMiddlewareTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/ProcessorTest.php
+++ b/Tests/Functional/ProcessorTest.php
@@ -53,8 +53,11 @@ final class ProcessorTest extends FunctionalTestCase
         $contentType = $response->getHeaderLine('Content-Type');
         self::assertNotEmpty($contentType, 'Response should have Content-Type header');
 
-        $body = (string) $response->getBody();
-        self::assertNotEmpty($body, 'Response body should contain image data');
+        // getSize() reports the backing stream's length without consuming it,
+        // which is robust against PSR-7 streams returned by TYPO3 core where
+        // (string) $body relies on __toString() + internal rewind semantics
+        // that have proven flaky under PHPUnit 11 / functional-test bootstrap.
+        self::assertGreaterThan(0, $response->getBody()->getSize(), 'Response body should contain image data');
     }
 
     #[Test]

--- a/Tests/Unit/Controller/MaintenanceControllerTest.php
+++ b/Tests/Unit/Controller/MaintenanceControllerTest.php
@@ -97,7 +97,7 @@ class MaintenanceControllerTest extends TestCase
             if ($item->isDir()) {
                 rmdir($item->getPathname());
             } else {
-                unlink($item->getPathname());
+                unlink($item->getPathname()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -220,11 +220,11 @@ class ProcessorTest extends TestCase
             $path = $item->getPathname();
 
             if ($item->isLink()) {
-                @unlink($path);
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             } elseif ($item->isDir()) {
                 @rmdir($path);
             } else {
-                @unlink($path);
+                @unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
@@ -555,7 +555,7 @@ class ProcessorTest extends TestCase
         self::assertTrue($this->callMethod($this->processor, 'hasVariantFor', $base, 'webp'));
         self::assertFalse($this->callMethod($this->processor, 'hasVariantFor', $base, 'avif'));
 
-        unlink($webp);
+        unlink($webp); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -657,8 +657,8 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.avif');
-        unlink($base . '.webp');
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -679,7 +679,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.webp');
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -700,7 +700,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -734,7 +734,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -770,9 +770,9 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.avif');
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.avif'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -946,7 +946,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -987,8 +987,8 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -1010,7 +1010,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -1032,8 +1032,8 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base . '.webp');
-        unlink($base);
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -1657,7 +1657,7 @@ class ProcessorTest extends TestCase
             if ($item->isDir()) {
                 rmdir($item->getPathname());
             } else {
-                unlink($item->getPathname());
+                unlink($item->getPathname()); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
@@ -1869,7 +1869,7 @@ class ProcessorTest extends TestCase
 
         self::assertNotNull($result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -2080,7 +2080,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base . '.webp');
+        unlink($base . '.webp'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -2101,7 +2101,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($response, $result);
 
-        unlink($base);
+        unlink($base); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------
@@ -2439,11 +2439,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2521,11 +2521,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2603,11 +2603,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2673,11 +2673,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2746,11 +2746,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2814,11 +2814,11 @@ class ProcessorTest extends TestCase
 
         if ($files !== false) {
             foreach ($files as $f) {
-                unlink($f);
+                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath);
+        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/processed');
         rmdir($tempDir);
     }
@@ -2929,8 +2929,8 @@ class ProcessorTest extends TestCase
         self::assertSame($response400, $result);
 
         // Cleanup
-        unlink($symlinkPath);
-        unlink($tempDir . '/outside/photo.jpg');
+        unlink($symlinkPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($tempDir . '/outside/photo.jpg'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($tempDir . '/outside');
         rmdir($tempDir . '/public/processed');
         rmdir($tempDir . '/public');

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -120,8 +120,8 @@ class ProcessorTest extends TestCase
     private function resetAllowedRootsCache(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
+        $prop->setValue(null, []);
     }
 
     /**
@@ -1044,8 +1044,8 @@ class ProcessorTest extends TestCase
     public function isPathWithinAllowedRootsAcceptsPathsInsidePublicDir(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
+        $prop->setValue(null, []);
 
         $tempDir = sys_get_temp_dir() . '/nr-pio-pubroot-' . uniqid('', true);
         mkdir($tempDir . '/public/subdir', 0o777, true);
@@ -1086,7 +1086,7 @@ class ProcessorTest extends TestCase
         rmdir($tempDir . '/public');
         rmdir($tempDir);
 
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
         Environment::initialize(
             new ApplicationContext('Testing'),
             true,
@@ -1104,7 +1104,7 @@ class ProcessorTest extends TestCase
     public function isPathWithinAllowedRootsReturnsFalseWhenNoAllowedRootsAreResolvable(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
         // Simulate cached empty result (neither the public path nor any FAL
         // storage base path could be realpath'd — e.g., early bootstrap).
         $prop->setValue(null, []);
@@ -1114,14 +1114,14 @@ class ProcessorTest extends TestCase
         self::assertFalse($result);
 
         // Reset
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
     }
 
     #[Test]
     public function isPathWithinAllowedRootsReturnsFalseForNonExistentPaths(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
 
         $tempDir = sys_get_temp_dir() . '/nr-pio-walk-' . uniqid('', true);
         mkdir($tempDir . '/public/deep/nested', 0o777, true);
@@ -1138,7 +1138,7 @@ class ProcessorTest extends TestCase
             'UNIX',
         );
 
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
 
         // Non-existent file path: realpath() returns false, and the parent walk loop
         // body is unreachable due to the while-condition assignment pattern
@@ -1167,7 +1167,7 @@ class ProcessorTest extends TestCase
         rmdir($tempDir . '/public');
         rmdir($tempDir);
 
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
         Environment::initialize(
             new ApplicationContext('Testing'),
             true,
@@ -1615,7 +1615,7 @@ class ProcessorTest extends TestCase
     /**
      * Set up a real temp directory for tests that exercise generateAndSend (needs real filesystem for path validation).
      *
-     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedAllowedRoots property
+     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedAllowedRootsByPublicPath property
      */
     private function setUpRealEnvironment(): array
     {
@@ -1624,8 +1624,8 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/public/images', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
+        $prop->setValue(null, []);
 
         Environment::initialize(
             new ApplicationContext('Testing'),
@@ -1663,7 +1663,7 @@ class ProcessorTest extends TestCase
 
         rmdir($tempDir);
 
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
         Environment::initialize(
             new ApplicationContext('Testing'),
             true,
@@ -2891,8 +2891,8 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/outside', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
+        $prop->setValue(null, []);
 
         Environment::initialize(
             new ApplicationContext('Testing'),
@@ -2936,7 +2936,7 @@ class ProcessorTest extends TestCase
         rmdir($tempDir . '/public');
         rmdir($tempDir);
 
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
         Environment::initialize(
             new ApplicationContext('Testing'),
             true,

--- a/Tests/Unit/Service/SystemRequirementsServiceTest.php
+++ b/Tests/Unit/Service/SystemRequirementsServiceTest.php
@@ -116,13 +116,13 @@ class SystemRequirementsServiceTest extends TestCase
             'makeItem',
             'sysreq.testLabel',
             '8.2.0',
-            '>= 8.1.0',
+            '>= 8.2.0',
             'success',
         );
 
         self::assertSame('sysreq.testLabel', $result['labelKey']);
         self::assertSame('8.2.0', $result['current']);
-        self::assertSame('>= 8.1.0', $result['required']);
+        self::assertSame('>= 8.2.0', $result['required']);
         self::assertSame('success', $result['status']);
         self::assertSame('status-dialog-ok', $result['icon']);
         self::assertSame('bg-success', $result['badgeClass']);
@@ -215,7 +215,7 @@ class SystemRequirementsServiceTest extends TestCase
         $phpVersion = $result['items'][0];
         self::assertSame('sysreq.phpVersion', $phpVersion['labelKey']);
         self::assertSame(PHP_VERSION, $phpVersion['current']);
-        self::assertSame('>= 8.1.0', $phpVersion['required']);
+        self::assertSame('>= 8.2.0', $phpVersion['required']);
 
         // PHP 8.2+ should be success
         self::assertSame('success', $phpVersion['status']);

--- a/Tests/Unit/Service/SystemRequirementsServiceTest.php
+++ b/Tests/Unit/Service/SystemRequirementsServiceTest.php
@@ -435,7 +435,7 @@ class SystemRequirementsServiceTest extends TestCase
         self::assertSame('1.2.3', $result);
 
         // Cleanup
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -460,7 +460,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'test/package');
         self::assertSame('v1.0.0', $result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -483,7 +483,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'lock/package');
         self::assertSame('2.0.0', $result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -505,7 +505,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'dev/package');
         self::assertSame('3.0.0', $result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -533,8 +533,8 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'missing/package');
         self::assertNull($result);
 
-        unlink($vendorDir . '/installed.json');
-        unlink($projectPath . '/composer.lock');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -559,7 +559,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerInstalled', 'flat/package');
         self::assertSame('4.0.0', $result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -674,7 +674,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromInstalledJson', 'any/package');
         self::assertNull($result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -692,7 +692,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromInstalledJson', 'any/package');
         self::assertNull($result);
 
-        unlink($vendorDir . '/installed.json');
+        unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
     }
@@ -719,7 +719,7 @@ class SystemRequirementsServiceTest extends TestCase
 
         // Restore permissions before cleanup
         chmod($file, 0o644);
-        unlink($file);
+        unlink($file); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         rmdir($vendorDir);
         rmdir($projectPath . '/vendor');
 
@@ -740,7 +740,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'any/package');
         self::assertNull($result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -753,7 +753,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'any/package');
         self::assertNull($result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     #[Test]
@@ -775,7 +775,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'any/package');
 
         chmod($file, 0o644);
-        unlink($file);
+        unlink($file); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
 
         self::assertNull($result);
     }
@@ -794,7 +794,7 @@ class SystemRequirementsServiceTest extends TestCase
         $result = $this->callMethod('findVersionFromComposerLock', 'missing/package');
         self::assertNull($result);
 
-        unlink($projectPath . '/composer.lock');
+        unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
     }
 
     // -------------------------------------------------------------------------

--- a/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
@@ -390,7 +390,7 @@ class SourceSetViewHelperTest extends TestCase
 
         self::assertSame($expected, $result);
 
-        unlink($absolutePath);
+        unlink($absolutePath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         @rmdir($directory);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
             "homepage": "https://www.netresearch.de"
         }
     ],
+    "homepage": "https://extensions.typo3.org/extension/nr_image_optimize",
+    "support": {
+        "issues": "https://github.com/netresearch/t3x-nr-image-optimize/issues",
+        "source": "https://github.com/netresearch/t3x-nr-image-optimize"
+    },
     "config": {
         "bin-dir": ".build/bin",
         "vendor-dir": ".build/vendor",
@@ -26,27 +31,26 @@
         "optimize-autoloader": true,
         "platform-check": false,
         "allow-plugins": {
-            "typo3/cms-composer-installers": true,
-            "typo3/class-alias-loader": true
+            "a9f/fractor-extension-installer": true,
+            "captainhook/hook-installer": true,
+            "infection/extension-installer": true,
+            "phpstan/extension-installer": true,
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
         }
     },
     "require": {
-        "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+        "php": ">=8.2",
         "typo3/cms-core": "^12.0",
         "typo3/cms-extbase": "^12.0",
         "typo3/cms-fluid": "^12.0",
         "intervention/image": "3.7.2 || 3.11.1"
     },
     "require-dev": {
-        "typo3/testing-framework": "^6.0 || ^7.0 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^3.1",
-        "friendsoftypo3/phpstan-typo3": "^0.9",
-        "overtrue/phplint": "^3.4 || ^9.0",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-strict-rules": "^1.5",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "ssch/typo3-rector": "^2.0 || ^3.0"
+        "netresearch/typo3-ci-workflows": "^1.1"
+    },
+    "replace": {
+        "saschaegerer/phpstan-typo3": "2.1.1"
     },
     "autoload": {
         "psr-4": {
@@ -68,8 +72,17 @@
         }
     },
     "scripts": {
+        "ci:cgl": [
+            "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .build/.php-cs-fixer.cache"
+        ],
+        "ci:rector": [
+            "rector process --config Build/rector.php"
+        ],
+        "ci:fractor": [
+            "fractor process --config Build/fractor.php"
+        ],
         "ci:test:php:cgl": [
-            "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .build/.php-cs-fixer.cache --dry-run"
+            "@ci:cgl --dry-run"
         ],
         "ci:test:php:lint": [
             "phplint --configuration Build/.phplint.yml"
@@ -81,6 +94,12 @@
             "@putenv XDEBUG_MODE=coverage",
             "phpunit --configuration Build/UnitTests.xml --coverage-html .build/coverage/"
         ],
+        "ci:test:php:acceptance": [
+            "phpunit --configuration Build/AcceptanceTests.xml"
+        ],
+        "ci:test:php:functional": [
+            "phpunit --configuration Build/FunctionalTests.xml"
+        ],
         "ci:test:php:fuzz": [
             "phpunit --configuration Build/FuzzTests.xml --no-coverage"
         ],
@@ -89,26 +108,24 @@
             "infection --configuration=infection.json5 --threads=4 --no-progress --show-mutations"
         ],
         "ci:test:php:phpstan": [
-            "phpstan analyze --configuration Build/phpstan.neon"
+            "phpstan analyze --configuration Build/phpstan.neon --memory-limit=-1"
         ],
         "ci:test:php:phpstan:baseline": [
-            "phpstan analyze --configuration Build/phpstan.neon --generate-baseline Build/phpstan-baseline.neon --allow-empty-baseline"
+            "phpstan analyze --configuration Build/phpstan.neon --memory-limit=-1 --generate-baseline Build/phpstan-baseline.neon --allow-empty-baseline"
         ],
         "ci:test:php:rector": [
-            "rector process --config Build/rector.php --dry-run"
+            "@ci:rector --dry-run"
+        ],
+        "ci:test:php:fractor": [
+            "@ci:fractor --dry-run"
         ],
         "ci:test": [
             "@ci:test:php:lint",
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
+            "@ci:test:php:fractor",
             "@ci:test:php:unit",
             "@ci:test:php:cgl"
-        ],
-        "ci:cgl": [
-            "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .build/.php-cs-fixer.cache"
-        ],
-        "ci:php:rector": [
-            "rector process --config Build/rector.php"
         ]
     }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,7 +19,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints'    => [
         'depends' => [
             'typo3' => '12.0.0-12.4.99',
-            'php'   => '8.1.0-8.4.99',
+            'php'   => '8.2.0-8.4.99',
         ],
         'conflicts' => [],
         'suggests'  => [


### PR DESCRIPTION
## Explain the details

**Supersedes the inline CI approach in earlier iterations of this PR.** Follow-up to #73 which unblocked CI execution on the maintenance branch for the first time.

TYPO3_12 CI now consumes the shared workflow repository `netresearch/typo3-ci-workflows` the same way `main` does, instead of maintaining a divergent inline workflow. Enabling shared workflows brought the full matrix up for the first time — fuzz, **functional-tests-with-containers**, license-check, scorecard, codeql, dependency-review, pr-quality, and labeler all come online on this branch.

Enabling **functional tests surfaced two real production bugs** (latent on main as well, documented below).

### PHP 8.1 dropped

The meta-package and its transitive deps (`infection`, `a9f/typo3-fractor`, `rector/rector ^2.0`, `saschaegerer/phpstan-typo3 ^2.0`) all floor at PHP 8.2. TYPO3 v12 itself still runs on PHP 8.1, but aligning the maintenance branch's *tooling* floor with `main`'s keeps backports mechanical and lets us consume the shared workflow as-is. Per the earlier conversation on this PR (Option A), this is a deliberate trade-off.

### `saschaegerer/phpstan-typo3` constraint wrinkle

The meta-package transitively requires `saschaegerer/phpstan-typo3 ^2.0 || ^3.0`, but those versions require TYPO3 ≥ 13.4 / 14. For TYPO3 12 there is no compatible version. Composer's `replace` directive is used to satisfy the constraint without actually installing an incompatible package. PHPStan still runs; just without the TYPO3-specific rule extension.

### Pinning scope

The **individual actions** inside the shared workflows — `actions/checkout`, `shivammathur/setup-php`, `actions/cache`, `codecov/codecov-action` — are SHA-pinned per the repo ruleset. The **shared workflow references themselves** (`netresearch/typo3-ci-workflows/...@main`) are tag-pinned to `@main`, matching main's own usage. Switching shared-workflow references to SHA pinning would diverge from main and is a legitimate follow-up on both branches.

## Production bugs surfaced and fixed

Enabling functional tests in CI for the first time exposed two bugs that were latent both here and on main:

### 1. Static allowed-roots cache never invalidated (`Classes/Processor.php`, commit 867d1f0)

`$resolvedAllowedRoots` was a single static array shared across all `Processor` instances in a PHP process. In normal HTTP requests the public path is constant so it never mattered, but:

- TYPO3 functional tests create a fresh test instance per test under `typo3temp/var/tests/functional-XXXX/` with a different `Environment::getPublicPath()`, and the old cache kept the first test's roots forever → every subsequent test rejected with HTTP 400.
- Long-running FrankenPHP / swoole / RoadRunner workers that reinitialise `Environment` between handler invocations would have the same issue.

Fix: replaced `private static ?array $resolvedAllowedRoots` with `private static array $resolvedAllowedRootsByPublicPath` keyed on `Environment::getPublicPath()`. In production this degenerates to a single-entry cache; in tests it auto-invalidates.

### 2. `buildFileResponse` served 0-byte variants (commits e487ec9 + a2d7582)

When Imagick lacks an AVIF encoder (common in distros that haven't packaged `heif`/`libavif`), `$image->save($pathVariant.'.avif')` silently creates an empty file. `buildFileResponse` used to return that 0-byte file with `HTTP 200 Content-Type: image/avif` — a broken image for every end user.

Fix in two steps: `buildFileResponse` now returns `null` for 0-byte files, and `serveCachedVariant` cascades AVIF → WebP → primary so a 0-byte variant no longer short-circuits the cache path.

## Scope

**`composer.json`**
- `require.php`: `^8.1 || … || ^8.4` → `>=8.2`
- `require-dev`: drop individual tool deps, add `netresearch/typo3-ci-workflows: ^1.1`
- `replace`: `saschaegerer/phpstan-typo3: 2.1.1` (satisfy-without-install shim)
- `allow-plugins`: add the four plugin hooks (fractor-extension-installer, hook-installer, infection/extension-installer, phpstan/extension-installer)
- `scripts`: replaced wholesale with main's `ci:*` layout — 17 scripts including `fractor`, `fuzz`, `mutation`, `acceptance`, `functional`
- `homepage` + `support` + polished description copied from main

**`Build/`**
- `phpstan.neon`: level 8 → 10, phpVersion 80100 → 80200, restructured to match main. `reportUnmatchedIgnoredErrors: false` on this branch (main uses `true`) while the 71-entry baseline is being reduced — flipping to `true` would block CI on stale baseline entries without preventing new regressions. Follow-up PRs should shrink the baseline.
- `phpstan-baseline.neon`: regenerated — captures **100 level-10 violations that pre-exist on this branch** (not introduced by this commit). Paths use `%currentWorkingDirectory%` so Rector's phpstanConfig integration resolves them correctly.
- `rector.php`: phpVersion 80100 → 80200, `UP_TO_PHP_81` → `UP_TO_PHP_82`. Keeps `UP_TO_TYPO3_12` (main uses `UP_TO_TYPO3_13`).
- `.php-cs-fixer.dist.php`: deprecated rule-set aliases migrated (`@PER-CS2.0` → `@PER-CS2x0`, `@PHP80Migration` → `@PHP8x0Migration`, etc.); adds `@PHP8x2Migration`.
- `FuzzTests.xml`: backported verbatim from main (was missing; `ci:test:php:fuzz` was broken).
- `Scripts/runTests.sh`: backported from main for container-based functional/acceptance. `IMAGE_ALPINE` bumped from alpine:3.8 (EOL May 2020) → alpine:3.22 (current stable).

**`ext_emconf.php`**: php `8.1.0-8.4.99` → `8.2.0-8.4.99`.

**Surface-level updates of the PHP 8.1 drop**
- `README.md` + `README.rst`: badges + requirements list.
- `Documentation/Introduction/Index.rst`: requirements list.
- `AGENTS.md`: runtime note.
- `Classes/Service/SystemRequirementsService.php`: `MIN_PHP_VERSION` `'8.1.0'` → `'8.2.0'`.
- `Tests/Unit/Service/SystemRequirementsServiceTest.php`: 3 assertions updated accordingly.
- `Documentation/Changelog/Index.rst`: Unreleased entry for the PHP 8.1 drop.

**`Tests/Functional/` fixes**
- `ProcessorTest.php`: `(string) $response->getBody()` → `$response->getBody()->getSize() > 0` — PSR-7 `__toString()` rewind semantics are unreliable for file-backed streams under PHPUnit 11 + functional-test bootstrap. `getSize()` reports the backing file length without consuming the stream.
- `Middleware/ProcessingMiddlewareTest.php`: added `#[UsesClass(Processor::class)]` to complement `#[CoversClass(ProcessingMiddleware::class)]` so PHPUnit 11 with `beStrictAboutCoverageMetadata="true"` no longer flags the test as "risky" for legitimately touching the Processor.

**`.github/workflows/ci.yml`**

Replaced with 9 shared-workflow calls, one-for-one with main:

```yaml
jobs:
  ci:                netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
  security:          netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
  fuzz:              netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
  license-check:     netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
  codeql:            netresearch/.github/.github/workflows/codeql.yml@main
  scorecard:         netresearch/.github/.github/workflows/scorecard.yml@main (scheduled only)
  dependency-review: netresearch/.github/.github/workflows/dependency-review.yml@main (PR only)
  pr-quality:        netresearch/.github/.github/workflows/pr-quality.yml@main       (PR only)
  labeler:           netresearch/.github/.github/workflows/labeler.yml@main          (PR only)
```

The `ci` call passes branch-appropriate inputs:

```yaml
php-versions: '["8.2","8.3","8.4"]'
typo3-versions: '["^12.0"]'
upload-coverage: true
run-functional-tests: true
php-extensions: intl, mbstring, xml, imagick, gd  # imagick required by production code; gd for the Intervention v3 GD fallback
```

The "push restricted to `TYPO3_12`" trigger dedupe inherited from #73 is preserved so PR pushes do not double-fire `push` and `pull_request`.

## Test plan (required)

- [x] Unit Tests (3 × PHP 8.2/8.3/8.4): 252 tests, 619 assertions, 1 skipped
- [x] **Functional Tests SQLite** (3 × PHP 8.2/8.3/8.4): 27 tests, 65 assertions, 0 failures
- [x] Fuzz Tests (PHP 8.4): 3 tests, 1041 assertions
- [x] PHPStan (3 × PHP), Rector, Fractor, PHP-CS-Fixer, PHPLint: all green
- [x] Composer Validate, Composer Audit (security advisories), License Check: all green
- [x] CodeQL, Opengrep SAST, Dependency Review, PR Quality, Labeler: all green

Total: **27 SUCCESS, 0 FAILURES**, `mergeStateStatus: CLEAN`.

## To port to main

All production-code fixes (static cache keying, 0-byte variant handling, `serveCachedVariant` cascade) apply cleanly to main — the affected code paths are identical. Test-code fixes (`getSize()` body check, `#[UsesClass]` on middleware) also apply cleanly.

## Checklist

- [x] CI checks pass
- [x] Tests added or updated — test-code fixes for functional suite
- [x] `Documentation/Changelog/Index.rst` updated with PHP 8.1-drop entry