### PR TITLE
docs(phpstan): clarify why Tests/* is included in path-scoped rules

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -43,7 +43,9 @@ parameters:
         # quality override, optional display label). Introducing sentinels
         # or builder objects would be strictly worse than the PHP-native
         # idiom. Path-scoped so new nullable params outside these files
-        # still flag.
+        # still flag. Tests/* is included because fixtures and data
+        # providers exercise the same prod signatures (otherwise every
+        # `?int $width` test case would re-flag the rule).
         - identifier: ergebnis.noParameterWithNullableTypeDeclaration
           paths:
               - %currentWorkingDirectory%/Classes/Controller/MaintenanceController.php
@@ -57,7 +59,8 @@ parameters:
         # "find-or-null" lookup semantics (cache miss, file-not-found,
         # binary-not-available, version-not-detected). Throwing exceptions
         # for each not-found case would invert the control flow for purely
-        # optional queries. Path-scoped.
+        # optional queries. Path-scoped. Tests/* is included because test
+        # doubles and helper methods mirror the prod return shapes.
         - identifier: ergebnis.noNullableReturnTypeDeclaration
           paths:
               - %currentWorkingDirectory%/Classes/Processor.php
@@ -68,7 +71,9 @@ parameters:
         # ergebnis.noParameterWithNullDefaultValue — `?X $x = null` is the
         # PHP-native "use configured default when absent" pattern. The two
         # affected services load their real defaults from constructor
-        # config at call time. Path-scoped.
+        # config at call time. Path-scoped. Tests/* is included because
+        # tests instantiate these services directly and re-use the same
+        # `?X $x = null` signatures.
         - identifier: ergebnis.noParameterWithNullDefaultValue
           paths:
               - %currentWorkingDirectory%/Classes/Service/ImageOptimizer.php


### PR DESCRIPTION
Follow-up to #100 review feedback (3 unresolved threads).

## Background

Three reviewer comments on #100 flagged that the PR description claimed each rule was `path-scoped to N files` but the config also included `%currentWorkingDirectory%/Tests/*`, effectively widening the suppression to the whole test suite.

## Why Tests/* is intentional

Tests instantiate the prod classes directly and exercise their public APIs. Every `?int $width`, `?float $quality` signature in prod is mirrored in dataProvider arrays, mocks, and helper methods. Without `Tests/*` in scope:

- 100+ test cases would re-flag `noParameterWithNullableTypeDeclaration`
- find-or-null lookups in test doubles would re-flag `noNullableReturnTypeDeclaration`
- `?X $x = null` service constructors used in tests would re-flag `noParameterWithNullDefaultValue`

Removing `Tests/*` would force test code to either drop the rule's intended coverage entirely or duplicate the suppression with no added rigor.

## Change

Adds a one-line rationale to each of the three rule comments explaining why `Tests/*` is bundled with the prod paths. No PHPStan behaviour change.

Resolves the unresolved review threads on:
- https://github.com/netresearch/t3x-nr-image-optimize/pull/100#discussion_r3140581687
- https://github.com/netresearch/t3x-nr-image-optimize/pull/100#discussion_r3140581702
- https://github.com/netresearch/t3x-nr-image-optimize/pull/100#discussion_r3140581715