### PR TITLE
fix(processor): log 400 responses, harden allowed-roots cache, functional symlink test (TYPO3_12 backport for #70)

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -147,16 +147,50 @@ case "${DBMS}" in
 esac
 
 # Docker images
-IMAGE_PHP="ghcr.io/typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
+IMAGE_PHP_BASE="ghcr.io/typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
+IMAGE_PHP="nr-image-optimize-testing-php${PHP_VERSION}:latest"
 IMAGE_ALPINE="docker.io/alpine:3.22"
 IMAGE_MARIADB="docker.io/mariadb:10"
 IMAGE_MYSQL="docker.io/mysql:8.0"
 IMAGE_POSTGRES="docker.io/postgres:16-alpine"
 
+# Build (or rebuild) a thin derived image that adds the Imagick PHP
+# extension to the upstream core-testing image. The intervention/image
+# driver used by the Processor requires imagick; the upstream core-testing
+# containers ship GD but NOT imagick, which makes every functional test
+# that constructs the Processor fail locally with
+# "Imagick PHP extension must be installed to use this driver".
+# CI sets this up via shivammathur/setup-php with php-extensions input —
+# this step gives local runs the same environment.
+#
+# The upstream image is docker-php based (php installs under /usr/local),
+# NOT the alpine-apk PHP, so the matching toolchain is pecl + the
+# docker-php-ext-enable helper. apk packages like php84-pecl-imagick
+# target the alpine /etc/php84 install and would not be picked up.
+ensure_imagick_image() {
+    local base="${IMAGE_PHP_BASE}"
+    local tagged="${IMAGE_PHP}"
+
+    # Refresh if the base image was just pulled or if the derived image
+    # does not exist yet; rebuilding is idempotent and the Dockerfile
+    # below has exactly one cache-friendly RUN layer.
+    if [ "${UPDATE_IMAGES}" = "yes" ] || ! ${CONTAINER_BIN} image inspect "${tagged}" >/dev/null 2>&1; then
+        echo "Building ${tagged} (adding imagick on top of ${base})..."
+        ${CONTAINER_BIN} build --quiet --tag "${tagged}" - <<EOF
+FROM ${base}
+RUN set -eux; \
+    apk add --no-cache --virtual .build-deps \$PHPIZE_DEPS imagemagick-dev pkgconf; \
+    pecl install imagick; \
+    docker-php-ext-enable imagick; \
+    apk del --no-network .build-deps
+EOF
+    fi
+}
+
 # Update images if requested
 if [ "${UPDATE_IMAGES}" = "yes" ]; then
     echo "Pulling latest Docker images..."
-    ${CONTAINER_BIN} pull "${IMAGE_PHP}"
+    ${CONTAINER_BIN} pull "${IMAGE_PHP_BASE}"
     case "${DBMS}" in
         mariadb)  ${CONTAINER_BIN} pull "${IMAGE_MARIADB}" ;;
         mysql)    ${CONTAINER_BIN} pull "${IMAGE_MYSQL}" ;;
@@ -164,6 +198,11 @@ if [ "${UPDATE_IMAGES}" = "yes" ]; then
     esac
     echo ""
 fi
