### PR TITLE
test(acceptance): fix SourceSet type-attribute tests to match intent

### DIFF
--- a/Tests/Acceptance/ViewHelpers/SourceSetViewHelperHtmlOutputTest.php
+++ b/Tests/Acceptance/ViewHelpers/SourceSetViewHelperHtmlOutputTest.php
@@ -259,8 +259,17 @@ class SourceSetViewHelperHtmlOutputTest extends TestCase
         self::assertStringContainsString('/processed/fileadmin/product.w600h400m0q100.jpg 2x', $srcset);
     }
 
+    /**
+     * For universally-supported formats (JPEG, PNG, GIF) the view helper
+     * deliberately omits the `type` attribute — every browser that supports
+     * `<picture>` also supports those formats, so the type hint would only
+     * add markup noise without giving the browser any skip-signal.
+     *
+     * See `SourceSetViewHelper::EXTENSION_MIME_MAP` for the intentional
+     * format whitelist (webp, avif only).
+     */
     #[Test]
-    public function sourceElementHasCorrectTypeAttribute(): void
+    public function sourceElementHasNoTypeAttributeForJpeg(): void
     {
         $this->viewHelper->setArguments([
             'path'   => '/fileadmin/product.jpg',
@@ -276,11 +285,14 @@ class SourceSetViewHelperHtmlOutputTest extends TestCase
 
         $source = $this->getFirstElement($doc, 'source');
         self::assertNotNull($source);
-        self::assertSame('image/jpeg', $source->getAttribute('type'));
+        self::assertFalse(
+            $source->hasAttribute('type'),
+            'source elements for JPEG must not carry a type attribute (universally supported format)',
+        );
     }
 
     #[Test]
-    public function sourceElementHasCorrectTypeForPng(): void
+    public function sourceElementHasNoTypeAttributeForPng(): void
     {
         $this->viewHelper->setArguments([
             'path'   => '/fileadmin/product.png',
@@ -296,7 +308,78 @@ class SourceSetViewHelperHtmlOutputTest extends TestCase
 
         $source = $this->getFirstElement($doc, 'source');
         self::assertNotNull($source);
-        self::assertSame('image/png', $source->getAttribute('type'));
+        self::assertFalse(
+            $source->hasAttribute('type'),
+            'source elements for PNG must not carry a type attribute (universally supported format)',
+        );
+    }
+
+    #[Test]
+    public function sourceElementHasNoTypeAttributeForGif(): void
+    {
+        $this->viewHelper->setArguments([
+            'path'   => '/fileadmin/animation.gif',
+            'width'  => 600,
+            'height' => 400,
+            'set'    => [
+                480 => ['width' => 300, 'height' => 200],
+            ],
+        ]);
+
+        $html = $this->viewHelper->render();
+        $doc  = $this->parseHtml($html);
+
+        $source = $this->getFirstElement($doc, 'source');
+        self::assertNotNull($source);
+        self::assertFalse(
+            $source->hasAttribute('type'),
+            'source elements for GIF must not carry a type attribute (universally supported format)',
+        );
+    }
+
+    /**
+     * For next-gen formats (webp, avif) the type attribute lets the browser
+     * skip downloading a `<source>` it can't decode, so the view helper
+     * emits it explicitly.
+     */
+    #[Test]
+    public function sourceElementHasCorrectTypeForWebp(): void
+    {
+        $this->viewHelper->setArguments([
+            'path'   => '/fileadmin/photo.webp',
+            'width'  => 600,
+            'height' => 400,
+            'set'    => [
+                480 => ['width' => 300, 'height' => 200],
+            ],
+        ]);
+
+        $html = $this->viewHelper->render();
+        $doc  = $this->parseHtml($html);
+
+        $source = $this->getFirstElement($doc, 'source');
+        self::assertNotNull($source);
+        self::assertSame('image/webp', $source->getAttribute('type'));
+    }
+
+    #[Test]
+    public function sourceElementHasCorrectTypeForAvif(): void
+    {
+        $this->viewHelper->setArguments([
+            'path'   => '/fileadmin/photo.avif',
+            'width'  => 600,
+            'height' => 400,
+            'set'    => [
+                480 => ['width' => 300, 'height' => 200],
+            ],
+        ]);
+
+        $html = $this->viewHelper->render();
+        $doc  = $this->parseHtml($html);
+
+        $source = $this->getFirstElement($doc, 'source');
+        self::assertNotNull($source);
+        self::assertSame('image/avif', $source->getAttribute('type'));
     }
 
     // ──────────────────────────────────────────────────


### PR DESCRIPTION
## What

Replace two pre-existing red acceptance tests with a set that actually matches the view helper's documented behavior.

## Why

\`SourceSetViewHelperHtmlOutputTest::sourceElementHasCorrectTypeAttribute\` (line 279) and \`::sourceElementHasCorrectTypeForPng\` (line 299) asserted:

\`\`\`php
self::assertSame('image/jpeg', \$source->getAttribute('type'));
self::assertSame('image/png',  \$source->getAttribute('type'));
\`\`\`

But the view helper deliberately **omits** the \`type\` attribute for JPEG / PNG / GIF. The decision is documented inline:

\`\`\`php
// Classes/ViewHelpers/SourceSetViewHelper.php
/**
 * MIME types for next-gen formats where the \`type\` attribute on \`<source>\`
 * provides genuine browser skip-signal value. Universally-supported formats
 * (JPEG, PNG, GIF) are omitted since every browser that supports \`<picture>\`
 * also supports those formats — adding \`type\` for them provides no benefit.
 */
private const EXTENSION_MIME_MAP = [
    'webp' => 'image/webp',
    'avif' => 'image/avif',
];
\`\`\`

The tests were wrong — they asserted behavior the production code had **explicitly rejected**. They were pre-existing reds before PR #91 landed and only became visible in CI once PR #91 actually enabled functional/acceptance tests to run there.

## What changed

Replaced the two wrong tests with a full set covering both branches of the \`EXTENSION_MIME_MAP\` decision:

| Old (wrong)                                | New                                     | Asserts                           |
|--------------------------------------------|-----------------------------------------|-----------------------------------|
| \`sourceElementHasCorrectTypeAttribute\`     | \`sourceElementHasNoTypeAttributeForJpeg\` | No \`type\` attribute on \`<source>\`   |
| \`sourceElementHasCorrectTypeForPng\`        | \`sourceElementHasNoTypeAttributeForPng\`  | No \`type\` attribute on \`<source>\`   |
| —                                          | \`sourceElementHasNoTypeAttributeForGif\`  | Completes the universally-supported set |
| —                                          | \`sourceElementHasCorrectTypeForWebp\`     | \`type=\"image/webp\"\`               |
| —                                          | \`sourceElementHasCorrectTypeForAvif\`     | \`type=\"image/avif\"\`               |

## Test plan

- [x] 46/46 acceptance tests green locally (was 44/46)
- [x] 549/549 unit tests still green
- [x] 30/30 functional tests still green
- [x] PHPStan, Rector, Fractor, CS-Fixer, Lint all green

## Related

- Surfaced during [#91](https://github.com/netresearch/t3x-nr-image-optimize/pull/91) review discussion after functional tests first ran in CI. Tracked as a follow-up task to avoid scope creep on the symlink fix.