### PR TITLE
ci: add workflow_dispatch-only caller for manual TER publish (TYPO3_12 backport)

### DIFF
--- a/.github/workflows/ter-publish.yml
+++ b/.github/workflows/ter-publish.yml
@@ -1,0 +1,14 @@
+name: Publish to TER (manual)
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish-to-ter:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
+    permissions:
+      contents: read
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
Backport of the main-branch manual-trigger caller to TYPO3_12. Same pattern as [t3x-nr-llm](https://github.com/netresearch/t3x-nr-llm/blob/main/.github/workflows/ter-publish.yml).

Immediate use case: re-push the updated v1.1.1 release notes to TER with the honest expanded notes (zero-byte variant fix, license change, CI migration — not just the symlink fix).

NOTE: this new `ter-publish.yml` (workflow_dispatch-triggered, calls the shared reusable workflow, reads the GitHub release body as comment) does NOT conflict with the existing `publish-to-ter.yml` (release:published-triggered, uses a local hard-coded short comment). They are triggered by different events.