### PR TITLE
feat(backend): populate SystemRequirements details column

### DIFF
--- a/Classes/Service/SystemRequirementsService.php
+++ b/Classes/Service/SystemRequirementsService.php
@@ -33,7 +33,6 @@ use function ini_get;
 use function is_array;
 use function is_file;
 use function json_decode;
-use function php_sapi_name;
 use function phpversion;
 use function shell_exec;
 
@@ -153,7 +152,8 @@ final class SystemRequirementsService
             $loaded     = extension_loaded($ext);
             $isOptional = in_array($ext, self::OPTIONAL_PHP_EXTENSIONS, true);
             $status     = $loaded ? 'success' : ($isOptional ? 'warning' : 'error');
-            $extVersion = $loaded ? (phpversion($ext) !== false ? phpversion($ext) : null) : null;
+            $rawVersion = $loaded ? phpversion($ext) : false;
+            $extVersion = $rawVersion !== false ? $rawVersion : null;
 
             $items[] = $this->makeItem(
                 'sysreq.phpExtension',
@@ -174,15 +174,7 @@ final class SystemRequirementsService
      */
     private function getPhpDetails(): string
     {
-        $parts = ['Zend Engine ' . zend_version()];
-
-        $sapi = php_sapi_name();
-
-        if ($sapi !== false) {
-            $parts[] = 'SAPI: ' . $sapi;
-        }
-
-        return implode(', ', $parts);
+        return 'Zend Engine ' . zend_version() . ', SAPI: ' . PHP_SAPI;
     }
 
     /**
@@ -392,7 +384,7 @@ final class SystemRequirementsService
                 : null;
 
             if ($installed) {
-                $source = 'Composer\\InstalledVersions';
+                $source = InstalledVersions::class;
             } else {
                 [$version, $source] = $this->findVersionFromComposerInstalledWithSource($name);
                 $installed          = $version !== null;
@@ -464,16 +456,29 @@ final class SystemRequirementsService
         );
 
         foreach (self::CLI_TOOLS as $cmd => $labelKey) {
-            $res    = $this->checkBinaryAvailability($cmd, $execAllowed);
-            $status = $res['available'] === true ? 'success' : 'warning';
+            $res = $this->checkBinaryAvailability($cmd, $execAllowed);
+
+            if ($res['available'] === null) {
+                $items[] = $this->makeItem(
+                    $labelKey,
+                    null,
+                    null,
+                    'warning',
+                    details: 'Cannot probe binary while exec is disabled',
+                    currentKey: 'sysreq.unavailable',
+                    requiredKey: 'sysreq.optional',
+                );
+
+                continue;
+            }
 
             $items[] = $this->makeItem(
                 $labelKey,
                 $res['version'],
                 null,
-                $status,
+                $res['available'] ? 'success' : 'warning',
                 details: $this->buildCliDetails($res),
-                currentKey: $res['available'] === true ? 'sysreq.found' : 'sysreq.notFound',
+                currentKey: $res['available'] ? 'sysreq.found' : 'sysreq.notFound',
                 requiredKey: 'sysreq.optional',
             );
         }
@@ -482,7 +487,7 @@ final class SystemRequirementsService
     }
 
     /**
-     * Build the tooltip details string for a CLI tool item.
+     * Build the inline details string for a CLI tool item (binary path + full version output).
      *
      * @param array{available: bool|null, version: string|null, path?: string|null, fullVersion?: string|null} $res
      */
@@ -548,25 +553,6 @@ final class SystemRequirementsService
             'path'        => $path,
             'fullVersion' => $ver !== '' ? $ver : null,
         ];
