### PR TITLE
chore(phpstan): finish ergebnis rules re-evaluation (remaining 4)

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -32,13 +32,48 @@ parameters:
         # at odds with idiomatic TYPO3 extension code. Suppress rather than
         # fight the framework. Rules that catch real bugs (type safety,
         # architecture layering via phpat, ergebnis.final*) stay active.
-        - identifier: ergebnis.noNamedArgument          # PHP 8 idiom
+        # ergebnis.noNamedArgument — PHP 8 named arguments are idiomatic
+        # (improves constructor-call readability for DTOs/events with many
+        # params). Kept blanket-suppressed; the rule is a style preference
+        # we explicitly reject.
+        - identifier: ergebnis.noNamedArgument
           reportUnmatched: false
+        # ergebnis.noParameterWithNullableTypeDeclaration — `?X` parameters
+        # model the "Maybe<X>" pattern (unconstrained dimension, optional
+        # quality override, optional display label). Introducing sentinels
+        # or builder objects would be strictly worse than the PHP-native
+        # idiom. Path-scoped so new nullable params outside these files
+        # still flag.
         - identifier: ergebnis.noParameterWithNullableTypeDeclaration
+          paths:
+              - %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
+              - %currentWorkingDirectory%/Classes/Event/ImageProcessedEvent.php
+              - %currentWorkingDirectory%/Classes/Processor.php
+              - %currentWorkingDirectory%/Classes/Service/ImageOptimizer.php
+              - %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+              - %currentWorkingDirectory%/Tests/*
           reportUnmatched: false
+        # ergebnis.noNullableReturnTypeDeclaration — `?X` return types model
+        # "find-or-null" lookup semantics (cache miss, file-not-found,
+        # binary-not-available, version-not-detected). Throwing exceptions
+        # for each not-found case would invert the control flow for purely
+        # optional queries. Path-scoped.
         - identifier: ergebnis.noNullableReturnTypeDeclaration
+          paths:
+              - %currentWorkingDirectory%/Classes/Processor.php
+              - %currentWorkingDirectory%/Classes/Service/ImageOptimizer.php
+              - %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+              - %currentWorkingDirectory%/Tests/*
           reportUnmatched: false
+        # ergebnis.noParameterWithNullDefaultValue — `?X $x = null` is the
+        # PHP-native "use configured default when absent" pattern. The two
+        # affected services load their real defaults from constructor
+        # config at call time. Path-scoped.
         - identifier: ergebnis.noParameterWithNullDefaultValue
+          paths:
+              - %currentWorkingDirectory%/Classes/Service/ImageOptimizer.php
+              - %currentWorkingDirectory%/Classes/Service/SystemRequirementsService.php
+              - %currentWorkingDirectory%/Tests/*
           reportUnmatched: false
         # ergebnis.noExtends — only allowed where the framework requires inheritance
         # (Symfony Command, TYPO3 ActionController, Fluid ViewHelper, TYPO3 FunctionalTestCase).


### PR DESCRIPTION
## Summary

Follow-up to #99. Completes the re-evaluation by tightening the remaining 4 blanket-suppressed ergebnis rules — each finding is a deliberate PHP-8 idiom, not a bug.

## Per-rule outcomes

| Rule | Prod findings | Outcome |
|------|-------------:|---------|
| `ergebnis.noNamedArgument` | 21 (all `Processor.php`) | **Kept blanket-suppressed** — named args are readability, explicitly rejected style preference |
| `ergebnis.noParameterWithNullableTypeDeclaration` | 18 | **Path-scoped to 5 files** — "Maybe<X>" params for optional dimensions, quality, labels |
| `ergebnis.noNullableReturnTypeDeclaration` | 11 | **Path-scoped to 3 files** — "find-or-null" lookup semantics |
| `ergebnis.noParameterWithNullDefaultValue` | 6 | **Path-scoped to 2 files** — `?X $x = null` with service-level defaults |

## Why path-scope instead of fixing?

Alternatives considered:
- **Sentinels** (`0` = unconstrained, `''` = missing) — loses type safety, hides semantic state
- **Exception-based APIs** for every "find-or-null" lookup — inverts control flow for genuinely optional queries, forces 11 try/catch wrappers at callsites
- **Builder objects** replacing `?X` param lists — invasive and less readable for factory-style helpers

Each of those would be strictly worse than the PHP-native `?X` idiom. Path-scoping captures intent ("this idiom is OK here, flag it elsewhere") without forcing API rewrites.

## Net effect across both PRs

Of the 8 originally blanket-suppressed ergebnis rules:

- **1 rule fully enforced** (`noPhpstanIgnore` — 0 findings)
- **6 rules path-scoped** with documented rationale (`noExtends`, `noIsset`, `noErrorSuppression`, `noParameterWithNullableTypeDeclaration`, `noNullableReturnTypeDeclaration`, `noParameterWithNullDefaultValue`)
- **1 rule blanket-suppressed** with written justification (`noNamedArgument` — user-approved style)
- **8 production `isset()` replaced with `array_key_exists()`**

Any future ergebnis violation outside the listed paths now gets flagged in CI.

## Test plan

- [x] PHPStan locally clean
- [ ] CI green (PHPStan matrix, Unit Tests, Functional Tests, etc.)
- [ ] No new baseline needed