### PR TITLE
fix: port Processor bug fixes + tooling improvements from TYPO3_12

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -148,7 +148,7 @@ esac
 
 # Docker images
 IMAGE_PHP="ghcr.io/typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
-IMAGE_ALPINE="docker.io/alpine:3.8"
+IMAGE_ALPINE="docker.io/alpine:3.22"
 IMAGE_MARIADB="docker.io/mariadb:10"
 IMAGE_MYSQL="docker.io/mysql:8.0"
 IMAGE_POSTGRES="docker.io/postgres:16-alpine"

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -150,23 +150,26 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
     private const MODE_PATTERN = '/([hwqm])(\d+)/';
 
     /**
-     * Cached list of absolute filesystem roots (realpath-resolved) under which
-     * image paths are considered safe. Populated on first call to
-     * getAllowedRoots() and reused across requests in the same PHP process.
+     * Cached lists of absolute filesystem roots (realpath-resolved) under
+     * which image paths are considered safe, keyed by the TYPO3 public path
+     * that was in effect when each list was computed.
      *
-     * Contains the TYPO3 public path plus the basePath of every Local-driver
-     * FAL storage, each resolved through realpath so that legitimately
-     * symlinked storage directories (e.g. fileadmin on an NFS/EFS mount) are
-     * recognised as allowed. Any symlink inside a storage that points to a
-     * location outside these roots is rejected.
+     * Each entry contains the public path plus the basePath of every
+     * Local-driver FAL storage, each resolved through realpath so that
+     * legitimately symlinked storage directories (e.g. fileadmin on an
+     * NFS/EFS mount) are recognised as allowed. Any symlink inside a storage
+     * that points to a location outside these roots is rejected.
      *
-     * Because the cache persists for the life of the PHP process, tests must
-     * reset it between cases via reflection — see
-     * ProcessorTest::resetAllowedRootsCache().
+     * Keying by public path auto-invalidates the cache when the public path
+     * changes — matters for TYPO3 functional tests (each test instance has
+     * its own typo3temp/var/tests/functional-XXXX/ root) and long-running
+     * worker setups (FrankenPHP, swoole, RoadRunner) that might reinitialise
+     * Environment between handler invocations. In a normal HTTP request the
+     * public path is constant, so this degenerates to a single-entry cache.
      *
-     * @var list<string>|null
+     * @var array<string, list<string>>
      */
