### PR TITLE
fix(backend): resolve module labels via array format

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -13,12 +13,16 @@ use Netresearch\NrImageOptimize\Controller\MaintenanceController;
 
 return [
     'nr_image_optimize' => [
-        'parent'            => 'tools',
-        'position'          => ['after' => 'toolsmaintenance'],
-        'access'            => 'systemMaintainer',
-        'workspaces'        => 'live',
-        'path'              => '/module/tools/nr-image-optimize',
-        'labels'            => 'LLL:EXT:nr_image_optimize/Resources/Private/Language/locallang.xlf:module.maintenance',
+        'parent'     => 'tools',
+        'position'   => ['after' => 'toolsmaintenance'],
+        'access'     => 'systemMaintainer',
+        'workspaces' => 'live',
+        'path'       => '/module/tools/nr-image-optimize',
+        'labels'     => [
+            'title'            => 'LLL:EXT:nr_image_optimize/Resources/Private/Language/locallang.xlf:module.maintenance',
+            'description'      => 'LLL:EXT:nr_image_optimize/Resources/Private/Language/locallang.xlf:module.maintenance.description',
+            'shortDescription' => 'LLL:EXT:nr_image_optimize/Resources/Private/Language/locallang.xlf:module.maintenance.title',
+        ],
         'extensionName'     => 'NrImageOptimize',
         'iconIdentifier'    => 'module-image-optimize',
         'controllerActions' => [


### PR DESCRIPTION
## Summary

In TYPO3 v14 the Image Optimize backend module title renders as a raw LLL key (`LLL:EXT:nr_image_optimize/Resources/Private/Language/locallang.xlf:module.maintenance:mlang_tabs_tab`) instead of "Image Optimize". Same issue affects the description and short-description labels.

The same `Configuration/Backend/Modules.php` works correctly under TYPO3 v13, which is why the issue surfaced only during the v14 upgrade.

## Why it breaks in v14 but not v13

Both versions go through the same `BaseModule::createFromConfiguration()` code path: when `labels` is a `LLL:` string, TYPO3 appends three suffixes to derive the trans-unit keys:

- `:mlang_tabs_tab` → title
- `:mlang_labels_tabdescr` → description
- `:mlang_labels_tablabel` → shortDescription

With the existing config the resulting reference is `LLL:EXT:…/locallang.xlf:module.maintenance:mlang_tabs_tab`, i.e. **two** suffix segments after the file path. v13 tolerated this; v14 does not.

The actual divergence lives in `LanguageService::sL()` / `getLLL()`:

```diff
- $parts = explode(':', trim($restStr));        // v13 – splits every colon
+ $parts = explode(':', trim($restStr), 2);     // v14 – limit=2, single split
```

Under v13 the no-limit `explode` decomposed the string into `[EXT, EXT-path, module.maintenance, mlang_tabs_tab]` and the resolver matched `module.maintenance` as the trans-unit ID, silently ignoring the trailing `:mlang_tabs_tab`. Under v14 the limited split yields `[EXT, EXT-path:module.maintenance:mlang_tabs_tab]`, which is interpreted as a single (non-existent) identifier and falls through to the raw key.

Either way, the original `'labels' => 'LLL:…:module.maintenance'` config was relying on lenient v13 behaviour. The string form is only safe when the trans-unit IDs are literally `mlang_tabs_tab`, `mlang_labels_tabdescr` and `mlang_labels_tablabel`.

## Fix

Switch to the array shape that `BaseModule` supports for exactly this case, so each label targets a real existing trans-unit by name:

```php
'labels' => [
    'title'            => 'LLL:EXT:…/locallang.xlf:module.maintenance',
    'description'      => 'LLL:EXT:…/locallang.xlf:module.maintenance.description',
    'shortDescription' => 'LLL:EXT:…/locallang.xlf:module.maintenance.title',
],
```

All three target units already exist in `Resources/Private/Language/locallang.xlf` — no language-file changes needed. The array form is the recommended shape going forward and works identically on v13 and v14 (verified locally under both).

## Verification

```
$ docker compose exec phpfpm vendor/bin/typo3 debug:backend:modules | grep image-optimize
| netresearch/nr-image-optimize | admin | nr_image_optimize | … | Image Optimize [ … ]
```

Module title now resolves to "Image Optimize" instead of the raw LLL string. Same for description / shortDescription.

Patched into a live TYPO3 v13 instance as well — no regression there (label was already rendering correctly due to the v13 lenient parse).

Local CI checks: `make lint` ✅, `make cgl` ✅. `make phpstan` reports the same 24 preexisting `Tests/*` `property.uninitialized` findings as `origin/main` (no new issues introduced by this change). GitHub Actions matrix is green on PHP 8.2-8.5 × TYPO3 ^13.4 + ^14.0.

## Notes for reviewers

- Pure configuration change. No code paths, no tests, no documentation changes.
- The `TYPO3_12` branch uses the same `Modules.php` schema; a port is identical if desired. Happy to open a follow-up PR there.
- The `labeler / Label PR` failure on this PR is unrelated — it's the standard GitHub fork-PR permission issue (`HttpError: Resource not accessible by integration`), not a code problem.