### PR TITLE
ci: accept 'X.Y.Z' and 'vX.Y.Z' tag styles in publish-to-ter

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -17,19 +17,28 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Check tag
+        env:
+          REF: ${{ github.ref }}
         run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+          if ! [[ "$REF" =~ ^refs/tags/v?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "::error::Tag '$REF' does not match SemVer 'X.Y.Z' or 'vX.Y.Z'"
             exit 1
           fi
 
       - name: Get version
         id: get-version
-        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        run: |
+          # Strip 'refs/tags/' prefix, then strip optional 'v' prefix so
+          # `tailor ter:publish` gets the bare version (1.2.3), matching
+          # ext_emconf.php. Supports both tag styles: '1.2.3' (historic
+          # TYPO3_12 convention) and 'v1.2.3' (signed-tag convention).
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "version=${TAG#v}" >> "$GITHUB_ENV"
 
       - name: Get comment
         id: get-comment
         run: |
-          readonly local comment=$(git tag -n10 -l ${{ env.version }} | sed "s/^[0-9.]*[ ]*//g")
+          readonly local comment=$(git tag -n10 -l "${{ env.version }}" "v${{ env.version }}" | sed "s/^v\?[0-9.]*[ ]*//g")
 
           if [[ -z "${comment// }" ]]; then
             echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }} -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

The `Check tag` step in `.github/workflows/publish-to-ter.yml` rejects v-prefixed tags (`^refs/tags/[0-9]{1,3}...`), so v1.1.1 — released today [as a signed tag per the team convention](https://github.com/netresearch/t3x-nr-image-optimize/releases/tag/v1.1.1) — failed TER publication despite being a valid SemVer tag.

Historic releases on this branch used bare-version tags (1.0.3, 1.1.0), which matched the old regex. The fix accepts **both** styles.

## Changes

- Regex: `^refs/tags/v?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$`
- `version` env-var strips `refs/tags/` AND an optional leading `v`, so `tailor ter:publish` gets the bare version that matches `ext_emconf.php`
- `git tag -n10 -l "${version}" "v${version}"` looks up both forms for the release comment
- Hardening: `env: REF: ${{ github.ref }}` + `"$REF"` instead of interpolating `github.ref` into the shell script, per the GitHub Actions workflow-injection guide

## Test plan

- [x] Regex locally: `[[ "refs/tags/v1.1.1" =~ ^refs/tags/v?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]` — passes
- [x] Regex locally: `[[ "refs/tags/1.1.0" =~ ^refs/tags/v?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]` — passes
- [x] Rejects invalid: `[[ "refs/tags/bad-tag" =~ ... ]]` — fails (as intended)
- [ ] After merge: re-trigger publish-to-ter for v1.1.1 (re-publish the GitHub release, or publish manually via `tailor`)

## Context

Discovered while releasing v1.1.1 — follow-up to [#77](https://github.com/netresearch/t3x-nr-image-optimize/pull/77) / [#70](https://github.com/netresearch/t3x-nr-image-optimize/issues/70). See [the failed run](https://github.com/netresearch/t3x-nr-image-optimize/actions/runs/24738423613).