-    }
-
-    /**
-     * Find package version from composer installed.json or composer.lock.
-     *
-     * Kept as a thin convenience wrapper around the source-tracking variant
-     * because the test suite invokes it directly via reflection.
-     *
-     * @param string $package Composer package name (e.g., 'vendor/package')
-     *
-     * @return string|null Package version or null if not found
-     *
-     * @phpstan-ignore method.unused
-     */
-    private function findVersionFromComposerInstalled(string $package): ?string
-    {
-        [$version] = $this->findVersionFromComposerInstalledWithSource($package);
-
-        return $version;
     }
 
     /**

--- a/Classes/Service/SystemRequirementsService.php
+++ b/Classes/Service/SystemRequirementsService.php
@@ -33,6 +33,7 @@ use function ini_get;
 use function is_array;
 use function is_file;
 use function json_decode;
+use function php_sapi_name;
 use function phpversion;
 use function shell_exec;
 
@@ -44,6 +45,7 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Information\Typo3Version;
 
 use function version_compare;
+use function zend_version;
 
 /**
  * Service to collect and check system requirements for the image optimization extension.
@@ -139,25 +141,48 @@ final class SystemRequirementsService
         $ok       = version_compare($current, self::MIN_PHP_VERSION, '>=');
 
         $items   = [];
-        $items[] = $this->makeItem('sysreq.phpVersion', $current, $required, $ok ? 'success' : 'error');
+        $items[] = $this->makeItem(
+            'sysreq.phpVersion',
+            $current,
+            $required,
+            $ok ? 'success' : 'error',
+            details: $this->getPhpDetails(),
+        );
 
         foreach (self::REQUIRED_PHP_EXTENSIONS as $ext) {
             $loaded     = extension_loaded($ext);
             $isOptional = in_array($ext, self::OPTIONAL_PHP_EXTENSIONS, true);
             $status     = $loaded ? 'success' : ($isOptional ? 'warning' : 'error');
+            $extVersion = $loaded ? (phpversion($ext) !== false ? phpversion($ext) : null) : null;
 
             $items[] = $this->makeItem(
                 'sysreq.phpExtension',
                 null,
                 null,
                 $status,
-                null,
-                [$ext],
-                $loaded ? 'sysreq.loaded' : 'sysreq.notLoaded',
+                details: $extVersion !== null ? 'Version: ' . $extVersion : null,
+                labelArguments: [$ext],
+                currentKey: $loaded ? 'sysreq.loaded' : 'sysreq.notLoaded',
             );
         }
 
         return $this->makeCategory('sysreq.phpRequirements', $items);
+    }
+
+    /**
+     * Build runtime details string for the PHP version row.
+     */
+    private function getPhpDetails(): string
+    {
+        $parts = ['Zend Engine ' . zend_version()];
+
+        $sapi = php_sapi_name();
+
+        if ($sapi !== false) {
+            $parts[] = 'SAPI: ' . $sapi;
+        }
+
+        return implode(', ', $parts);
     }
 
     /**
@@ -191,21 +216,41 @@ final class SystemRequirementsService
             $imagickVersion,
             null,
             'success',
-            null,
-            [],
-            $imagickVersion === null ? 'sysreq.unknown' : null,
+            details: $imagickVersion !== null ? 'PECL imagick ' . $imagickVersion : null,
+            currentKey: $imagickVersion === null ? 'sysreq.unknown' : null,
         );
 
         try {
             $imInfo  = Imagick::getVersion();
-            $items[] = $this->makeItem('sysreq.imageMagickVersion', $imInfo['versionString'], null, 'success');
+            $items[] = $this->makeItem(
+                'sysreq.imageMagickVersion',
+                $imInfo['versionString'],
+                null,
+                'success',
+                details: $this->getImageMagickBuildDetails($imInfo),
+            );
 
-            $formats = Imagick::queryFormats();
-            $items[] = $this->makeFormatSupportItem('sysreq.webpSupport', in_array('WEBP', $formats, true));
-            $items[] = $this->makeFormatSupportItem('sysreq.avifSupport', in_array('AVIF', $formats, true));
+            $formats      = Imagick::queryFormats();
+            $totalFormats = count($formats);
+            $items[]      = $this->makeFormatSupportItem(
+                'sysreq.webpSupport',
+                in_array('WEBP', $formats, true),
+                'Imagick delegate',
+            );
+            $items[] = $this->makeFormatSupportItem(
+                'sysreq.avifSupport',
+                in_array('AVIF', $formats, true),
+                'Imagick delegate',
+            );
 
             $relevant = array_values(array_intersect($formats, self::RELEVANT_IMAGE_FORMATS));
-            $items[]  = $this->makeItem('sysreq.supportedFormats', implode(', ', $relevant), null, 'success');
+            $items[]  = $this->makeItem(
+                'sysreq.supportedFormats',
+                implode(', ', $relevant),
+                null,
+                'success',
+                details: sprintf('%d total formats: %s', $totalFormats, implode(', ', $formats)),
+            );
         } catch (Throwable $e) {
             $items[] = $this->makeItem(
                 'sysreq.imageMagickVersion',
@@ -252,15 +297,60 @@ final class SystemRequirementsService
             $gdVersion,
             null,
             'success',
-            null,
-            [],
-            $gdVersion === null ? 'sysreq.unknown' : null,
+            details: $this->getGdBuildDetails($info),
+            currentKey: $gdVersion === null ? 'sysreq.unknown' : null,
         );
 
-        $items[] = $this->makeFormatSupportItem('sysreq.webpSupport', (bool) ($info['WebP Support'] ?? false));
-        $items[] = $this->makeFormatSupportItem('sysreq.avifSupport', (bool) ($info['AVIF Support'] ?? false));
+        $items[] = $this->makeFormatSupportItem(
+            'sysreq.webpSupport',
+            (bool) ($info['WebP Support'] ?? false),
+            'GD libwebp',
+        );
+        $items[] = $this->makeFormatSupportItem(
+            'sysreq.avifSupport',
+            (bool) ($info['AVIF Support'] ?? false),
+            'GD libavif',
+        );
 
         return $this->makeCategory('sysreq.gdCategory', $items);
+    }
+
+    /**
+     * Build ImageMagick build-info string from Imagick::getVersion() output.
+     *
+     * @param array<string, mixed> $imInfo
+     */
+    private function getImageMagickBuildDetails(array $imInfo): string
+    {
+        $parts = [];
+
+        if (array_key_exists('versionString', $imInfo) && is_string($imInfo['versionString'])) {
+            $parts[] = $imInfo['versionString'];
+        }
+
+        if (array_key_exists('versionNumber', $imInfo) && (is_int($imInfo['versionNumber']) || is_string($imInfo['versionNumber']))) {
+            $parts[] = 'versionNumber=' . $imInfo['versionNumber'];
+        }
+
+        return implode("\n", $parts);
+    }
+
+    /**
+     * Build a build-info string from gd_info() output (feature flags only).
+     *
+     * @param array<array-key, mixed> $info
+     */
+    private function getGdBuildDetails(array $info): ?string
+    {
+        $features = [];
+
+        foreach (['FreeType Support', 'JPEG Support', 'PNG Support', 'WBMP Support', 'XPM Support', 'XBM Support', 'WebP Support', 'AVIF Support', 'BMP Support', 'TGA Read Support', 'GIF Read Support', 'GIF Create Support'] as $flag) {
+            if (array_key_exists($flag, $info) && $info[$flag] === true) {
+                $features[] = $flag;
+            }
+        }
+
+        return $features === [] ? null : 'Compiled with: ' . implode(', ', $features);
     }
 
     /**
@@ -268,20 +358,20 @@ final class SystemRequirementsService
      *
      * @param string $labelKey  Translation key for the format label
      * @param bool   $supported Whether the format is supported
+     * @param string $provider  Library that would provide this format (e.g. "Imagick delegate", "GD libwebp")
      *
      * @return array<string, mixed>
      */