+
+# Ensure the imagick-enabled derived image exists before any suite that
+# might run PHP against this project's codebase (cheap cache hit if
+# already built).
+ensure_imagick_image
 
 # Common container parameters
 CONTAINER_COMMON_PARAMS="--rm ${CI_PARAMS} --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -157,6 +157,25 @@ class Processor
     private static array $resolvedAllowedRootsByPublicPath = [];
 
     /**
+     * Per-request memoization of the resolved allowed-roots list.
+     *
+     * Reset at the top of generateAndSend() so a single request computes the
+     * list at most once — even on the error path where StorageRepository
+     * throws. Without this, getAllowedRoots() would be invoked three times
+     * per failing request (once per pathOriginal, pathVariant, and for the
+     * log context), each invocation retrying findAll() and emitting the
+     * "StorageRepository unavailable" log. That log flood surfaced in the
+     * #91/#92 PR review as a real observability concern.
+     *
+     * The static per-process cache ($resolvedAllowedRootsByPublicPath)
+     * handles the happy path across requests. This instance cache handles
+     * repeated calls within one request — on the failure path especially.
+     *
+     * @var list<string>|null
+     */
+    private ?array $requestAllowedRoots = null;
+
+    /**
      * Initialize the image processor with all required dependencies.
      *
      * @param ImageManager             $imageManager      Intervention Image manager used to read/encode images
@@ -199,6 +218,11 @@ class Processor
      */
     public function generateAndSend(RequestInterface $request): ResponseInterface
     {
+        // Reset the per-request allowed-roots memoization so a fresh list
+        // (or a fresh retry of StorageRepository::findAll() if it was
+        // unavailable earlier) is computed on the first call below.
+        $this->requestAllowedRoots = null;
+
         $variantUrl = urldecode($request->getUri()->getPath());
 
         $urlInfo = $this->gatherInformationBasedOnUrl($variantUrl);
@@ -710,10 +734,19 @@ class Processor
      */
     private function getAllowedRoots(): array
     {
+        // Per-request memoization: return the list computed earlier in
+        // this same request (including any degraded fallback from a
+        // StorageRepository throw), avoiding a redundant findAll() +
+        // duplicate warning log for the log-context and second
+        // isPathWithinAllowedRoots() call below.
+        if ($this->requestAllowedRoots !== null) {
+            return $this->requestAllowedRoots;
+        }
+
         $publicPathRaw = Environment::getPublicPath();
 
         if (isset(self::$resolvedAllowedRootsByPublicPath[$publicPathRaw])) {
-            return self::$resolvedAllowedRootsByPublicPath[$publicPathRaw];
+            return $this->requestAllowedRoots = self::$resolvedAllowedRootsByPublicPath[$publicPathRaw];
         }
 
         $roots      = [];
@@ -819,13 +852,19 @@ class Processor
 
         $resolved = array_keys($roots);
 
-        // Only cache successful lookups. If the StorageRepository threw, the
-        // allow-list is degraded (public root only, without FAL storages).
-        // Caching that would persist the degraded result for the rest of the
-        // PHP-FPM worker's lifetime — every storage-backed variant request
-        // would return 400 until the worker recycles, even after the
-        // transient failure (TCA not yet loaded, DB hiccup, cache rebuild,
-        // etc.) has cleared. Retry on the next request instead.
+        // Always populate the per-request cache so follow-up calls in the
+        // same request (second isPathWithinAllowedRoots, log context, …)
+        // reuse this result instead of retrying findAll() and re-emitting
+        // the StorageRepository-unavailable log line.
+        $this->requestAllowedRoots = $resolved;
+
+        // Only populate the static per-process cache on success. A degraded
+        // fallback (public root only, without FAL storages) must not be
+        // cached across requests — otherwise a single transient failure
+        // (TCA not yet loaded, DB hiccup, cache rebuild, …) poisons every
+        // storage-backed variant request for the rest of the PHP-FPM
+        // worker's lifetime. generateAndSend() resets the per-request
+        // cache on the next invocation, giving findAll() another chance.
         if (!$storageLookupFailed) {
             self::$resolvedAllowedRootsByPublicPath[$publicPathRaw] = $resolved;
         }

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -33,6 +33,7 @@ use function file_exists;
 use function filemtime;
 use function filesize;
 use function gmdate;
+use function implode;
 use function is_dir;
 use function is_link;
 use function is_string;
@@ -202,15 +203,38 @@ class Processor
 
         $urlInfo = $this->gatherInformationBasedOnUrl($variantUrl);
 
-        // Reject requests that did not match the expected URL pattern
+        // Reject requests that did not match the expected URL pattern.
+        // Intentionally logged via error_log() (not the PSR logger) for
+        // consistency with the existing catch-branch diagnostic in
+        // getAllowedRoots(): this TYPO3_12 maintenance-branch keeps a
+        // narrow dependency surface and does not pull in LoggerAwareTrait.
         if ($urlInfo === null) {
+            error_log(sprintf(
+                'nr_image_optimize: rejecting variant request with 400 (URL does not match expected pattern): url=%s',
+                $variantUrl,
+            ));
+
             return $this->responseFactory->createResponse(400);
         }
 
         // Validate that both resolved paths stay within an allowed root
-        if (!$this->isPathWithinAllowedRoots($urlInfo['pathOriginal'])
-            || !$this->isPathWithinAllowedRoots($urlInfo['pathVariant'])
-        ) {
+        $originalAllowed = $this->isPathWithinAllowedRoots($urlInfo['pathOriginal']);
+        $variantAllowed  = $this->isPathWithinAllowedRoots($urlInfo['pathVariant']);
+
+        if (!$originalAllowed || !$variantAllowed) {
+            error_log(sprintf(
+                'nr_image_optimize: rejecting variant request with 400 (path outside allowed roots): '
+                . 'url=%s pathOriginal=%s pathVariant=%s originalAllowed=%s variantAllowed=%s '
+                . 'allowedRoots=[%s] publicPath=%s',
+                $variantUrl,
+                $urlInfo['pathOriginal'],
+                $urlInfo['pathVariant'],
+                $originalAllowed ? '1' : '0',
+                $variantAllowed ? '1' : '0',
+                implode(', ', $this->getAllowedRoots()),
+                Environment::getPublicPath(),
+            ));
+
             return $this->responseFactory->createResponse(400);
         }
 
@@ -699,6 +723,12 @@ class Processor
             $roots[$publicPath] = true;
         }
 
+        // The try/catch also protects tests that construct Processor via
+        // ReflectionClass::newInstanceWithoutConstructor() without injecting
+        // this readonly property — accessing an uninitialized typed property
+        // throws Error, which extends Throwable.
+        $storageLookupFailed = false;
+
         try {
             foreach ($this->storageRepository->findAll() as $storage) {
                 if ($storage->getDriverType() !== 'Local') {
@@ -738,6 +768,8 @@ class Processor
                 'nr_image_optimize: path validation limited to public root; StorageRepository unavailable: %s',
                 $e->getMessage(),
             ));
+
+            $storageLookupFailed = true;
         }
 
         // The FAL-storage lookup above resolves fileadmin (its basePath is
@@ -787,7 +819,16 @@ class Processor
 
         $resolved = array_keys($roots);
 
-        self::$resolvedAllowedRootsByPublicPath[$publicPathRaw] = $resolved;
+        // Only cache successful lookups. If the StorageRepository threw, the
+        // allow-list is degraded (public root only, without FAL storages).
+        // Caching that would persist the degraded result for the rest of the
+        // PHP-FPM worker's lifetime — every storage-backed variant request
+        // would return 400 until the worker recycles, even after the
+        // transient failure (TCA not yet loaded, DB hiccup, cache rebuild,
+        // etc.) has cleared. Retry on the next request instead.
+        if (!$storageLookupFailed) {
+            self::$resolvedAllowedRootsByPublicPath[$publicPathRaw] = $resolved;
+        }
 
         return $resolved;
     }

--- a/Tests/Functional/ProcessorSymlinkedFileadminTest.php
+++ b/Tests/Functional/ProcessorSymlinkedFileadminTest.php
@@ -29,6 +29,7 @@ use function is_link;
 use function mkdir;
 use function rmdir;
 use function scandir;
+use function sprintf;
 use function symlink;
 use function uniqid;
 use function unlink;

--- a/Tests/Functional/ProcessorSymlinkedFileadminTest.php
+++ b/Tests/Functional/ProcessorSymlinkedFileadminTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-image-optimize.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrImageOptimize\Tests\Functional;
+
+use Netresearch\NrImageOptimize\Processor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Functional regression tests for issue #70 and its follow-ups, exercising
+ * the real TYPO3 bootstrap + FAL LocalDriver + middleware request cycle
+ * against a test instance where fileadmin / processed / uploads are
+ * symlinks to an external directory outside the public root.
+ *
+ * This mirrors the Chemnitz AWS/ECS + EFS production layout where
+ * scripts/post-deployment links public/fileadmin, public/processed and
+ * public/uploads into /mnt/efs/cms/ before the webserver starts.
+ *
+ * The earlier unit tests in ProcessorTest exercise isPathWithinAllowedRoots
+ * via reflection with a mocked StorageRepository; these tests drive the
+ * exact same code through generateAndSend() with the real DI container and
+ * a real fileadmin storage, to prove the fix works end-to-end and not just
+ * against a mocked boundary.
+ */
+#[CoversClass(Processor::class)]
+final class ProcessorSymlinkedFileadminTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'netresearch/nr-image-optimize',
+    ];
+
+    /**
+     * Stage the source image into a neutral location inside the test
+     * instance; setUp() below moves it into the external "EFS-like"
+     * directory and restores the expected symlinked layout.
+     */
+    protected array $pathsToProvideInTestInstance = [
+        'typo3conf/ext/nr_image_optimize/Tests/Functional/Fixtures/test-image.png' => 'typo3temp/nr-pio-fixture/test-image.png',
+    ];
+
+    /**
+     * Absolute path to the external directory simulating the EFS mount.
+     * Allocated in setUp(), cleaned up in tearDown().
+     */
+    private string $externalMount = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $publicPath = Environment::getPublicPath();
+
+        // Sanity: the staged fixture must be readable before we start
+        // restructuring the public tree.
+        $fixture = $publicPath . '/typo3temp/nr-pio-fixture/test-image.png';
+        self::assertFileExists($fixture, 'Fixture staging failed');
+
+        // External mount lives OUTSIDE publicPath so that realpath() on the
+        // symlinks resolves to a target that does NOT start with publicPath
+        // — this is exactly the condition that triggered HTTP 400 in #70.
+        $this->externalMount = dirname($publicPath) . '/nr-pio-efs-' . uniqid('', true);
+        mkdir($this->externalMount . '/fileadmin', 0o777, true);
+        mkdir($this->externalMount . '/processed', 0o777, true);
+        mkdir($this->externalMount . '/uploads', 0o777, true);
+
+        // Copy (do not rename) the fixture into the external fileadmin:
+        // the testing framework reuses the instance across tests in the
+        // same case and only populates pathsToProvideInTestInstance on the
+        // first test, so subsequent setUps rely on the staged copy still
+        // being readable at its original location.
+        copy($fixture, $this->externalMount . '/fileadmin/test-image.png');
+
+        // Replace the real public/fileadmin directory (created by the
+        // testing framework) with a symlink pointing into the external
+        // mount — mirrors `ln -sf /mnt/efs/cms/fileadmin/ /var/www/public`
+        // from chemnitz/cms/main/scripts/post-deployment.
+        $this->replaceDirWithSymlink(
+            $publicPath . '/fileadmin',
+            $this->externalMount . '/fileadmin',
+        );
+        $this->replaceDirWithSymlink(
+            $publicPath . '/processed',
+            $this->externalMount . '/processed',
+        );
+        $this->replaceDirWithSymlink(
+            $publicPath . '/uploads',
+            $this->externalMount . '/uploads',
+        );
+
+        // getAllowedRoots() caches the resolved list statically across
+        // invocations. Parent setUp() may already have resolved it against
+        // the non-symlinked layout — reset so our symlink layout is picked
+        // up on the first real request.
+        $this->resetAllowedRootsCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetAllowedRootsCache();
+
+        if ($this->externalMount !== '' && is_dir($this->externalMount)) {
+            $this->removeRecursive($this->externalMount);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Core regression for #70: with `public/fileadmin` symlinked to an
+     * external directory outside the public root, a request for an
+     * uncached image variant must succeed (not return HTTP 400 from path
+     * validation).
+     */
+    #[Test]
+    public function uncachedVariantUnderSymlinkedFileadminReturns200(): void
+    {
+        $processor = $this->get(Processor::class);
+
+        $uri     = new Uri('https://example.com/processed/fileadmin/test-image.w50h38m0q80.png');
+        $request = new ServerRequest($uri);
+
+        $response = $processor->generateAndSend($request);
+
+        self::assertNotSame(
+            400,
+            $response->getStatusCode(),
+            'Path validation rejected a request under symlinked fileadmin. '
+            . 'Check the regression conditions of issue #70.',
+        );
+        self::assertSame(200, $response->getStatusCode());
+
+        // The variant must actually have been written to the external
+        // mount (following the symlink), not to the empty public/processed.
+        self::assertFileExists(
+            $this->externalMount . '/processed/fileadmin/test-image.w50h38m0q80.png',
+            'Variant should be stored through the public/processed symlink on the external mount',
+        );
+    }
+
+    /**
+     * Serving an already-cached variant under a symlinked public/processed
+     * (the #70 follow-up path-variant branch of isPathWithinAllowedRoots)
+     * must succeed on the second request too.
+     */
+    #[Test]
+    public function cachedVariantUnderSymlinkedProcessedIsServedFromCache(): void
+    {
+        $processor = $this->get(Processor::class);
+
+        $uri     = new Uri('https://example.com/processed/fileadmin/test-image.w50h38m0q80.png');
+        $request = new ServerRequest($uri);
+
+        // First request generates the variant; second must hit the cached-
+        // file short-circuit at the top of generateAndSend().
+        $first = $processor->generateAndSend($request);
+        self::assertSame(200, $first->getStatusCode(), 'First request failed — base regression broken');
+
+        $second = $processor->generateAndSend($request);
+        self::assertSame(200, $second->getStatusCode(), 'Second request failed — cached-variant path validation broken under symlinks');
+        self::assertNotEmpty($second->getHeaderLine('Cache-Control'));
+    }
+
+    /**
+     * Security guarantee: the symlinked-fileadmin fix must not be
+     * permissive enough to let a traversal sequence escape the allowed
+     * roots and hit an arbitrary file on disk.
+     */
+    #[Test]
+    public function pathTraversalStillRejectedWhenFileadminIsSymlinked(): void
+    {
+        $processor = $this->get(Processor::class);
+
+        $uri     = new Uri('https://example.com/processed/../../etc/passwd.w100h75m0q80.png');
+        $request = new ServerRequest($uri);
+
+        $response = $processor->generateAndSend($request);
+
+        self::assertSame(
+            400,
+            $response->getStatusCode(),
+            'Path traversal bypassed validation when fileadmin is a symlink',
+        );
+    }
+
+    /**
+     * Atomically replace `$linkTarget` (likely an empty directory created by
+     * the testing framework) with a symlink pointing at `$linkDestination`.
+     */
+    private function replaceDirWithSymlink(string $linkTarget, string $linkDestination): void
+    {
+        if (is_link($linkTarget)) {
+            unlink($linkTarget);
+        } elseif (is_dir($linkTarget)) {
+            $this->removeRecursive($linkTarget);
+        } elseif (file_exists($linkTarget)) {
+            unlink($linkTarget);
+        }
+
+        symlink($linkDestination, $linkTarget);
+    }
+
+    /**
+     * Recursively remove a directory tree — symlinks are unlinked without
+     * descending into their target so we don't accidentally delete the
+     * external mount contents.
+     */
+    private function removeRecursive(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            unlink($path);
+
+            return;
+        }
+
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        if ($entries === false) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $this->removeRecursive($path . '/' . $entry);
+        }
+
+        rmdir($path);
+    }
+
+    /**
+     * Clear the static allowed-roots cache on Processor so that
+     * getAllowedRoots() rebuilds against the current on-disk layout.
+     */
+    private function resetAllowedRootsCache(): void
+    {
+        $reflection = new ReflectionClass(Processor::class);
+
+        if (!$reflection->hasProperty('resolvedAllowedRootsByPublicPath')) {
+            return;
+        }
+
+        $property = $reflection->getProperty('resolvedAllowedRootsByPublicPath');
+        $property->setValue(null, []);
+    }
+}

