### PR TITLE
ci: drop flaky git-tag comment extraction in publish-to-ter

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -26,7 +26,6 @@ jobs:
           fi
 
       - name: Get version
-        id: get-version
         run: |
           # Strip 'refs/tags/' prefix, then strip optional 'v' prefix so
           # `tailor ter:publish` gets the bare version (1.2.3), matching
@@ -35,16 +34,22 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           echo "version=${TAG#v}" >> "$GITHUB_ENV"
 
-      - name: Get comment
-        id: get-comment
+      - name: Build comment
+        env:
+          VERSION: ${{ env.version }}
+          EXT_KEY: ${{ env.TYPO3_EXTENSION_KEY }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          readonly local comment=$(git tag -n10 -l "${{ env.version }}" "v${{ env.version }}" | sed "s/^v\?[0-9.]*[ ]*//g")
-
-          if [[ -z "${comment// }" ]]; then
-            echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }} -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          else
-            echo "comment=$comment -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          fi
+          # Always build a deterministic single-line comment that points to the
+          # GitHub release. Previous versions tried to derive the comment from
+          # `git tag -n10` annotations, which is unreliable: actions/checkout
+          # does a shallow fetch that frequently drops tag annotations, so the
+          # command falls through to the commit's subject+body — often
+          # multi-line content that GitHub Actions rejects when writing to
+          # $GITHUB_ENV ("Invalid format '## Summary'"). The GitHub release
+          # body is the authoritative, user-visible changelog anyway.
+          echo "comment=Released version ${VERSION} of ${EXT_KEY} -- for details see ${SERVER_URL}/${REPOSITORY}/releases/tag/v${VERSION}" >> "$GITHUB_ENV"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
@@ -57,4 +62,7 @@ jobs:
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
 
       - name: Publish to TER
-        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.comment }}" ${{ env.version }}
+        env:
+          COMMENT: ${{ env.comment }}
+          VERSION: ${{ env.version }}
+        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "$COMMENT" "$VERSION"


### PR DESCRIPTION
## Summary

Follow-up to #81. After that fix accepted the `v1.1.1` tag, the next step (`Get comment`) still failed:

```
##[error]Unable to process file command 'env' successfully.
##[error]Invalid format '## Summary'
```

Run: https://github.com/netresearch/t3x-nr-image-optimize/actions/runs/24738689192

## Cause

The step ran:

```bash
readonly local comment=\$(git tag -n10 -l \"\${version}\" \"v\${version}\" | sed 's/...//g')
```

intending to read the tag's annotation. But `actions/checkout@v4` does a shallow fetch that frequently drops tag annotations. With no annotation, `git tag -n` falls through to the tagged **commit's** subject + body — multi-line content starting with the PR title and a `## Summary` heading from the merge commit. That multi-line value gets piped to `>> \$GITHUB_ENV` verbatim, and GitHub Actions rejects it (`## Summary` is not a valid env-var name).

Previous releases on this branch just happened to have short commit subjects that didn't break env parsing, so the bug went unnoticed.

## Fix

Drop the git-tag extraction entirely. Always build a deterministic single-line comment pointing at the GitHub release:

```
Released version X.Y.Z of {ext-key} -- for details see https://github.com/.../releases/tag/vX.Y.Z
```

The release body on GitHub is the authoritative, user-visible changelog, so the TER tooltip just needs to link to it.

## Additional hardening

All `${{ ... }}` substitutions that end up inside `run:` shell scripts are now routed through an `env:` block with `"$VAR"` references, per the [GitHub Actions workflow-injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/) — removes the last remaining direct interpolations in this workflow.

## Test plan

- [x] Regex check still accepts both `1.1.1` and `v1.1.1` (unchanged)
- [x] `Get version` unchanged (already correct from #81)
- [ ] After merge: re-publish v1.1.1 release → workflow runs cleanly → TER gets v1.1.1