### PR TITLE
ci: add workflow_dispatch-only caller for manual TER publish

### DIFF
--- a/.github/workflows/ter-publish.yml
+++ b/.github/workflows/ter-publish.yml
@@ -1,0 +1,14 @@
+name: Publish to TER (manual)
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish-to-ter:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
+    permissions:
+      contents: read
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
Mirrors the pattern used in [t3x-nr-llm](https://github.com/netresearch/t3x-nr-llm/blob/main/.github/workflows/ter-publish.yml) and [t3x-nr-mcp-agent](https://github.com/netresearch/t3x-nr-mcp-agent/blob/main/.github/workflows/ter-publish.yml) — a tiny caller with `on: workflow_dispatch` that forwards to the shared `publish-to-ter.yml` reusable workflow.

Use cases:
- Retry a failed TER publish after `release.yml` already ran (tailor timeouts, TER API hiccups)
- Re-upload a version after the GitHub release notes have been edited (the shared workflow reads the release body as the TER upload comment — so dispatching against the tag picks up the new text)
- Ship a TER-only fix without cutting a new tag

Trigger:
```
gh workflow run ter-publish.yml --ref v2.2.2
```

Immediate use case: re-push the updated v2.2.2 release notes (from #83) to TER, which will replace the current short comment with the honest release notes.