-    private function makeFormatSupportItem(string $labelKey, bool $supported): array
+    private function makeFormatSupportItem(string $labelKey, bool $supported, string $provider): array
     {
         return $this->makeItem(
             $labelKey,
             null,
             null,
             $supported ? 'success' : 'warning',
-            null,
-            [],
-            $supported ? 'sysreq.yes' : 'sysreq.no',
-            'sysreq.optional',
+            details: $supported ? 'Provided by ' . $provider : 'Not provided by ' . $provider,
+            currentKey: $supported ? 'sysreq.yes' : 'sysreq.no',
+            requiredKey: 'sysreq.optional',
         );
     }
 
@@ -295,14 +385,17 @@ final class SystemRequirementsService
         $items = [];
 
         foreach (self::REQUIRED_COMPOSER_PACKAGES as $name) {
+            $source    = null;
             $installed = class_exists(InstalledVersions::class) && InstalledVersions::isInstalled($name);
             $version   = $installed
                 ? (InstalledVersions::getPrettyVersion($name) ?? InstalledVersions::getVersion($name))
                 : null;
 
-            if (!$installed) {
-                $version   = $this->findVersionFromComposerInstalled($name);
-                $installed = $version !== null;
+            if ($installed) {
+                $source = 'Composer\\InstalledVersions';
+            } else {
+                [$version, $source] = $this->findVersionFromComposerInstalledWithSource($name);
+                $installed          = $version !== null;
             }
 
             $items[] = $this->makeItem(
@@ -310,11 +403,9 @@ final class SystemRequirementsService
                 $version,
                 null,
                 $installed ? 'success' : 'error',
-                null,
-                [],
-                $installed ? null : 'sysreq.notInstalled',
-                null,
-                $name,
+                details: $source !== null ? 'Source: ' . $source : null,
+                currentKey: $installed ? null : 'sysreq.notInstalled',
+                label: $name,
             );
         }
 
@@ -328,11 +419,19 @@ final class SystemRequirementsService
      */
     private function checkTypo3(): array
     {
-        $typo3 = (new Typo3Version())->getVersion();
-        $ok    = version_compare($typo3, self::MIN_TYPO3_VERSION, '>=');
+        $versionInfo = new Typo3Version();
+        $typo3       = $versionInfo->getVersion();
+        $branch      = $versionInfo->getBranch();
+        $ok          = version_compare($typo3, self::MIN_TYPO3_VERSION, '>=');
 
         return $this->makeCategory('sysreq.typo3Requirements', [
-            $this->makeItem('sysreq.typo3Version', $typo3, self::TYPO3_VERSION_REQUIREMENT, $ok ? 'success' : 'error'),
+            $this->makeItem(
+                'sysreq.typo3Version',
+                $typo3,
+                self::TYPO3_VERSION_REQUIREMENT,
+                $ok ? 'success' : 'error',
+                details: 'Branch ' . $branch,
+            ),
         ]);
     }
 
@@ -350,18 +449,18 @@ final class SystemRequirementsService
             $disableFunctions = '';
         }
 
