### PR TITLE
chore(phpstan): re-evaluate ergebnis rule suppressions (4 of 8)

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -40,7 +40,16 @@ parameters:
           reportUnmatched: false
         - identifier: ergebnis.noParameterWithNullDefaultValue
           reportUnmatched: false
-        - identifier: ergebnis.noExtends                # controllers / commands must extend framework
+        # ergebnis.noExtends — only allowed where the framework requires inheritance
+        # (Symfony Command, TYPO3 ActionController, Fluid ViewHelper, TYPO3 FunctionalTestCase).
+        # Path-scoped so a new `extends` in Services/Events/Middleware would get caught.
+        - identifier: ergebnis.noExtends
+          paths:
+              - %currentWorkingDirectory%/Classes/Command/*
+              - %currentWorkingDirectory%/Classes/Controller/*
+              - %currentWorkingDirectory%/Classes/ViewHelpers/*
+              - %currentWorkingDirectory%/Tests/Functional/*
+              - %currentWorkingDirectory%/Tests/Unit/Command/AbstractImageCommandTest.php
           reportUnmatched: false
         - identifier: ergebnis.noIsset                  # idiomatic for array-key-exists
           reportUnmatched: false

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -46,8 +46,6 @@ parameters:
           reportUnmatched: false
         - identifier: ergebnis.noErrorSuppression       # `@` sometimes unavoidable with core PHP funcs
           reportUnmatched: false
-        - identifier: ergebnis.noPhpstanIgnore          # surgical inline suppressions auditable in diff
-          reportUnmatched: false
 
         # --- Pragmatic PHPStan ignores ---
         # Intervention\Image v3 renamed `decode()` to `read()`. We dispatch

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -53,7 +53,17 @@ parameters:
           reportUnmatched: false
         - identifier: ergebnis.noIsset                  # idiomatic for array-key-exists
           reportUnmatched: false
-        - identifier: ergebnis.noErrorSuppression       # `@` sometimes unavoidable with core PHP funcs
+        # ergebnis.noErrorSuppression — only allowed in files that wrap PHP
+        # native filesystem/image functions whose error contract is "returns
+        # false, set_error_handler can't replace the idiom" (mkdir+is_dir
+        # race-safe, filesize/unlink/getimagesize). New `@` elsewhere flags.
+        - identifier: ergebnis.noErrorSuppression
+          paths:
+              - %currentWorkingDirectory%/Classes/Processor.php
+              - %currentWorkingDirectory%/Classes/Service/ImageOptimizer.php
+              - %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+              - %currentWorkingDirectory%/Classes/ViewHelpers/SourceSetViewHelper.php
+              - %currentWorkingDirectory%/Tests/*
           reportUnmatched: false
 
         # --- Pragmatic PHPStan ignores ---

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -51,7 +51,12 @@ parameters:
               - %currentWorkingDirectory%/Tests/Functional/*
               - %currentWorkingDirectory%/Tests/Unit/Command/AbstractImageCommandTest.php
           reportUnmatched: false
-        - identifier: ergebnis.noIsset                  # idiomatic for array-key-exists
+        # ergebnis.noIsset — production code replaced isset() with
+        # array_key_exists() where idiomatic. Tests still use isset() for
+        # terseness in fixture setup; scope the suppression there.
+        - identifier: ergebnis.noIsset
+          paths:
+              - %currentWorkingDirectory%/Tests/*
           reportUnmatched: false
         # ergebnis.noErrorSuppression — only allowed in files that wrap PHP
         # native filesystem/image functions whose error contract is "returns

--- a/Classes/Command/AbstractImageCommand.php
+++ b/Classes/Command/AbstractImageCommand.php
@@ -171,7 +171,7 @@ abstract class AbstractImageCommand extends Command
      */
     final protected function buildLabel(array $record): string
     {
-        if (isset($record['identifier']) && is_string($record['identifier']) && $record['identifier'] !== '') {
+        if (array_key_exists('identifier', $record) && is_string($record['identifier']) && $record['identifier'] !== '') {
             return $record['identifier'];
         }
 

--- a/Classes/EventListener/OptimizeOnUploadListener.php
+++ b/Classes/EventListener/OptimizeOnUploadListener.php
@@ -44,7 +44,7 @@ final class OptimizeOnUploadListener
         // FAL identifiers are only unique within a storage, so key the guard
         // on storage UID + identifier to avoid cross-storage collisions.
         $id = $storage->getUid() . ':' . $file->getIdentifier();
-        if (isset($this->guard[$id])) {
+        if (array_key_exists($id, $this->guard)) {
             return; // Re-entrancy guard (e.g. triggered by replaceFile)
         }
 

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -648,7 +648,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
 
             for ($i = 0; $i < $count; ++$i) {
                 // First occurrence wins (matches original behavior of array_search)
-                if (!isset($values[$matches[1][$i]])) {
+                if (!array_key_exists($matches[1][$i], $values)) {
                     $values[$matches[1][$i]] = (int) $matches[2][$i];
                 }
             }
@@ -827,7 +827,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
 
         $publicPathRaw = Environment::getPublicPath();
 
-        if (isset(self::$resolvedAllowedRootsByPublicPath[$publicPathRaw])) {
+        if (array_key_exists($publicPathRaw, self::$resolvedAllowedRootsByPublicPath)) {
             return $this->requestAllowedRoots = self::$resolvedAllowedRootsByPublicPath[$publicPathRaw];
         }
 

--- a/Classes/Service/SystemRequirementsService.php
+++ b/Classes/Service/SystemRequirementsService.php
@@ -246,7 +246,7 @@ final class SystemRequirementsService
         }
 
         $info      = gd_info();
-        $gdVersion = isset($info['GD Version']) && is_string($info['GD Version']) ? $info['GD Version'] : null;
+        $gdVersion = array_key_exists('GD Version', $info) && is_string($info['GD Version']) ? $info['GD Version'] : null;
         $items[]   = $this->makeItem(
             'sysreq.gdVersion',
             $gdVersion,

--- a/Classes/ViewHelpers/SourceSetViewHelper.php
+++ b/Classes/ViewHelpers/SourceSetViewHelper.php
@@ -371,7 +371,7 @@ final class SourceSetViewHelper extends AbstractViewHelper
         if ($width === 0 && $height === 0) {
             // Use static cache to avoid repeated getimagesize() disk I/O
             // for the same source image across multiple variant URLs.
-            if (!isset(self::$imageSizeCache[$path])) {
+            if (!array_key_exists($path, self::$imageSizeCache)) {
                 self::$imageSizeCache[$path] = @getimagesize(Environment::getPublicPath() . $path);
             }
 
@@ -390,7 +390,7 @@ final class SourceSetViewHelper extends AbstractViewHelper
 
         $pathInfo = PathUtility::pathinfo($path);
 
-        if (isset($pathInfo['extension']) && strtolower($pathInfo['extension']) === 'svg') {
+        if (array_key_exists('extension', $pathInfo) && strtolower($pathInfo['extension']) === 'svg') {
             return $path;
         }
 
@@ -565,7 +565,7 @@ final class SourceSetViewHelper extends AbstractViewHelper
      */
     private function getAttributes(): array
     {
-        if (!isset($this->arguments['attributes'])
+        if (!array_key_exists('attributes', $this->arguments)
             || !is_array($this->arguments['attributes'])
         ) {
             return [];


### PR DESCRIPTION
## Summary

Re-evaluate the 8 blanket-suppressed `ergebnis/phpstan-rules` opinions in `Build/phpstan.neon`. Where a rule had zero findings, re-enable it. Where the findings map to framework idioms concentrated in specific paths, narrow the suppression so **new** violations elsewhere get caught.

This PR tackles **4 of the 8** rules (see commits). The remaining 4 (`noNamedArgument`, `noParameterWithNullableTypeDeclaration`, `noNullableReturnTypeDeclaration`, `noParameterWithNullDefaultValue`) are deep-structural and deferred for a separate decision.

## Per-rule changes

### `ergebnis.noPhpstanIgnore` — re-enabled (0 findings)
Every previously-needed inline `@phpstan-ignore` has since been resolved. Drop the dead suppression.

### `ergebnis.noExtends` — path-scoped
11 findings, all framework-heritage:
- `Classes/Command/*` — Symfony `Command`
- `Classes/Controller/*` — TYPO3 `ActionController`
- `Classes/ViewHelpers/*` — Fluid `AbstractViewHelper`
- `Tests/Functional/*` — `FunctionalTestCase`
- `Tests/Unit/Command/AbstractImageCommandTest.php` — test fixture

Any new `extends` in `Classes/Service/`, `Classes/Event/`, `Classes/EventListener/`, `Classes/Middleware/` now flags — which is the layer where composition should win anyway.

### `ergebnis.noErrorSuppression` — path-scoped
13 production findings all wrap PHP native filesystem/image functions whose error contract requires the `@` idiom (`@mkdir() && !is_dir()` race-safe, `@filesize()`, `@unlink()` finally-block cleanup, `@getimagesize()`, `@file_get_contents()`) — each followed by explicit `=== false`/`is_array()` checks. Replacing with `set_error_handler` wrappers would be substantially less readable without improving error handling.

Scoped to the 4 files that legitimately wrap these + `Tests/*`. New `@` in Commands, Controllers, Events, EventListeners, Middleware, or other Services flags.

### `ergebnis.noIsset` — 8 production replacements + test scope
Production `isset()` replaced with `array_key_exists()`:

| File | What |
|------|------|
| `AbstractImageCommand::buildLabel` | `$record['identifier']` check |
| `OptimizeOnUploadListener::handle` | re-entrancy guard map |
| `Processor::parseMode` | first-occurrence-wins for mode values |
| `Processor::resolveAllowedRoots` | static cache lookup |
| `SystemRequirementsService` | `gd_info()` key check |
| `SourceSetViewHelper` (3×) | imageSizeCache / pathinfo / arguments |

`array_key_exists()` is more explicit about "does the key exist" intent than `isset()` (which also returns false for null). Semantically equivalent here. Rule scoped to `Tests/*` where `isset()` is kept for fixture-setup terseness.

## Not in this PR (deferred)

Four rules with larger refactoring surface, left for a separate decision:

- `ergebnis.noNamedArgument` — 185 findings (164 Tests, 21 `Processor.php`). Named arguments are PHP 8 idiom; user has approved. Would need blanket suppression or invasive refactor.
- `ergebnis.noParameterWithNullableTypeDeclaration` — 28 findings. Event DTOs, Service helpers, Processor. Many legitimate (constructor with `?int $width = null` for optional metrics).
- `ergebnis.noNullableReturnTypeDeclaration` — 12 findings. Processor / Service helpers returning `?X` from "maybe-find" queries.
- `ergebnis.noParameterWithNullDefaultValue` — 15 findings. Optional parameter patterns.

## Test plan

- [x] PHPStan locally clean (with manually-restored GeneratedConfig.php for extension-installer)
- [ ] CI green (PHPStan matrix, Unit Tests, Functional Tests)
- [ ] No new baseline needed