-    private static ?array $resolvedAllowedRoots = null;
+    private static array $resolvedAllowedRootsByPublicPath = [];
 
     /**
      * Initialize the image processor with all required dependencies.
@@ -723,13 +726,14 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
      */
     private function getAllowedRoots(): array
     {
-        if (self::$resolvedAllowedRoots !== null) {
-            return self::$resolvedAllowedRoots;
+        $publicPathRaw = Environment::getPublicPath();
+
+        if (isset(self::$resolvedAllowedRootsByPublicPath[$publicPathRaw])) {
+            return self::$resolvedAllowedRootsByPublicPath[$publicPathRaw];
         }
 
-        $roots         = [];
-        $publicPathRaw = Environment::getPublicPath();
-        $publicPath    = realpath($publicPathRaw);
+        $roots      = [];
+        $publicPath = realpath($publicPathRaw);
 
         if ($publicPath !== false) {
             $roots[$publicPath] = true;
@@ -779,9 +783,11 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
             );
         }
 
-        self::$resolvedAllowedRoots = array_keys($roots);
+        $resolved = array_keys($roots);
 
-        return self::$resolvedAllowedRoots;
+        self::$resolvedAllowedRootsByPublicPath[$publicPathRaw] = $resolved;
+
+        return $resolved;
     }
 
     /**

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -328,22 +328,31 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
      */
     private function serveCachedVariant(string $pathVariant, string $extension): ?ResponseInterface
     {
-        // Prefer AVIF, then WebP, then the original format
-        if (!$this->isAvifImage($extension) && file_exists($pathVariant . '.avif')) {
-            return $this->buildFileResponse($pathVariant . '.avif', 'image/avif');
+        // Prefer AVIF, then WebP, then the original format. Each step falls
+        // through to the next when buildFileResponse returns null — which it
+        // does for missing AND for 0-byte files (see buildFileResponse). That
+        // matters when e.g. Imagick silently writes an empty .avif because
+        // the encoder isn't installed: we must not short-circuit on the empty
+        // file and skip a valid WebP/primary that's also on disk.
+        if (!$this->isAvifImage($extension)) {
+            $response = $this->buildFileResponse($pathVariant . '.avif', 'image/avif');
+
+            if ($response instanceof ResponseInterface) {
+                return $response;
+            }
         }
 
-        if (!$this->isWebpImage($extension) && file_exists($pathVariant . '.webp')) {
-            return $this->buildFileResponse($pathVariant . '.webp', 'image/webp');
+        if (!$this->isWebpImage($extension)) {
+            $response = $this->buildFileResponse($pathVariant . '.webp', 'image/webp');
+
+            if ($response instanceof ResponseInterface) {
+                return $response;
+            }
         }
 
-        if (file_exists($pathVariant)) {
-            $mimeType = self::EXTENSION_MIME_MAP[$extension] ?? 'application/octet-stream';
+        $mimeType = self::EXTENSION_MIME_MAP[$extension] ?? 'application/octet-stream';
 
-            return $this->buildFileResponse($pathVariant, $mimeType);
-        }
-
-        return null;
+        return $this->buildFileResponse($pathVariant, $mimeType);
     }
 
     /**
@@ -367,7 +376,14 @@ class Processor implements LoggerAwareInterface, ProcessorInterface
         $fileSize  = filesize($filePath);
         $fileMtime = filemtime($filePath);
 
-        if ($fileSize === false) {
+        // Treat 0-byte variant files as "not present" so buildOutputResponse's
+        // AVIF -> WebP -> primary fallback chain skips over them. Empty
+        // variant files occur when a driver silently writes nothing (most
+        // often: Imagick builds without AVIF encoder support leave an empty
+        // .avif next to a valid PNG). Returning that empty file to the
+        // client is strictly worse than falling back to the format that
+        // actually has pixels.
+        if ($fileSize === false || $fileSize === 0) {
             return null;
         }
 

--- a/Tests/Functional/Middleware/ProcessingMiddlewareTest.php
+++ b/Tests/Functional/Middleware/ProcessingMiddlewareTest.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 namespace Netresearch\NrImageOptimize\Tests\Functional\Middleware;
 
 use Netresearch\NrImageOptimize\Middleware\ProcessingMiddleware;
+use Netresearch\NrImageOptimize\Processor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -26,6 +28,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * Functional tests for ProcessingMiddleware PSR-15 pipeline behavior.
  */
 #[CoversClass(ProcessingMiddleware::class)]
+#[UsesClass(Processor::class)]
 final class ProcessingMiddlewareTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/ProcessorTest.php
+++ b/Tests/Functional/ProcessorTest.php
@@ -53,8 +53,11 @@ final class ProcessorTest extends FunctionalTestCase
         $contentType = $response->getHeaderLine('Content-Type');
         self::assertNotEmpty($contentType, 'Response should have Content-Type header');
 
-        $body = (string) $response->getBody();
-        self::assertNotEmpty($body, 'Response body should contain image data');
+        // getSize() reports the backing stream's length without consuming it,
+        // which is robust against PSR-7 streams returned by TYPO3 core where
+        // (string) $body relies on __toString() + internal rewind semantics
+        // that have proven flaky under PHPUnit 11 / functional-test bootstrap.
+        self::assertGreaterThan(0, $response->getBody()->getSize(), 'Response body should contain image data');
     }
 
     #[Test]

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -107,8 +107,8 @@ class ProcessorTest extends TestCase
     private function resetAllowedRootsCache(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
+        $prop->setValue(null, []);
     }
 
     /**
@@ -1029,7 +1029,7 @@ class ProcessorTest extends TestCase
     public function isPathWithinAllowedRootsReturnsFalseWhenNoAllowedRootsAreResolvable(): void
     {
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
         // Simulate cached empty result (neither the public path nor any FAL
         // storage base path could be realpath'd — e.g., early bootstrap).
         $prop->setValue(null, []);
@@ -1039,7 +1039,7 @@ class ProcessorTest extends TestCase
         self::assertFalse($result);
 
         // Reset
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
     }
 
     #[Test]
@@ -1632,7 +1632,7 @@ class ProcessorTest extends TestCase
     /**
      * Set up a real temp directory for tests that exercise generateAndSend (needs real filesystem for path validation).
      *
-     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedAllowedRoots property
+     * @return array{tempDir: string, prop: ReflectionProperty} Temp dir path and resolvedAllowedRootsByPublicPath property
      */
     private function setUpRealEnvironment(): array
     {
@@ -1641,7 +1641,7 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/public/images', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
 
         $this->resetAllowedRootsCache();
         $this->initializeEnvironment($tempDir, $tempDir . '/public');
@@ -1661,7 +1661,7 @@ class ProcessorTest extends TestCase
     private function tearDownRealEnvironment(string $tempDir, ReflectionProperty $prop): void
     {
         $this->removeOwnedTempTree($tempDir);
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
         $this->initializeDefaultEnvironment();
     }
 
@@ -2857,8 +2857,8 @@ class ProcessorTest extends TestCase
         mkdir($tempDir . '/outside', 0o777, true);
 
         $refClass = new ReflectionClass(Processor::class);
-        $prop     = $refClass->getProperty('resolvedAllowedRoots');
-        $prop->setValue(null, null);
+        $prop     = $refClass->getProperty('resolvedAllowedRootsByPublicPath');
+        $prop->setValue(null, []);
 
         Environment::initialize(
             new ApplicationContext('Testing'),
@@ -2902,7 +2902,7 @@ class ProcessorTest extends TestCase
         rmdir($tempDir . '/public');
         rmdir($tempDir);
 
-        $prop->setValue(null, null);
+        $prop->setValue(null, []);
         Environment::initialize(
             new ApplicationContext('Testing'),
             true,


### PR DESCRIPTION
## Explain the details

Port of production-code fixes and test-infrastructure improvements that surfaced on the `TYPO3_12` maintenance branch when its CI was expanded to run functional tests for the first time (in [PR #74](https://github.com/netresearch/t3x-nr-image-optimize/pull/74), merged as d51fd0a).

All four commits apply to the same code paths on `main` — they were pre-existing latent bugs that main's CI didn't catch (main also doesn't run functional tests, so the static-cache and 0-byte bugs never surfaced here either).

## Commits

### 1. `fix: key allowed-roots cache by public path` — ebae616

`$resolvedAllowedRoots` was a single static array shared across all `Processor` instances in a PHP process. In normal HTTP requests the public path is constant so staleness never mattered, but:

- Functional tests create a fresh test instance per test under `typo3temp/var/tests/functional-XXXX/`. The cache kept the first test's roots forever — every subsequent test's path got rejected with HTTP 400.
- Long-running FrankenPHP / swoole / RoadRunner workers that reinitialise `Environment` between handler invocations would have the same issue in production.

Replaced

```php
private static ?array $resolvedAllowedRoots = null;
```

with

```php
private static array $resolvedAllowedRootsByPublicPath = [];
```

keyed by `Environment::getPublicPath()`. In production this degenerates to a single-entry cache; in tests and worker setups it auto-invalidates.

### 2. `fix: skip zero-byte variants in buildFileResponse + serveCachedVariant cascade` — 7c63393

When a driver silently writes a 0-byte output file — most commonly when Imagick is built without an AVIF encoder (`libavif`/`heif` not available), it writes an empty `.avif` next to a valid `.webp`/`.png` — `buildFileResponse` used to serve that empty file with `HTTP 200 Content-Type: image/avif`. Every end user on such a host received a broken image for that URL.

Two-part fix:

- `buildFileResponse` now returns `null` for 0-byte files (same as for missing/unreadable files).
- `serveCachedVariant` cascades AVIF → WebP → primary. Previously it did `file_exists(.avif) && buildFileResponse(.avif)` and returned whatever came back — so after the first change, an empty `.avif` would cause `serveCachedVariant` to return null and force re-processing every request, even with a valid `.webp`/primary on disk. The cascade matches the semantics `buildOutputResponse` already uses in the fresh-processing path.

### 3. `chore(build): bump runTests.sh alpine from 3.8 to 3.22` — 76dfee6

Alpine 3.8 reached EOL in May 2020. Only used by `runTests.sh`'s DB `waitFor` helper (not exercised on the sqlite CI path), but worth keeping local runners off a 5-year-EOL image.

### 4. `test(functional): robust body check + UsesClass for middleware risky tests` — 2ec2023

Two test-code improvements that surfaced when functional tests actually executed under PHPUnit 11 on the TYPO3_12 branch:

- `Tests/Functional/ProcessorTest.php::processorResizesImageToRequestedDimensions`: `(string) $response->getBody()` returned empty under PHPUnit 11 + functional-test bootstrap (TYPO3 core's PSR-7 stream `__toString()` rewind semantics are unreliable for file-backed streams there). Switch to `getSize() > 0`, which reports the backing file length without consuming the stream. Test intent ("response has image data") preserved.
- `Tests/Functional/Middleware/ProcessingMiddlewareTest`: add `#[UsesClass(Processor::class)]` to complement the existing `#[CoversClass(ProcessingMiddleware::class)]`. PHPUnit 11 with `beStrictAboutCoverageMetadata="true"` flags the test as "risky" otherwise because the middleware test legitimately invokes the Processor indirectly.

Main doesn't currently run functional tests in CI (same default as before the TYPO3_12 migration), but these changes are correct and unblock future enablement.

## Test plan

- [x] Unit Tests: 543 tests, 1362 assertions, 2 skipped (unchanged from pre-port)
- [x] PHPStan: 28 errors (unchanged from main's baseline)
- [x] PHP-CS-Fixer, Rector, Fractor: all clean
- [x] Functional tests on TYPO3_12 (where CI actually runs them): all green with these fixes applied

## Out of scope

- Enabling functional tests in main's CI — that's a separate change (the shared workflow on main doesn't set `run-functional-tests: true` yet).
- Reducing main's PHPStan baseline — pre-existing, separate work.

## Checklist

- [x] CI checks pass
- [x] Tests added or updated — test-code fixes for the functional suite
- [x] CHANGELOG.md — not applicable (bug fixes in unreleased changelog bucket; next release will describe them)
- [x] Documentation — not applicable (behavior bug fixes)