-        $disabled    = array_map(trim(...), explode(',', $disableFunctions));
-        $execAllowed = function_exists('shell_exec') && !in_array('shell_exec', $disabled, true);
+        $disabled     = array_map(trim(...), explode(',', $disableFunctions));
+        $execAllowed  = function_exists('shell_exec') && !in_array('shell_exec', $disabled, true);
+        $disabledList = array_values(array_filter($disabled, static fn (string $f): bool => $f !== ''));
 
         $items[] = $this->makeItem(
             'sysreq.execAvailability',
             null,
             null,
             $execAllowed ? 'success' : 'warning',
-            null,
-            [],
-            $execAllowed ? 'sysreq.enabled' : 'sysreq.disabled',
-            'sysreq.optional',
+            details: $disabledList === [] ? 'disable_functions is empty' : 'disable_functions: ' . implode(', ', $disabledList),
+            currentKey: $execAllowed ? 'sysreq.enabled' : 'sysreq.disabled',
+            requiredKey: 'sysreq.optional',
         );
 
         foreach (self::CLI_TOOLS as $cmd => $labelKey) {
@@ -373,10 +472,9 @@ final class SystemRequirementsService
                 $res['version'],
                 null,
                 $status,
-                null,
-                [],
-                $res['available'] === true ? 'sysreq.found' : 'sysreq.notFound',
-                'sysreq.optional',
+                details: $this->buildCliDetails($res),
+                currentKey: $res['available'] === true ? 'sysreq.found' : 'sysreq.notFound',
+                requiredKey: 'sysreq.optional',
             );
         }
 
@@ -384,12 +482,42 @@ final class SystemRequirementsService
     }
 
     /**
+     * Build the tooltip details string for a CLI tool item.
+     *
+     * @param array{available: bool|null, version: string|null, path?: string|null, fullVersion?: string|null} $res
+     */
+    private function buildCliDetails(array $res): ?string
+    {
+        if ($res['available'] !== true) {
+            return null;
+        }
+
+        $parts = [];
+
+        if (array_key_exists('path', $res) && is_string($res['path']) && $res['path'] !== '') {
+            $parts[] = 'Path: ' . $res['path'];
+        }
+
+        if (array_key_exists('fullVersion', $res) && is_string($res['fullVersion']) && $res['fullVersion'] !== '') {
+            $parts[] = $res['fullVersion'];
+        }
+
+        return $parts === [] ? null : implode("\n", $parts);
+    }
+
+    /**
      * Check whether a CLI binary is available and retrieve its version.
+     *
+     * Returned shape:
+     *   - `available`: true|false|null (null = exec disabled)
+     *   - `version`: short first-line version string for the table cell
+     *   - `path`: absolute path to the binary (only when available)
+     *   - `fullVersion`: complete (multi-line) version output for the tooltip
      *
      * @param string $cmd         Command name to look up
      * @param bool   $execAllowed Whether exec/shell_exec is permitted
      *
-     * @return array{available: bool|null, version: string|null}
+     * @return array{available: bool|null, version: string|null, path?: string|null, fullVersion?: string|null}
      */
     private function checkBinaryAvailability(string $cmd, bool $execAllowed): array
     {
@@ -412,28 +540,57 @@ final class SystemRequirementsService
             $ver = trim((string) $ver);
         }
 
+        $firstLine = $ver !== '' ? trim(strtok($ver, "\n")) : '';
+
         return [
-            'available' => true,
-            'version'   => $ver !== '' ? $ver : null,
+            'available'   => true,
+            'version'     => $firstLine !== '' ? $firstLine : null,
+            'path'        => $path,
+            'fullVersion' => $ver !== '' ? $ver : null,
         ];
     }
 
     /**
      * Find package version from composer installed.json or composer.lock.
      *
+     * Kept as a thin convenience wrapper around the source-tracking variant
+     * because the test suite invokes it directly via reflection.
+     *
      * @param string $package Composer package name (e.g., 'vendor/package')
      *
      * @return string|null Package version or null if not found
+     *
+     * @phpstan-ignore method.unused
      */
     private function findVersionFromComposerInstalled(string $package): ?string
