### PR TITLE
docs(changelog): correct v1.1.2 error_log level wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@
 - **#70 follow-up diagnosability & cache robustness.** The 1.1.0/1.1.1 fixes
   silently returned HTTP 400 to clients when path validation rejected a
   request, leaving admins no signal to diagnose from. `Processor::generateAndSend()`
-  now logs both 400 branches via `error_log()`: the URL-pattern-mismatch
-  path at info level (scanners hit this constantly, so warning would drown
-  out genuine issues) and the path-outside-allowed-roots path at warning
-  level with full diagnostic context (url, pathOriginal, pathVariant,
-  which check failed, allowedRoots, publicPath).
+  now logs both 400 branches via `error_log()` so the rejection reason
+  reaches the SAPI error log: the URL-pattern-mismatch path with a short
+  one-line message (scanners hit this constantly, so a longer dump would
+  drown out genuine issues) and the path-outside-allowed-roots path with
+  full diagnostic context (url, pathOriginal, pathVariant, which check
+  failed, allowedRoots, publicPath). Both lines are written at the same
+  SAPI level — `error_log()` does not expose distinct severity tiers; the
+  two paths are distinguishable by message content, not log level.
 - **Cache poisoning on transient `StorageRepository` failure.** Previously a
   single `findAll()` throw during early TYPO3 bootstrap (TCA not yet loaded,
   DB hiccup, cache rebuild) populated the per-process allowed-roots cache


### PR DESCRIPTION
Follow-up to #96 review feedback.

The reviewer correctly noted that the v1.1.2 changelog entry described two 400 branches as logged at "info" vs "warning" levels, but `error_log()` does not expose distinct severity tiers — both branches write at the same SAPI level.

## Change

- Reworded the v1.1.2 entry to describe what is actually different between the two log lines (short one-line vs full diagnostic context).
- Added an explicit note that `error_log()` has no level distinction.

No code change. The published v1.1.2 release notes still carry the original wording (releases are immutable on GitHub) — this corrects the in-tree CHANGELOG so future v1.1.x entries have an accurate baseline.

Resolves the unresolved thread on #96 (https://github.com/netresearch/t3x-nr-image-optimize/pull/96#discussion_r3140360398).