### PR TITLE
ci: switch coverage driver to xdebug (TYPO3_12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
       # tests don't).
       php-extensions: intl, mbstring, xml, imagick, gd
       run-functional-tests: true
+      # Use xdebug instead of pcov for coverage. xdebug delivers branch
+      # coverage + path coverage and matches the local dev driver
+      # (composer ci:test:php:unit:coverage sets XDEBUG_MODE=coverage).
+      # pcov is faster but line-only; in our matrix the ~2-3 min extra
+      # CI time is worth the richer signal + local/CI parity.
+      coverage-tool: 'xdebug'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Companion to [#93](https://github.com/netresearch/t3x-nr-image-optimize/pull/93). Backport the CI coverage driver switch (pcov → xdebug) to TYPO3_12.

**What's included here (and what's not):**

- ✅ CI coverage driver: pcov → xdebug (in \`.github/workflows/ci.yml\`)
- ❌ **Not** the UsesClass additions from #93 — the TYPO3_12 \`Processor\` has a different architecture (no \`ImageManagerAdapter\` / \`ImageManagerFactory\` / \`ImageProcessedEvent\` / \`VariantServedEvent\` classes that exist on main). Its functional tests already pass with \`beStrictAboutCoverageMetadata=true\` without additional UsesClass declarations — verified locally.

**Why xdebug over pcov:**
- branch coverage + path coverage (pcov is line-only)
- matches the local dev driver (\`composer ci:test:php:unit:coverage\` already uses \`XDEBUG_MODE=coverage\`)
- ~2-3 min extra CI runtime, acceptable for the diagnostic gain

## Test plan

- [x] 30/30 functional tests pass locally with \`XDEBUG_MODE=coverage\` + strict metadata
- [x] 258/258 unit tests still green
- [ ] CI verifies on the 3 matrix variants (PHP 8.2/8.3/8.4 × TYPO3 ^12.0)

## Related

- [#93](https://github.com/netresearch/t3x-nr-image-optimize/pull/93) — sibling main PR
- Upcoming PR on \`netresearch/typo3-ci-workflows\` to flip the default org-wide