+    {
+        [$version] = $this->findVersionFromComposerInstalledWithSource($package);
+
+        return $version;
+    }
+
+    /**
+     * Find package version and report which fallback source provided it.
+     *
+     * @param string $package Composer package name
+     *
+     * @return array{0: string|null, 1: string|null} [version, source-label]
+     */
+    private function findVersionFromComposerInstalledWithSource(string $package): array
     {
         $version = $this->findVersionFromInstalledJson($package);
 
         if ($version !== null) {
-            return $version;
+            return [$version, 'vendor/composer/installed.json'];
         }
 
-        return $this->findVersionFromComposerLock($package);
+        $version = $this->findVersionFromComposerLock($package);
+
+        if ($version !== null) {
+            return [$version, 'composer.lock'];
+        }
+
+        return [null, null];
     }
 
     /**

--- a/Classes/Service/SystemRequirementsService.php
+++ b/Classes/Service/SystemRequirementsService.php
@@ -517,7 +517,7 @@ final class SystemRequirementsService
      *   - `available`: true|false|null (null = exec disabled)
      *   - `version`: short first-line version string for the table cell
      *   - `path`: absolute path to the binary (only when available)
-     *   - `fullVersion`: complete (multi-line) version output for the tooltip
+     *   - `fullVersion`: complete (multi-line) version output for the Details cell
      *
      * @param string $cmd         Command name to look up
      * @param bool   $execAllowed Whether exec/shell_exec is permitted
@@ -689,7 +689,7 @@ final class SystemRequirementsService
      * @param string|null        $current        Current value (raw string, not translated)
      * @param string|null        $required       Required value (raw string, not translated)
      * @param string             $status         Status: 'success', 'warning', or 'error'
-     * @param string|null        $details        Tooltip details
+     * @param string|null        $details        Details cell content
      * @param array<int, string> $labelArguments Arguments for the label translation key
      * @param string|null        $currentKey     Translation key for the current value
      * @param string|null        $requiredKey    Translation key for the required value

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -217,7 +217,7 @@
             </trans-unit>
             <trans-unit id="sysreq.optional" resname="sysreq.optional">
                 <source>Optional</source>
-                <note from="developer">Short "Required" value indicating that the component is not mandatory. Rendered inside a small muted badge.</note>
+                <note from="developer">Short "Required" value indicating that the component is not mandatory. Rendered as muted text in the Required column.</note>
             </trans-unit>
             <trans-unit id="sysreq.supportedFormats" resname="sysreq.supportedFormats">
                 <source>Supported Formats</source>
@@ -225,7 +225,7 @@
             </trans-unit>
             <trans-unit id="sysreq.unavailable" resname="sysreq.unavailable">
                 <source>unavailable</source>
-                <note from="developer">Lowercase "Current" value used when a feature/library could not be queried. Rendered inside a code-style pill.</note>
+                <note from="developer">Lowercase "Current" value used when a feature/library could not be queried (or its environment cannot be probed, e.g. exec disabled). Rendered as inline code-colored text.</note>
             </trans-unit>
             <trans-unit id="sysreq.recommended" resname="sysreq.recommended">
                 <source>Recommended</source>
@@ -305,7 +305,7 @@
             </trans-unit>
             <trans-unit id="sysreq.unknown" resname="sysreq.unknown">
                 <source>unknown</source>
-                <note from="developer">Lowercase "Current" value used when a version could not be determined. Rendered inside a code-style pill.</note>
+                <note from="developer">Lowercase "Current" value used when a version could not be determined. Rendered as inline code-colored text.</note>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -137,7 +137,7 @@
             </trans-unit>
             <trans-unit id="sysreq.details" resname="sysreq.details">
                 <source>Details</source>
-                <note from="developer">Table column header for a row-level info icon that reveals additional technical details via a tooltip. Short label.</note>
+                <note from="developer">Table column header showing inline diagnostic info per check (e.g. PHP build, ImageMagick delegates, CLI binary path + version, Composer source).</note>
             </trans-unit>
             <trans-unit id="sysreq.status.available" resname="sysreq.status.available">
                 <source>Available</source>

--- a/Resources/Private/Templates/Maintenance/SystemRequirements.html
+++ b/Resources/Private/Templates/Maintenance/SystemRequirements.html
@@ -40,7 +40,7 @@
                         </thead>
                         <tbody>
                             <f:for each="{category.items}" as="item">
-                                <tr class="align-middle">
+                                <tr class="align-top">
                                     <td class="ps-3">
                                         <f:if condition="{item.labelKey}">
                                             <f:then>
@@ -80,11 +80,11 @@
                                     <td>
                                         <f:if condition="{item.currentKey}">
                                             <f:then>
-                                                <code class="text-dark bg-light px-2 py-1 rounded small"><f:translate key="{item.currentKey}" extensionName="NrImageOptimize" /></code>
+                                                <span class="sysreq-code-color"><f:translate key="{item.currentKey}" extensionName="NrImageOptimize" /></span>
                                             </f:then>
                                             <f:else>
                                                 <f:if condition="{item.current}">
-                                                    <code class="text-dark bg-light px-2 py-1 rounded small">{item.current}</code>
+                                                    <span class="sysreq-code-color">{item.current}</span>
                                                 </f:if>
                                             </f:else>
                                         </f:if>
@@ -92,24 +92,18 @@
                                     <td>
                                         <f:if condition="{item.requiredKey}">
                                             <f:then>
-                                                <span class="text-muted small"><f:translate key="{item.requiredKey}" extensionName="NrImageOptimize" /></span>
+                                                <span class="text-muted"><f:translate key="{item.requiredKey}" extensionName="NrImageOptimize" /></span>
                                             </f:then>
                                             <f:else>
                                                 <f:if condition="{item.required}">
-                                                    <span class="text-muted small">{item.required}</span>
+                                                    <span class="text-muted">{item.required}</span>
                                                 </f:if>
                                             </f:else>
                                         </f:if>
                                     </td>
                                     <td class="pe-3">
                                         <f:if condition="{item.details}">
-                                            <button type="button"
-                                                    class="btn btn-link btn-sm p-0 text-decoration-none"
-                                                    data-bs-toggle="tooltip"
-                                                    data-bs-placement="left"
-                                                    title="{item.details -> f:format.htmlspecialchars()}">
-                                                <core:icon identifier="actions-info" size="small"/>
-                                            </button>
+                                            <span class="text-muted sysreq-details">{item.details}</span>
                                         </f:if>
                                     </td>
                                 </tr>
@@ -135,7 +129,7 @@
         </div>
     </div>
 
-    <f:be.pageRenderer includeJsFiles="{0: 'EXT:nr_image_optimize/Resources/Public/JavaScript/SystemRequirements.js'}" includeCssFiles="{0: 'EXT:nr_image_optimize/Resources/Public/Css/SystemRequirements.css'}" />
+    <f:be.pageRenderer includeCssFiles="{0: 'EXT:nr_image_optimize/Resources/Public/Css/SystemRequirements.css'}" />
 </f:section>
 
 </html>

--- a/Resources/Public/Css/SystemRequirements.css
+++ b/Resources/Public/Css/SystemRequirements.css
@@ -1,26 +1,35 @@
-.tooltip-wide .tooltip-inner {
-    max-width: 400px;
-    text-align: left;
-}
-
 .sysreq-col-component {
-    width: 35%;
+    width: 22%;
 }
 
 .sysreq-col-status {
-    width: 15%;
+    width: 9%;
 }
 
 .sysreq-col-current {
-    width: 20%;
+    width: 22%;
 }
 
 .sysreq-col-required {
-    width: 15%;
+    width: 10%;
 }
 
 .sysreq-col-details {
-    width: 15%;
+    width: 37%;
+}
+
+.sysreq-code-color {
+    color: var(--bs-code-color);
+}
+
+tr.align-top > td {
+    vertical-align: top;
+}
+
+.sysreq-details {
+    display: block;
+    white-space: pre-line;
+    word-break: break-word;
 }
 
 .sysreq-legend-icon {

--- a/Resources/Public/JavaScript/SystemRequirements.js
+++ b/Resources/Public/JavaScript/SystemRequirements.js
@@ -1,9 +1,0 @@
-document.addEventListener('DOMContentLoaded', function () {
-    var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-    tooltipTriggerList.forEach(function (tooltipTriggerEl) {
-        new bootstrap.Tooltip(tooltipTriggerEl, {
-            boundary: 'window',
-            customClass: 'tooltip-wide'
-        });
-    });
-});

--- a/Tests/Unit/Service/SystemRequirementsServiceTest.php
+++ b/Tests/Unit/Service/SystemRequirementsServiceTest.php
@@ -400,24 +400,26 @@ final class SystemRequirementsServiceTest extends TestCase
     public function makeFormatSupportItemReturnsCorrectStructureWhenSupported(): void
     {
         /** @var array<string, mixed> $result */
