### PR TITLE
ci: drop broken slsa-provenance job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,3 @@ jobs:
             --issues="https://github.com/netresearch/t3x-nr-image-optimize/issues" \
             --repository="https://github.com/netresearch/t3x-nr-image-optimize" \
             nr_image_optimize
-
-  slsa-provenance:
-    needs: release
-    uses: netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    with:
-      version: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

The release workflow has been silently broken since the [workflow consolidation in #43](https://github.com/netresearch/t3x-nr-image-optimize/pull/43): it calls a reusable workflow at `netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main` that does **not exist** in the `typo3-ci-workflows` repo. Available shared workflows there: ci / docs / e2e / extended-testing / fuzz / license-check / publish-to-ter / release / security / self-ci — no `slsa-provenance`.

Because the dangling `uses:` reference is a workflow-validation error, the entire `release.yml` never runs. The **first ever tag-triggered run** of this workflow (#11, on v2.2.2 pushed today) failed at parse time with zero jobs executed:
- https://github.com/netresearch/t3x-nr-image-optimize/actions/runs/24737473420

Previous releases (v2.0.x – v2.2.1) were cut before this workflow landed, so nobody noticed.

## Why remove, not fix

The `slsa-provenance` job duplicates what the reusable `typo3-ci-workflows/.github/workflows/release.yml` already does inside its own `release` job:

- SBOM generation (SPDX + CycloneDX) via `anchore/sbom-action`
- Artifact signing with Cosign keyless
- Build-provenance attestation via `actions/attest-build-provenance@v4`

See the current `release.yml` @main in `netresearch/typo3-ci-workflows`. Bringing back a separate provenance job would re-sign the same artifacts — the shared workflow already covers the SLSA surface end-to-end. The cleanest fix is to drop the redundant + broken job and let the `release` reusable workflow own provenance.

## Test plan

- [x] Workflow parses after the change (local validation)
- [ ] After merge, I'll re-tag v2.2.2 pointing at the new HEAD so the first proper release run fires. No GitHub release was created yet, so the tag name is not locked.

## Context

Discovered while trying to release v2.2.2 for [#76](https://github.com/netresearch/t3x-nr-image-optimize/pull/76) (issue #70 follow-up). Same workflow on TYPO3_12 does not exist, so v1.1.1 tag won't trigger anything there — I'll handle that release manually with `--latest=false`.