### PR TITLE
ci: pin typo3-ci-workflows to ~1.2.0 on TYPO3_12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "intervention/image": "3.7.2 || 3.11.1"
     },
     "require-dev": {
-        "netresearch/typo3-ci-workflows": "^1.1"
+        "netresearch/typo3-ci-workflows": "~1.2.0"
     },
     "replace": {
         "saschaegerer/phpstan-typo3": "2.1.1"


### PR DESCRIPTION
## Why

netresearch/typo3-ci-workflows **v1.3.0** added a transitive `ergebnis/phpstan-rules` dependency that activates the same style rules main path-scoped in #100 (`noErrorSuppression`, `noNullableReturnTypeDeclaration`, `noParameterWithNullableTypeDeclaration`, `noIsset`, `noFinalClass`). The TYPO3_12 maintenance branch's `Build/phpstan.neon` does not yet have those path-scoped suppressions, so PHPStan now goes red on every PR.

Last known-green CI on this branch (https://github.com/netresearch/t3x-nr-image-optimize/actions/runs/24888896353) used **v1.2.0**; today's runs lock to **v1.3.1** because there is no committed `composer.lock` (per the typo3-extensions convention).

## What

Tighten the constraint from `^1.1` to `~1.2.0` on the TYPO3_12 maintenance branch only. Main is unaffected.

## Follow-up

Either:
- Backport PR #100's path-scoped suppressions to TYPO3_12 `phpstan.neon` (bigger change, opens this branch up to v1.3+).
- Wait for upstream `typo3-ci-workflows` `dev-fix/ergebnis-rules-typo3-compat` (already in flight).

Either path lets us widen this constraint again in a future PR.