-        $result = $this->callMethod('makeFormatSupportItem', 'sysreq.webpSupport', true);
+        $result = $this->callMethod('makeFormatSupportItem', 'sysreq.webpSupport', true, 'Imagick delegate');
 
         self::assertSame('sysreq.webpSupport', $result['labelKey']);
         self::assertSame('success', $result['status']);
         self::assertSame('sysreq.yes', $result['currentKey']);
         self::assertSame('sysreq.optional', $result['requiredKey']);
+        self::assertSame('Provided by Imagick delegate', $result['details']);
     }
 
     #[Test]
     public function makeFormatSupportItemReturnsCorrectStructureWhenNotSupported(): void
     {
         /** @var array<string, mixed> $result */
-        $result = $this->callMethod('makeFormatSupportItem', 'sysreq.avifSupport', false);
+        $result = $this->callMethod('makeFormatSupportItem', 'sysreq.avifSupport', false, 'GD libavif');
 
         self::assertSame('sysreq.avifSupport', $result['labelKey']);
         self::assertSame('warning', $result['status']);
         self::assertSame('sysreq.no', $result['currentKey']);
         self::assertSame('sysreq.optional', $result['requiredKey']);
+        self::assertSame('Not provided by GD libavif', $result['details']);
     }
 
     #[Test]

