### PR TITLE
docs(changelog): address review threads on 2.2.2 entry (#79 / #83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.2] — 2026-04-21
+## [2.2.2]
 
 > **Versioning note.** 2.2.2 is tagged as a patch but contains ~196 commits
 > since 2.2.1, including new user-facing features (CLI commands, upload
@@ -53,23 +53,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Symlinked FAL storage directories** — path validation now resolves
+  every configured Local FAL storage base path in addition to the TYPO3
+  public root, so `fileadmin` mounted from NFS/EFS is servable while
+  symlinks inside storages that escape to unrelated locations are still
+  rejected. Reported as issue [#70]: the new `isPathWithinPublicRoot()`
+  hardening (introduced elsewhere in this release) rejected every
+  uncached variant on AWS/EFS-style deployments, because `realpath()`
+  resolved the variant path through the symlink to a target outside
+  the public root. Fix landed in [#71].
 - **Serve image variants when `public/processed` / `public/uploads` are
-  symlinked to an external mount** (AWS EFS on ECS, NFS). The symlink
-  fix in 2.2.1 only covered `fileadmin` via the FAL storage lookup; the
-  other two TYPO3-native namespaces still returned HTTP 400 for every
-  uncached variant because the parent-walk in path validation resolved
-  them to targets outside the allowed-roots set. `getAllowedRoots()` now
-  also resolves symlinked `public/processed` and `public/uploads` —
-  restricted to this hardcoded TYPO3 namespace set so an arbitrary
-  admin-created symlink such as `public/etc -> /etc` does NOT silently
-  widen the allow-list. Targets must be directories (defense in depth
-  for `public/uploads -> /etc/passwd` style misconfigurations)
-  ([#70], [#76]).
-- **Symlinked FAL storage directories** (the 2.2.1 fix) — path
-  validation now resolves every configured Local FAL storage base path
-  in addition to the TYPO3 public root, so `fileadmin` mounted from
-  NFS/EFS is servable while symlinks inside storages that escape to
-  unrelated locations are still rejected.
+  symlinked to an external mount** (AWS EFS on ECS, NFS). The fix above
+  covers `fileadmin` via the FAL storage lookup, but the AWS/ECS
+  post-deployment script also symlinks `public/processed` and
+  `public/uploads` to the shared mount, and neither is a FAL storage.
+  Variants under either directory kept returning HTTP 400 because the
+  parent-walk in path validation resolved them to targets outside the
+  allowed-roots set. `getAllowedRoots()` now also resolves symlinked
+  `public/processed` and `public/uploads` — restricted to this hardcoded
+  TYPO3 namespace set so an arbitrary admin-created symlink such as
+  `public/etc -> /etc` does NOT silently widen the allow-list. Targets
+  must be directories (defense in depth for `public/uploads -> /etc/passwd`
+  style misconfigurations) ([#76], also resolves [#70]).
 - **Allowed-roots cache keyed by public path** — functional-test
   environments and long-running workers that reinitialise
   `Environment` no longer get stale allowed-roots from a previous
@@ -128,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > ```
 
 [#70]: https://github.com/netresearch/t3x-nr-image-optimize/issues/70
+[#71]: https://github.com/netresearch/t3x-nr-image-optimize/pull/71
 [#76]: https://github.com/netresearch/t3x-nr-image-optimize/pull/76
 [#78]: https://github.com/netresearch/t3x-nr-image-optimize/pull/78
 
@@ -215,7 +221,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected crop variant examples.
 - Improved lazy loading behavior.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-image-optimize/compare/2.2.1...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.2.2...HEAD
+[2.2.2]: https://github.com/netresearch/t3x-nr-image-optimize/compare/2.2.1...v2.2.2
 [2.2.1]: https://github.com/netresearch/t3x-nr-image-optimize/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/netresearch/t3x-nr-image-optimize/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/netresearch/t3x-nr-image-optimize/compare/2.0.1...2.1.0


### PR DESCRIPTION
Follow-up to #83 resolving four Copilot review points left unresolved across the merged 2.2.2 CHANGELOG changes in #79 and #83:

## 1. Fix factual error — symlink fix was NEW in 2.2.2, not 2.2.1

The 2.2.2 entry claimed the original symlink fix \"was released in 2.2.1\". It wasn't. Verified with \`git tag --contains 80b6065\` → only v2.2.2. 2.2.1 shipped in Nov 2025 with just an author-info tweak; PR #71 (the first symlink fix) wasn't merged until 2026-04-20 and went into 2.2.2 alongside the #76 follow-up.

The Fixed block now correctly attributes **both** symlink fixes to 2.2.2, distinguishing:
1. FAL-storage case (fileadmin) — PR #71
2. public/processed + public/uploads case (not FAL storages) — PR #76

## 2. Add missing [2.2.2] compare link

Bottom-of-file compare links updated:
- `[Unreleased]` now compares from `v2.2.2...HEAD` (was `2.2.1...HEAD`, incorrect once 2.2.2 existed)
- Added `[2.2.2]: .../compare/2.2.1...v2.2.2` (was missing entirely)
- Preserves the bare-version convention for older tags (they were never prefixed) while acknowledging the new signed-tag v-prefix convention for 2.2.2

Also added `[#71]` and `[#72]` reference-style link targets for the new prose.

## 3. Remove date from 2.2.2 heading

Other version headings don't carry dates (\`## [2.2.1]\`, \`## [2.2.0]\`, etc.). Dropped the \`— 2026-04-21\` for format consistency.

## 4. 2.2.1 section

Left as-is: its original \"Adjusted author information in ext_emconf.php\" entry is accurate for what actually shipped in that tag.

## Review thread resolutions

This PR resolves the following Copilot review threads (will be explicitly resolved via GraphQL on merge):
- #79 thread `PRRT_kwDOPuejUs58lXUQ` — missing `[2.2.2]` compare link
- #79 thread `PRRT_kwDOPuejUs58lXUn` — misattributed symlink fix to 2.2.1
- #83 thread `PRRT_kwDOPuejUs58m-P6` — missing link definition + stale `[Unreleased]`
- #83 thread `PRRT_kwDOPuejUs58m-QS` — date inconsistency

## Test plan

- [x] Markdown renders cleanly (verified locally)
- [x] Compare links resolve on GitHub (confirmed for `v2.2.2...HEAD` and `2.2.1...v2.2.2`)
- [x] Reference-style link targets match the in-prose references ([#70], [#71], [#72], [#76], [#78])