--- a/Tests/Functional/ProcessorSymlinkedFileadminTest.php
+++ b/Tests/Functional/ProcessorSymlinkedFileadminTest.php
@@ -95,7 +95,12 @@ final class ProcessorSymlinkedFileadminTest extends FunctionalTestCase
         // same case and only populates pathsToProvideInTestInstance on the
         // first test, so subsequent setUps rely on the staged copy still
         // being readable at its original location.
-        copy($fixture, $this->externalMount . '/fileadmin/test-image.png');
+        $fixtureTarget = $this->externalMount . '/fileadmin/test-image.png';
+        self::assertTrue(
+            copy($fixture, $fixtureTarget),
+            sprintf('Fixture copy failed: %s -> %s', $fixture, $fixtureTarget),
+        );
+        self::assertFileExists($fixtureTarget, 'Fixture copy silently produced no file');
 
         // Replace the real public/fileadmin directory (created by the
         // testing framework) with a symlink pointing into the external
@@ -216,11 +221,11 @@ final class ProcessorSymlinkedFileadminTest extends FunctionalTestCase
     private function replaceDirWithSymlink(string $linkTarget, string $linkDestination): void
     {
         if (is_link($linkTarget)) {
-            unlink($linkTarget);
+            unlink($linkTarget); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp symlink
         } elseif (is_dir($linkTarget)) {
             $this->removeRecursive($linkTarget);
         } elseif (file_exists($linkTarget)) {
-            unlink($linkTarget);
+            unlink($linkTarget); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
         }
 
         symlink($linkDestination, $linkTarget);
@@ -234,7 +239,7 @@ final class ProcessorSymlinkedFileadminTest extends FunctionalTestCase
     private function removeRecursive(string $path): void
     {
         if (is_link($path) || is_file($path)) {
-            unlink($path);
+            unlink($path); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp files
 
             return;
         }

--- a/Tests/Functional/ProcessorSymlinkedFileadminTest.php
+++ b/Tests/Functional/ProcessorSymlinkedFileadminTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the package netresearch/nr-image-optimize.
  *
  * For the full copyright and license information, please read the
@@ -19,6 +19,19 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+use function copy;
+use function dirname;
+use function file_exists;
+use function is_dir;
+use function is_file;
+use function is_link;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function symlink;
+use function uniqid;
+use function unlink;
 
 /**
  * Functional regression tests for issue #70 and its follow-ups, exercising

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -1892,12 +1892,20 @@ class ProcessorTest extends TestCase
 
             // First call hits the throw: fileadmin path is only accepted if
             // the processor also falls back to accepting paths under the
-            // public root (fileadmin lives inside public/, so this passes)
+            // public root (fileadmin lives inside public/, so this passes).
+            // This simulates request N where findAll() throws.
             self::assertTrue($this->callMethod(
                 $processor,
                 'isPathWithinAllowedRoots',
                 $tempDir . '/public/fileadmin',
             ));
+
+            // Simulate the next incoming request by resetting the instance-
+            // level requestAllowedRoots cache (in production, generateAndSend()
+            // does this at its entry). Without this reset the test would not
+            // catch the degraded-static-cache bug — only the instance cache
+            // would shield the second call from findAll() re-invocation.
+            $this->setProperty($processor, 'requestAllowedRoots', null);
 
             // Second call must trigger findAll() AGAIN — that's the whole
             // point: recover once the transient error has cleared.

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -1849,6 +1849,71 @@ class ProcessorTest extends TestCase
     }
 
     /**
+     * Regression test for bootstrap-race concern raised on #70 follow-up: a
+     * transient failure of StorageRepository::findAll() (TCA not yet loaded,
+     * DB hiccup, cache rebuild in flight, …) used to permanently poison the
+     * static allowed-roots cache for the rest of the PHP-FPM worker's life,
+     * silently returning HTTP 400 for every storage-backed variant request
+     * even after the underlying condition had cleared.
+     *
+     * After the fix, the degraded fallback (public root only) is returned
+     * for the current request but NOT cached, so a subsequent request with
+     * a healthy StorageRepository rebuilds the full allow-list including
+     * FAL storages.
+     */
+    #[Test]
+    public function isPathWithinAllowedRootsDoesNotCacheDegradedFallbackOnStorageThrow(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/nr-pio-no-cache-err-' . uniqid('', true);
+        mkdir($tempDir . '/public/fileadmin', 0o777, true);
+
+        $healthyStorage = $this->createMock(ResourceStorage::class);
+        $healthyStorage->method('getDriverType')->willReturn('Local');
+        $healthyStorage->method('getConfiguration')->willReturn([
+            'basePath' => 'fileadmin/',
+            'pathType' => 'relative',
+        ]);
+
+        // First call throws (degraded result must NOT be cached); second call
+        // succeeds (now the full allow-list must be built from scratch).
+        $storageRepository = $this->createMock(StorageRepository::class);
+        $storageRepository->expects(self::exactly(2))
+            ->method('findAll')
+            ->willReturnOnConsecutiveCalls(
+                self::throwException(new RuntimeException('TCA not yet initialised')),
+                [$healthyStorage],
+            );
+
+        try {
+            $this->initializeEnvironment($tempDir, $tempDir . '/public');
+
+            $processor = $this->createProcessor(storageRepository: $storageRepository);
+            $this->resetAllowedRootsCache();
+
+            // First call hits the throw: fileadmin path is only accepted if
+            // the processor also falls back to accepting paths under the
+            // public root (fileadmin lives inside public/, so this passes)
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/fileadmin',
+            ));
+
+            // Second call must trigger findAll() AGAIN — that's the whole
+            // point: recover once the transient error has cleared.
+            self::assertTrue($this->callMethod(
+                $processor,
+                'isPathWithinAllowedRoots',
+                $tempDir . '/public/fileadmin',
+            ));
+        } finally {
+            $this->removeOwnedTempTree($tempDir);
+            $this->resetAllowedRootsCache();
+            $this->initializeDefaultEnvironment();
+        }
+    }
+
+    /**
      * The static cache must short-circuit repeat invocations —
      * StorageRepository::findAll() should be consulted once per process.
      */