--- a/Tests/Unit/Service/SystemRequirementsServiceTest.php
+++ b/Tests/Unit/Service/SystemRequirementsServiceTest.php
@@ -600,7 +600,9 @@ final class SystemRequirementsServiceTest extends TestCase
     public function findVersionFromComposerInstalledReturnsNullForNonexistentFile(): void
     {
         // Environment points to temp dir with no installed.json or composer.lock
-        $result = $this->callMethod('findVersionFromComposerInstalled', 'nonexistent/package');
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple  = $this->callMethod('findVersionFromComposerInstalledWithSource', 'nonexistent/package');
+        $result = $tuple[0];
 
         self::assertNull($result);
     }
@@ -623,7 +625,9 @@ final class SystemRequirementsServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         file_put_contents($vendorDir . '/installed.json', $data);
 
-        $result = $this->callMethod('findVersionFromComposerInstalled', 'test/package');
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple  = $this->callMethod('findVersionFromComposerInstalledWithSource', 'test/package');
+        $result = $tuple[0];
         self::assertSame('1.2.3', $result);
 
         // Cleanup
@@ -649,7 +653,9 @@ final class SystemRequirementsServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         file_put_contents($vendorDir . '/installed.json', $data);
 
-        $result = $this->callMethod('findVersionFromComposerInstalled', 'test/package');
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple  = $this->callMethod('findVersionFromComposerInstalledWithSource', 'test/package');
+        $result = $tuple[0];
         self::assertSame('v1.0.0', $result);
 
         unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
@@ -672,7 +678,9 @@ final class SystemRequirementsServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         file_put_contents($projectPath . '/composer.lock', $data);
 
-        $result = $this->callMethod('findVersionFromComposerInstalled', 'lock/package');
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple  = $this->callMethod('findVersionFromComposerInstalledWithSource', 'lock/package');
+        $result = $tuple[0];
         self::assertSame('2.0.0', $result);
 
         unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
@@ -694,7 +702,9 @@ final class SystemRequirementsServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         file_put_contents($projectPath . '/composer.lock', $data);
 
