### PR TITLE
test(functional): restore strict coverage metadata + switch CI to xdebug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         run-functional-tests: true
         functional-test-db: 'sqlite'
         php-extensions: 'intl, mbstring, xml, imagick, gd'
+        # Use xdebug instead of pcov for coverage. xdebug delivers branch
+        # coverage + path coverage and matches the local dev driver
+        # (composer ci:test:php:unit:coverage sets XDEBUG_MODE=coverage).
+        # pcov is faster but line-only; in our matrix the ~2-3 min extra
+        # CI time is worth the richer signal + local/CI parity.
+        coverage-tool: 'xdebug'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -4,7 +4,7 @@
          bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
          cacheDirectory="../.build/.phpunit.cache"
          executionOrder="depends,defects"
-         beStrictAboutCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"

--- a/Tests/Functional/Middleware/ProcessingMiddlewareTest.php
+++ b/Tests/Functional/Middleware/ProcessingMiddlewareTest.php
@@ -11,8 +11,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrImageOptimize\Tests\Functional\Middleware;
 
+use Netresearch\NrImageOptimize\Event\VariantServedEvent;
 use Netresearch\NrImageOptimize\Middleware\ProcessingMiddleware;
 use Netresearch\NrImageOptimize\Processor;
+use Netresearch\NrImageOptimize\Service\ImageManagerAdapter;
+use Netresearch\NrImageOptimize\Service\ImageManagerFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -26,9 +29,18 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
  * Functional tests for ProcessingMiddleware PSR-15 pipeline behavior.
+ *
+ * Declares UsesClass for everything the middleware transitively exercises
+ * when it delegates to Processor (image processing service chain + events).
+ * beStrictAboutCoverageMetadata fails the run on anything unlisted here
+ * so this list must stay in sync with what the Processor actually pulls
+ * in via DI — growing pains of integration tests.
  */
 #[CoversClass(ProcessingMiddleware::class)]
 #[UsesClass(Processor::class)]
+#[UsesClass(ImageManagerAdapter::class)]
+#[UsesClass(ImageManagerFactory::class)]
+#[UsesClass(VariantServedEvent::class)]
 final class ProcessingMiddlewareTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/ProcessorSymlinkedFileadminTest.php
+++ b/Tests/Functional/ProcessorSymlinkedFileadminTest.php
@@ -11,9 +11,14 @@ declare(strict_types=1);
 
 namespace Netresearch\NrImageOptimize\Tests\Functional;
 
+use Netresearch\NrImageOptimize\Event\ImageProcessedEvent;
+use Netresearch\NrImageOptimize\Event\VariantServedEvent;
 use Netresearch\NrImageOptimize\Processor;
+use Netresearch\NrImageOptimize\Service\ImageManagerAdapter;
+use Netresearch\NrImageOptimize\Service\ImageManagerFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use ReflectionClass;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -37,6 +42,10 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * against a mocked boundary.
  */
 #[CoversClass(Processor::class)]
+#[UsesClass(ImageManagerAdapter::class)]
+#[UsesClass(ImageManagerFactory::class)]
+#[UsesClass(ImageProcessedEvent::class)]
+#[UsesClass(VariantServedEvent::class)]
 final class ProcessorSymlinkedFileadminTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/ProcessorTest.php
+++ b/Tests/Functional/ProcessorTest.php
@@ -13,9 +13,14 @@ namespace Netresearch\NrImageOptimize\Tests\Functional;
 
 use function getimagesize;
 
+use Netresearch\NrImageOptimize\Event\ImageProcessedEvent;
+use Netresearch\NrImageOptimize\Event\VariantServedEvent;
 use Netresearch\NrImageOptimize\Processor;
+use Netresearch\NrImageOptimize\Service\ImageManagerAdapter;
+use Netresearch\NrImageOptimize\Service\ImageManagerFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Uri;
@@ -25,9 +30,16 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * Functional tests for the Processor with real image fixtures.
  *
  * These tests verify actual image processing (resize/crop) behavior
- * against test fixture images.
+ * against test fixture images. They drive the full image-processing chain
+ * the Processor delegates into (ImageManager adapter/factory) and dispatch
+ * the pre-/post-processing events, so those classes must be declared via
+ * UsesClass to satisfy beStrictAboutCoverageMetadata.
  */
 #[CoversClass(Processor::class)]
+#[UsesClass(ImageManagerAdapter::class)]
+#[UsesClass(ImageManagerFactory::class)]
+#[UsesClass(ImageProcessedEvent::class)]
+#[UsesClass(VariantServedEvent::class)]
 final class ProcessorTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [


### PR DESCRIPTION
Follow-up to [#91](https://github.com/netresearch/t3x-nr-image-optimize/pull/91) review: the \`beStrictAboutCoverageMetadata=\"false\"\` relaxation there was a pragmatic unblocker to get the symlink regression landed, but loses enforcement value. This PR restores strict metadata and annotates the 17 functional tests that were surfacing as \"risky\" with precise \`#[UsesClass]\` attributes.

## What changed

### \`Build/FunctionalTests.xml\`
- \`beStrictAboutCoverageMetadata=\"true\"\` (reverted the earlier relaxation)

### Functional tests — explicit coverage deklarations
| Test file | Added \`#[UsesClass]\` |
|---|---|
| \`ProcessingMiddlewareTest\` | \`ImageManagerAdapter\`, \`ImageManagerFactory\`, \`VariantServedEvent\` (already had \`Processor\`) |
| \`ProcessorTest\` | \`ImageManagerAdapter\`, \`ImageManagerFactory\`, \`ImageProcessedEvent\`, \`VariantServedEvent\` |
| \`ProcessorSymlinkedFileadminTest\` | \`ImageManagerAdapter\`, \`ImageManagerFactory\`, \`ImageProcessedEvent\`, \`VariantServedEvent\` |

Every test now declares — at the class level via \`#[UsesClass(...)]\` — every non-test class it transitively executes during coverage. Future DI changes that add new transitive executions will surface as risky failures, which is the **point** of the strict policy.

### CI coverage driver: pcov → xdebug

\`.github/workflows/ci.yml\` now passes \`coverage-tool: 'xdebug'\` to the reusable workflow.

**Why xdebug over pcov:**
1. **Branch + path coverage** — pcov is line-only. xdebug catches untested branches.
2. **Local/CI parity** — \`composer ci:test:php:unit:coverage\` already sets \`XDEBUG_MODE=coverage\` locally; using xdebug in CI too eliminates \"works locally, different story in CI\" drift (which is how the \"risky\" tests surfaced in #91 in the first place).
3. **Cost** — ~2-3 min extra CI runtime across the 8-job matrix; acceptable for the diagnostic gain.

A parallel PR against [\`netresearch/typo3-ci-workflows\`](https://github.com/netresearch/typo3-ci-workflows) will flip the default org-wide. Until then this explicit override captures intent.

## Test plan

- [x] 30/30 functional tests pass locally with \`beStrictAboutCoverageMetadata=true\` + \`XDEBUG_MODE=coverage\`, zero risky reports
- [x] 549/549 unit tests still green
- [x] PHPStan, Rector, Fractor, CS-Fixer, Lint all green
- [ ] CI green on all 8 matrix variants (validated post-merge)

## Related

- [#91](https://github.com/netresearch/t3x-nr-image-optimize/pull/91) landed the symlink regression with the relaxation; this closes that loop.
- Backport to \`TYPO3_12\` opens as a sibling PR.