### PR DESCRIPTION
Backport of [#91](https://github.com/netresearch/t3x-nr-image-optimize/pull/91) to the \`TYPO3_12\` branch. **This is the branch line Chemnitz actually runs on** (TYPO3 v12.4.45, via \`chemnitz/cms/main\`).

See [#91](https://github.com/netresearch/t3x-nr-image-optimize/pull/91) for the full rationale — in short:

1. \`Processor::generateAndSend()\` used to return HTTP 400 silently at two points (URL pattern mismatch, path outside allowed roots). Admins had nothing in the log to diagnose against.
2. \`getAllowedRoots()\` used to cache a degraded fallback when \`StorageRepository::findAll()\` threw, poisoning the static cache for the rest of the PHP-FPM worker's life.
3. There were **zero** functional tests covering the symlinked-fileadmin scenario — all coverage was unit-only with a mocked \`StorageRepository\`.

## TYPO3_12-specific adjustments from the \`main\` PR

- **Logging uses \`error_log()\`**, not the PSR \`getLogger()\` helper: this branch keeps a narrow dependency surface and \`Processor\` does not implement \`LoggerAwareInterface\` (consistent with the existing catch-branch in \`getAllowedRoots()\`).
- **Log format**: key=value printf-style rather than PSR context array (dictated by \`error_log()\`), but the same diagnostic payload: url, pathOriginal, pathVariant, which of the two checks failed, the resolved allowedRoots list, and publicPath.

Everything else — the functional test, the cache-fix flag, the unit test for the cache-fix — is unchanged.

## Regression test

\`Tests/Functional/ProcessorSymlinkedFileadminTest.php\` reproduces the exact Chemnitz AWS ECS + EFS layout from [chemnitz/cms/main/scripts/post-deployment](https://git.netresearch.de/chemnitz/cms/main/-/blob/main/scripts/post-deployment):

\`\`\`bash
ln -sf \$efsPath/fileadmin/  /var/www/public/fileadmin
ln -sf \$efsPath/processed/  /var/www/public/processed
ln -sf \$efsPath/uploads/    /var/www/public/uploads
\`\`\`

Empirically verified (on the \`main\` PR, same test code) that the test fails when either the #70 core FAL-storage expansion OR the #76 follow-up processed/uploads expansion is removed. Not a vacuous regression test.

## Test plan

- [x] \`Build/Scripts/runTests.sh -s unit\` — **258 tests, 638 assertions, 0 errors** (incl. new \`isPathWithinAllowedRootsDoesNotCacheDegradedFallbackOnStorageThrow\`)
- [x] PHPStan, Rector (dry-run), Fractor (dry-run), CS-Fixer, Lint: all green
- [ ] Functional tests require the Imagick PHP extension which is missing on my local Docker image; CI matrix installs it explicitly (\`php-extensions: ..., imagick, gd\` in \`.github/workflows/ci.yml\`), so the 3 new tests will run there.

## Scope

Does not close #70 (already closed). Addresses the follow-up reports on v1.1.1 — Chemnitz is the known EFS-symlink reporter and will consume this as v1.1.2.

## Checklist

- [x] CI checks pass locally (except Imagick-requiring functional tests)
- [x] Tests added for each behavior change
- [ ] CHANGELOG.md — will update in the release PR
- [ ] Documentation — internal diagnostic output only, no user-facing API change