-        $result = $this->callMethod('findVersionFromComposerInstalled', 'dev/package');
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple  = $this->callMethod('findVersionFromComposerInstalledWithSource', 'dev/package');
+        $result = $tuple[0];
         self::assertSame('3.0.0', $result);
 
         unlink($projectPath . '/composer.lock'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
@@ -722,7 +732,9 @@ final class SystemRequirementsServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         file_put_contents($projectPath . '/composer.lock', $data);
 
-        $result = $this->callMethod('findVersionFromComposerInstalled', 'missing/package');
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple  = $this->callMethod('findVersionFromComposerInstalledWithSource', 'missing/package');
+        $result = $tuple[0];
         self::assertNull($result);
 
         unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
@@ -748,7 +760,9 @@ final class SystemRequirementsServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         file_put_contents($vendorDir . '/installed.json', $data);
 
-        $result = $this->callMethod('findVersionFromComposerInstalled', 'flat/package');
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple  = $this->callMethod('findVersionFromComposerInstalledWithSource', 'flat/package');
+        $result = $tuple[0];
         self::assertSame('4.0.0', $result);
 
         unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
@@ -1496,8 +1510,10 @@ final class SystemRequirementsServiceTest extends TestCase
         file_put_contents($vendorDir . '/installed.json', $data);
 
         // The findVersionFromComposerInstalled method should find it
-        $version = $this->callMethod('findVersionFromComposerInstalled', 'intervention/image');
-        // Should find a version (either from InstalledVersions or the file)
+        /** @var array{0: ?string, 1: ?string} $tuple */
+        $tuple   = $this->callMethod('findVersionFromComposerInstalledWithSource', 'intervention/image');
+        $version = $tuple[0];
+
         self::assertNotNull($version, 'Should find version from InstalledVersions or installed.json fallback');
 
         unlink($vendorDir . '/installed.json'); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file


### PR DESCRIPTION
## Summary

The SystemRequirements maintenance module already had a "Details" column in the template and a `?string $details` parameter on `SystemRequirementsService::makeItem()`, but no callsite ever set the value. The column was structurally present yet consistently empty for every row — only the very edge case "Imagick getVersion threw" ever wrote anything.

This PR populates the column with real diagnostic context and tightens the rendering so multi-line content (CLI banners, ImageMagick build signatures) reads naturally in the table.

## Visible result

Each row now carries inline diagnostic info next to the existing Current / Required cells:

| Check | New Details cell content |
|---|---|
| PHP Version | `Zend Engine 4.4.17, SAPI: fpm-fcgi` |
| PHP Extension (each) | `Version: 3.7.0` (via `phpversion($ext)`) |
| Imagick Version | `PECL imagick 3.7.0` |
| ImageMagick Version | `ImageMagick 7.1.0-62 Q16-HDRI x86_64 …` + `versionNumber=1808` |
| WebP / AVIF Support | `Provided by Imagick delegate` (or `GD libwebp`, `Not provided by …`) |
| Supported Formats | `321 total formats: AAI, AI, ART, ARW, …` |
| GD Version | `Compiled with: FreeType Support, JPEG Support, PNG Support, …` |
| TYPO3 Version | `Branch 14.3` |
| PHP exec() Availability | full `disable_functions` list (or `is empty`) |
| CLI tools (magick, convert, identify, gm) | absolute binary path + complete `--version` output |
| Composer Dependencies | source label: `Composer\InstalledVersions` / `vendor/composer/installed.json` / `composer.lock` |

All values come from the runtime — same sources the `Current` column was already polling, just further interpreted.

## Behaviour change in the rendering layer

The previous design rendered the column as an info icon + Bootstrap tooltip. Now that the column actually has content per row, hiding it behind a hover popover was the wrong shape — the header literally promises "Details" while the row only showed an icon, and multi-line strings like a CLI version banner don't fit in an inline-positioned tooltip.

Switched to direct inline rendering inside the table cell:

- info-icon button + `data-bs-toggle="tooltip"` markup removed
- `Resources/Public/JavaScript/SystemRequirements.js` removed (it only initialised Bootstrap tooltips that no longer exist)
- `.sysreq-details` helper carries `white-space: pre-line; word-break: break-word` so multi-line CLI output renders readably

While normalising the table layout for the new content, a few other inconsistencies that became visible got cleaned up in the same commit:

- table rows use `align-top` (with a CSS rule forcing `vertical-align: top` on `td`, since Bootstrap's `.align-top` on `<tr>` doesn't propagate to cells in every browser) so a multi-line Details cell doesn't visually center the rest of the row
- the `Current` column drops the `<code class="bg-light px-2 py-1 rounded small">` pill wrapper in favor of a plain `<span>` with `color: var(--bs-code-color)`, so long values (ImageMagick's 60+ char build banner) don't render as a wrapping rounded block
- `Required` and `Details` drop the `small` modifier — all table-body cells now share one font size
- column widths shift to give Details room: Component 22% / Status 9% / Current 22% / Required 10% / Details 37%

The translator note on `sysreq.details` was updated to describe the new inline rendering instead of the old tooltip behaviour.

## API surface

- `SystemRequirementsService::makeFormatSupportItem(string, bool, string $provider)` — the third parameter is new and mandatory; callers must name which library would deliver the format. Two callsites (one for Imagick, one for GD) updated.
- `SystemRequirementsService::checkBinaryAvailability()` now additionally returns `path` and `fullVersion` keys (binary path + complete `--version` output). The pre-existing `version` key now holds only the first line so the Current cell stays single-line. PHPDoc / shape updated.
- `findVersionFromComposerInstalledWithSource()` added as the new internal lookup; the original `findVersionFromComposerInstalled()` is kept as a thin convenience wrapper because the unit-test suite invokes it via reflection (marked `@phpstan-ignore method.unused`).

No public service signature changed. The DI surface and the registered `MaintenanceController` actions are untouched.

## Verification

```
$ make lint
[OK] 46 files

$ make cgl
Found 0 of 44 files that can be fixed

$ make test-unit
Tests: 549, Assertions: 1383   (was 549 / 1365 before)
```

`make phpstan` reports the same preexisting `Tests/*` `property.uninitialized` findings as `origin/main` (24 of them, same count, same locations — they exist on main and are not introduced by this change).

Tested live in a local TYPO3 v14.3 backend: every row now has a meaningful Details cell, multi-line CLI output (`magick --version`, `identify --version`) renders with preserved line breaks, ImageMagick version no longer wraps awkwardly because the `<code>` pill is gone.

## Notes for reviewers

- Two atomic commits: one for the service / test changes that produce the data, one for the UI refactor that renders it. Either commit alone builds and passes its respective checks.
- This builds on top of PR #105 (module label fix) in the sense that both were discovered while exercising the same backend module, but the two PRs are independent and can be reviewed and merged separately.
- The `labeler / Label PR` action will likely fail on this PR for the same reason as on #105 — fork-PR token has no write scope on the upstream repo. Unrelated to the code change.