### PR TITLE
[BUGFIX] Apply the configured quality when encoding image variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,28 @@ jobs:
       coverage-tool: 'xdebug'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # The shared reusable workflow has no acceptance-test input, so the acceptance
+  # suite runs here. Overriding unit-test-command instead would replace the
+  # coverage-instrumented default and break the Codecov upload.
+  acceptance:
+    name: Acceptance tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          extensions: intl, mbstring, xml, imagick, gd
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Run acceptance tests
+        run: composer ci:test:php:acceptance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       typo3-versions: '["^13.4","^14.0"]'
       upload-coverage: true
       run-functional-tests: true
+      run-acceptance-tests: true
       functional-test-db: 'sqlite'
       php-extensions: 'intl, mbstring, xml, imagick, gd'
       coverage-tool: 'xdebug'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,28 +27,3 @@ jobs:
       coverage-tool: 'xdebug'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  # The shared reusable workflow has no acceptance-test input, so the acceptance
-  # suite runs here. Overriding unit-test-command instead would replace the
-  # coverage-instrumented default and break the Codecov upload.
-  acceptance:
-    name: Acceptance tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
-        with:
-          php-version: '8.4'
-          tools: composer:v2
-          extensions: intl, mbstring, xml, imagick, gd
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress
-
-      - name: Run acceptance tests
-        run: composer ci:test:php:acceptance

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -117,6 +117,14 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
     private const MAX_QUALITY = 100;
 
     /**
+     * Default output quality applied when the variant URL carries no `q` value.
+     *
+     * Mirrors Intervention's AbstractEncoder::DEFAULT_QUALITY so that URLs
+     * without an explicit quality keep encoding byte-stable.
+     */
+    private const DEFAULT_QUALITY = 75;
+
+    /**
      * Cache-Control max-age for processed images (1 year in seconds).
      * Processed image URLs contain dimension/quality parameters, making them
      * effectively content-addressed -- the URL changes whenever the variant changes.
@@ -609,7 +617,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
         // Clamp dimensions and quality to safe ranges to prevent DoS
         $targetWidth   = $this->clampDimension($modeValues['w'] ?? null);
         $targetHeight  = $this->clampDimension($modeValues['h'] ?? null);
-        $targetQuality = $this->clampQuality($modeValues['q'] ?? self::MAX_QUALITY);
+        $targetQuality = $this->clampQuality($modeValues['q'] ?? self::DEFAULT_QUALITY);
 
         return [
             'pathVariant'    => $basePath . $variantUrl,

--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -500,7 +500,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
 
         $this->ensureDirectoryExists(dirname($urlInfo['pathVariant']));
 
-        $image->save($urlInfo['pathVariant'], $targetQuality);
+        $image->save($urlInfo['pathVariant'], quality: $targetQuality);
 
         $extension   = $urlInfo['extension'];
         $pathVariant = $urlInfo['pathVariant'];
@@ -1110,7 +1110,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
      */
     private function generateWebpVariant(ImageInterface $image, int $targetQuality, string $pathVariant): void
     {
-        $image->save($pathVariant . '.webp', $targetQuality);
+        $image->save($pathVariant . '.webp', quality: $targetQuality);
     }
 
     /**
@@ -1122,7 +1122,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
      */
     private function generateAvifVariant(ImageInterface $image, int $targetQuality, string $pathVariant): void
     {
-        $image->save($pathVariant . '.avif', $targetQuality);
+        $image->save($pathVariant . '.avif', quality: $targetQuality);
     }
 
     /**

--- a/Classes/ViewHelpers/SourceSetViewHelper.php
+++ b/Classes/ViewHelpers/SourceSetViewHelper.php
@@ -59,7 +59,7 @@ final class SourceSetViewHelper extends AbstractViewHelper
     /**
      * Default quality for generated image variants.
      */
-    private const DEFAULT_QUALITY = 100;
+    private const DEFAULT_QUALITY = 75;
 
     /**
      * Transparent 1x1 GIF used as placeholder for JS lazy-loaded images.

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -163,7 +163,7 @@ Parameters
 ..  note::
 
     Quality and output format are not exposed as ViewHelper
-    arguments. Quality defaults to 100 and is baked into the
+    arguments. Quality defaults to 75 and is baked into the
     generated ``/processed/...q<n>...`` URL; the variant's
     file extension is inherited from the source image. Use
     :ref:`the URL format <configuration-url-format>` and

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -29,14 +29,17 @@ Basic responsive image
 ======================
 
 ..  code-block:: html
-    :caption: Simple responsive image with quality setting
+    :caption: Simple responsive image
 
     <nr:sourceSet file="{image}"
                   width="1200"
                   height="800"
-                  quality="85"
                   sizes="(max-width: 768px) 100vw, 50vw"
     />
+
+Quality is not configurable per call: the ViewHelper always
+emits its default quality of 75 into the generated
+``/processed/...q<n>...`` URL.
 
 ..  _usage-responsive-srcset:
 
@@ -96,8 +99,8 @@ Output comparison
 ..  code-block:: html
     :caption: Density-based 2x srcset output
 
-    <img src="/processed/fileadmin/image.w625h250m1q100.jpg"
-         srcset="/processed/fileadmin/image.w1250h500m1q100.jpg x2"
+    <img src="/processed/fileadmin/image.w625h250m1q75.jpg"
+         srcset="/processed/fileadmin/image.w1250h500m1q75.jpg x2"
          width="625"
          height="250"
          loading="lazy">
@@ -107,14 +110,14 @@ Output comparison
 ..  code-block:: html
     :caption: Width-based srcset output
 
-    <img src="/processed/fileadmin/image.w1250h1250m1q100.png"
-         srcset="/processed/fileadmin/image.w480h480m1q100.png 480w,
-                 /processed/fileadmin/image.w576h576m1q100.png 576w,
-                 /processed/fileadmin/image.w640h640m1q100.png 640w,
-                 /processed/fileadmin/image.w768h768m1q100.png 768w,
-                 /processed/fileadmin/image.w992h992m1q100.png 992w,
-                 /processed/fileadmin/image.w1200h1200m1q100.png 1200w,
-                 /processed/fileadmin/image.w1800h1800m1q100.png 1800w"
+    <img src="/processed/fileadmin/image.w1250h1250m1q75.png"
+         srcset="/processed/fileadmin/image.w480h480m1q75.png 480w,
+                 /processed/fileadmin/image.w576h576m1q75.png 576w,
+                 /processed/fileadmin/image.w640h640m1q75.png 640w,
+                 /processed/fileadmin/image.w768h768m1q75.png 768w,
+                 /processed/fileadmin/image.w992h992m1q75.png 992w,
+                 /processed/fileadmin/image.w1200h1200m1q75.png 1200w,
+                 /processed/fileadmin/image.w1800h1800m1q75.png 1800w"
          sizes="auto, (min-width: 992px) 991px, 100vw"
          width="991"
          loading="lazy"

--- a/Tests/Acceptance/ViewHelpers/SourceSetViewHelperHtmlOutputTest.php
+++ b/Tests/Acceptance/ViewHelpers/SourceSetViewHelperHtmlOutputTest.php
@@ -105,7 +105,7 @@ final class SourceSetViewHelperHtmlOutputTest extends TestCase
 
         self::assertNotNull($img, 'Expected an <img> tag in the output.');
         self::assertSame(
-            '/processed/fileadmin/hero.w800h600m0q100.jpg',
+            '/processed/fileadmin/hero.w800h600m0q75.jpg',
             $img->getAttribute('src'),
         );
     }
@@ -127,7 +127,7 @@ final class SourceSetViewHelperHtmlOutputTest extends TestCase
         self::assertNotNull($img);
 
         $srcset = $img->getAttribute('srcset');
-        self::assertStringContainsString('/processed/fileadmin/hero.w800h600m0q100.jpg 2x', $srcset);
+        self::assertStringContainsString('/processed/fileadmin/hero.w800h600m0q75.jpg 2x', $srcset);
     }
 
     #[Test]
@@ -254,9 +254,9 @@ final class SourceSetViewHelperHtmlOutputTest extends TestCase
 
         $srcset = $source->getAttribute('srcset');
         // 1x candidate
-        self::assertStringContainsString('/processed/fileadmin/product.w300h200m0q100.jpg', $srcset);
+        self::assertStringContainsString('/processed/fileadmin/product.w300h200m0q75.jpg', $srcset);
         // 2x candidate
-        self::assertStringContainsString('/processed/fileadmin/product.w600h400m0q100.jpg 2x', $srcset);
+        self::assertStringContainsString('/processed/fileadmin/product.w600h400m0q75.jpg 2x', $srcset);
     }
 
     /**

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -225,9 +225,18 @@ final class ProcessorTest extends TestCase
      * well: those go through save() too, so the mock receives three invocations
      * and only the first one carries the base-format path.
      *
-     * @param MockObject&ImageInterface $image            Image mock receiving the save() expectation
-     * @param string|null               $writeContents    Payload to write to the saved path, or null to write nothing
-     * @param bool                      $expectSingleCall Whether save() must be invoked exactly once
+     * The optional parameters cover the remaining save() wirings of the
+     * processAndRespond* family so that no call site has to re-implement the
+     * callback: an exact invocation count, a white list of accepted paths and
+     * the exceptions thrown for the WebP/AVIF variant paths.
+     *
+     * @param MockObject&ImageInterface $image             Image mock receiving the save() expectation
+     * @param string|null               $writeContents     Payload to write to the saved path, or null to write nothing
+     * @param bool                      $expectSingleCall  Whether save() must be invoked exactly once
+     * @param int|null                  $expectedCallCount Exact number of expected invocations, overrides $expectSingleCall
+     * @param list<string>|null         $allowedPaths      When given, every saved path must be one of these
+     * @param Throwable|null            $webpError         Thrown instead of writing when the path ends in ".webp"
+     * @param Throwable|null            $avifError         Thrown instead of writing when the path ends in ".avif"
      *
      * @return ArrayObject<string, mixed> Holder with the captured 'path' and 'options'
      */
@@ -235,6 +244,10 @@ final class ProcessorTest extends TestCase
         MockObject $image,
         ?string $writeContents = null,
         bool $expectSingleCall = true,
+        ?int $expectedCallCount = null,
+        ?array $allowedPaths = null,
+        ?Throwable $webpError = null,
+        ?Throwable $avifError = null,
     ): ArrayObject {
         /** @var ArrayObject<string, mixed> $capture */
         $capture = new ArrayObject([
@@ -242,13 +255,29 @@ final class ProcessorTest extends TestCase
             'options' => [],
         ]);
 
-        $invocationRule = $expectSingleCall ? self::once() : self::atLeastOnce();
+        if ($expectedCallCount !== null) {
+            $invocationRule = self::exactly($expectedCallCount);
+        } else {
+            $invocationRule = $expectSingleCall ? self::once() : self::atLeastOnce();
+        }
 
         $image->expects($invocationRule)->method('save')->willReturnCallback(
-            static function (?string $path = null, mixed ...$options) use ($capture, $image, $writeContents): ImageInterface {
+            static function (?string $path = null, mixed ...$options) use ($capture, $image, $writeContents, $allowedPaths, $webpError, $avifError): ImageInterface {
                 if ($capture['path'] === null) {
                     $capture['path']    = $path;
                     $capture['options'] = $options;
+                }
+
+                if ($allowedPaths !== null) {
+                    self::assertContains($path, $allowedPaths);
+                }
+
+                if (($path !== null) && ($webpError !== null) && str_ends_with($path, '.webp')) {
+                    throw $webpError;
+                }
+
+                if (($path !== null) && ($avifError !== null) && str_ends_with($path, '.avif')) {
+                    throw $avifError;
                 }
 
                 if (($writeContents !== null) && ($path !== null)) {
@@ -2847,15 +2876,68 @@ final class ProcessorTest extends TestCase
         return ['processor' => $instance, 'image' => $image];
     }
 
-    #[Test]
-    public function processAndRespondProcessesImageAndBuildsResponse(): void
-    {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-process-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
+    /**
+     * Build the arrangement shared by every processAndRespond* test: the
+     * temporary original file, the PSR-17 response and stream factories, a
+     * Processor backed by a mocked image reader, the request with its query
+     * string and the matching $urlInfo array.
+     *
+     * Only the parts that actually differ between the tests are parameters; the
+     * save() wiring stays with the caller and goes through captureSaveCall().
+     *
+     * @param string      $prefix           Temp directory name prefix
+     * @param string      $extension        File extension of original and variant
+     * @param int         $sourceWidth      Width reported by the image mock
+     * @param int         $sourceHeight     Height reported by the image mock
+     * @param int|null    $targetHeight     Requested target height, null for scale mode
+     * @param int         $processingMode   Requested processing mode
+     * @param string      $query            Request query string
+     * @param object|null $eventDispatcher  Event dispatcher stub/mock
+     * @param string      $variantDir       Directory below the temp dir holding the variant
+     * @param bool        $createVariantDir Whether the variant directory is created upfront
+     *
+     * @return array{
+     *     processor: Processor,
+     *     image: MockObject&ImageInterface,
+     *     response: MockObject&ResponseInterface,
+     *     request: MockObject&ServerRequestInterface,
+     *     tempDir: string,
+     *     originalPath: string,
+     *     variantPath: string,
+     *     urlInfo: array<string, mixed>
+     * }
+     */
+    private function setUpProcessAndRespondScenario(
+        string $prefix,
+        string $extension,
+        int $sourceWidth,
+        int $sourceHeight,
+        ?int $targetHeight,
+        int $processingMode,
+        string $query,
+        ?object $eventDispatcher = null,
+        string $variantDir = 'processed',
+        bool $createVariantDir = true,
+    ): array {
+        $targetWidth   = 400;
+        $targetQuality = 80;
 
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpeg-data');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.jpg';
+        $tempDir = sys_get_temp_dir() . '/' . $prefix . uniqid('', true);
+        mkdir($createVariantDir ? $tempDir . '/' . $variantDir : $tempDir, 0o777, true);
+
+        $originalPath = $tempDir . '/original.' . $extension;
+        file_put_contents($originalPath, 'fake-image-data');
+
+        $variantPath = sprintf(
+            '%s/%s/original.w%d%sm%dq%d.%s',
+            $tempDir,
+            $variantDir,
+            $targetWidth,
+            $targetHeight !== null ? 'h' . $targetHeight : '',
+            $processingMode,
+            $targetQuality,
+            $extension,
+        );
 
         $response200 = $this->createMock(ResponseInterface::class);
         $response200->method('withHeader')->willReturn($response200);
@@ -2871,410 +2953,169 @@ final class ProcessorTest extends TestCase
         ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
             responseFactory: $responseFactory,
             streamFactory: $streamFactory,
+            eventDispatcher: $eventDispatcher,
         );
 
-        $image->method('width')->willReturn(800);
-        $image->method('height')->willReturn(400);
+        $image->method('width')->willReturn($sourceWidth);
+        $image->method('height')->willReturn($sourceHeight);
         $image->method('cover')->willReturn($image);
-        $capture = $this->captureSaveCall($image, 'processed-image', expectSingleCall: false);
+        $image->method('scale')->willReturn($image);
 
         $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
+        $uri->method('getQuery')->willReturn($query);
         $request = $this->createMock(ServerRequestInterface::class);
         $request->method('getUri')->willReturn($uri);
 
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
+        return [
+            'processor'    => $processor,
+            'image'        => $image,
+            'response'     => $response200,
+            'request'      => $request,
+            'tempDir'      => $tempDir,
+            'originalPath' => $originalPath,
+            'variantPath'  => $variantPath,
+            'urlInfo'      => [
+                'pathVariant'    => $variantPath,
+                'pathOriginal'   => $originalPath,
+                'extension'      => $extension,
+                'targetWidth'    => $targetWidth,
+                'targetHeight'   => $targetHeight,
+                'targetQuality'  => $targetQuality,
+                'processingMode' => $processingMode,
+            ],
         ];
+    }
 
-        $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
+    /**
+     * Invoke the protected processAndRespond() with the arrangement built by
+     * setUpProcessAndRespondScenario().
+     *
+     * @param array{processor: Processor, request: MockObject&ServerRequestInterface, urlInfo: array<string, mixed>, ...} $scenario
+     */
+    private function invokeProcessAndRespond(array $scenario): mixed
+    {
+        return $this->callMethod($scenario['processor'], 'processAndRespond', $scenario['request'], $scenario['urlInfo']);
+    }
 
-        self::assertSame($response200, $result);
+    /**
+     * Remove the temporary directory tree created by setUpProcessAndRespondScenario().
+     */
+    private function tearDownProcessAndRespondScenario(string $tempDir): void
+    {
+        $entries = glob($tempDir . '/*');
 
-        // The base format is saved with the requested quality as a named option.
-        self::assertSame($variantPath, $capture['path']);
-        self::assertSame(['quality' => 80], $capture['options']);
+        if ($entries !== false) {
+            foreach ($entries as $entry) {
+                if (is_dir($entry)) {
+                    $this->tearDownProcessAndRespondScenario($entry);
 
-        $files = glob($tempDir . '/processed/*');
+                    continue;
+                }
 
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+                unlink($entry); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
             }
         }
 
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
         rmdir($tempDir);
+    }
+
+    #[Test]
+    public function processAndRespondProcessesImageAndBuildsResponse(): void
+    {
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-process-', 'jpg', 800, 400, 200, 0, '');
+
+        $capture = $this->captureSaveCall($scenario['image'], 'processed-image', expectSingleCall: false);
+
+        self::assertSame($scenario['response'], $this->invokeProcessAndRespond($scenario));
+
+        // The base format is saved with the requested quality as a named option.
+        self::assertSame($scenario['variantPath'], $capture['path']);
+        self::assertSame(['quality' => 80], $capture['options']);
+
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     #[Test]
     public function processAndRespondSkipsWebpWhenExtensionIsWebp(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-webp-skip-proc-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
-
-        $originalPath = $tempDir . '/original.webp';
-        file_put_contents($originalPath, 'fake-webp');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.webp';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
-        );
-
-        $image->method('width')->willReturn(400);
-        $image->method('height')->willReturn(200);
-        $image->method('cover')->willReturn($image);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-webp-skip-proc-', 'webp', 400, 200, 200, 0, '');
 
         // WebP source: save primary (.webp) + AVIF variant, but NOT an extra .webp
-        $image->expects(self::exactly(2))->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image, $variantPath): ImageInterface {
-                self::assertThat($path, self::logicalOr(
-                    self::equalTo($variantPath),
-                    self::equalTo($variantPath . '.avif'),
-                ));
-                file_put_contents($path, 'processed');
-
-                return $image;
-            },
+        $this->captureSaveCall(
+            $scenario['image'],
+            'processed',
+            expectedCallCount: 2,
+            allowedPaths: [$scenario['variantPath'], $scenario['variantPath'] . '.avif'],
         );
 
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
+        self::assertSame($scenario['response'], $this->invokeProcessAndRespond($scenario));
 
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'webp',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
-
-        $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-
-        self::assertSame($response200, $result);
-
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     #[Test]
     public function processAndRespondSkipsAvifWhenExtensionIsAvif(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-avif-skip-proc-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
-
-        $originalPath = $tempDir . '/original.avif';
-        file_put_contents($originalPath, 'fake-avif');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.avif';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
-        );
-
-        $image->method('width')->willReturn(400);
-        $image->method('height')->willReturn(200);
-        $image->method('cover')->willReturn($image);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-avif-skip-proc-', 'avif', 400, 200, 200, 0, '');
 
         // AVIF source: save primary (.avif) + WebP variant, but NOT an extra .avif
-        $image->expects(self::exactly(2))->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image, $variantPath): ImageInterface {
-                self::assertThat($path, self::logicalOr(
-                    self::equalTo($variantPath),
-                    self::equalTo($variantPath . '.webp'),
-                ));
-                file_put_contents($path, 'processed');
-
-                return $image;
-            },
+        $this->captureSaveCall(
+            $scenario['image'],
+            'processed',
+            expectedCallCount: 2,
+            allowedPaths: [$scenario['variantPath'], $scenario['variantPath'] . '.webp'],
         );
 
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
+        self::assertSame($scenario['response'], $this->invokeProcessAndRespond($scenario));
 
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'avif',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
-
-        $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-
-        self::assertSame($response200, $result);
-
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     #[Test]
     public function processAndRespondSkipsBothVariantsViaQueryParams(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-skip-both-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
-
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpg');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.jpg';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
-        );
-
-        $image->method('width')->willReturn(400);
-        $image->method('height')->willReturn(200);
-        $image->method('cover')->willReturn($image);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-skip-both-', 'jpg', 400, 200, 200, 0, 'skipWebP=1&skipAvif=1');
 
         // Both variants skipped: save() called exactly once for the primary file only,
         // with the quality passed as a named option (positional is dropped by Intervention v3/v4).
-        $capture = $this->captureSaveCall($image, 'processed');
+        $capture = $this->captureSaveCall($scenario['image'], 'processed');
 
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('skipWebP=1&skipAvif=1');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
+        self::assertSame($scenario['response'], $this->invokeProcessAndRespond($scenario));
 
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
-
-        $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-        self::assertSame($response200, $result);
-
-        self::assertSame($variantPath, $capture['path']);
+        self::assertSame($scenario['variantPath'], $capture['path']);
         self::assertSame(['quality' => 80], $capture['options']);
 
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     #[Test]
     public function processAndRespondHandlesWebpAndAvifGenerationFailure(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-gen-fail-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-gen-fail-', 'jpg', 400, 200, 200, 0, '');
 
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpg');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.jpg';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
+        $this->captureSaveCall(
+            $scenario['image'],
+            'processed',
+            expectSingleCall: false,
+            webpError: new RuntimeException('WebP encoding failed'),
+            avifError: new RuntimeException('AVIF encoding failed'),
         );
 
-        $image->method('width')->willReturn(400);
-        $image->method('height')->willReturn(200);
-        $image->method('cover')->willReturn($image);
-        $image->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image): ImageInterface {
-                if (str_ends_with($path, '.webp')) {
-                    throw new RuntimeException('WebP encoding failed');
-                }
+        self::assertSame($scenario['response'], $this->invokeProcessAndRespond($scenario));
 
-                if (str_ends_with($path, '.avif')) {
-                    throw new RuntimeException('AVIF encoding failed');
-                }
-
-                file_put_contents($path, 'processed');
-
-                return $image;
-            },
-        );
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
-
-        $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-
-        self::assertSame($response200, $result);
-
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     #[Test]
     public function processAndRespondUsesScaleModeWithDerivedHeight(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-scale-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-scale-', 'jpg', 800, 400, null, 1, 'skipWebP=1&skipAvif=1');
 
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpg');
-        $variantPath = $tempDir . '/processed/original.w400m1q80.jpg';
+        $this->captureSaveCall($scenario['image'], 'processed');
 
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
+        self::assertSame($scenario['response'], $this->invokeProcessAndRespond($scenario));
 
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
-        );
-
-        $image->method('width')->willReturn(800);
-        $image->method('height')->willReturn(400);
-        $image->method('scale')->willReturn($image);
-        $image->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image): ImageInterface {
-                file_put_contents($path, 'processed');
-
-                return $image;
-            },
-        );
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('skipWebP=1&skipAvif=1');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => null,
-            'targetQuality'  => 80,
-            'processingMode' => 1,
-        ];
-
-        $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-        self::assertSame($response200, $result);
-
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     // =========================================================================
@@ -3564,34 +3405,24 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondDispatchesImageProcessedEventWithCorrectPayload(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-evt-proc-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
-
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpeg-data');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.jpg';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
+        // The paths are only known once the scenario has been built, so the
+        // expectation reads them through a holder filled in right afterwards.
+        /** @var ArrayObject<string, string|null> $paths */
+        $paths = new ArrayObject([
+            'original' => null,
+            'variant'  => null,
+        ]);
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher->expects(self::once())
             ->method('dispatch')
-            ->with(self::callback(static function (object $event) use ($originalPath, $variantPath): bool {
+            ->with(self::callback(static function (object $event) use ($paths): bool {
                 if (!$event instanceof ImageProcessedEvent) {
                     return false;
                 }
 
-                return $event->pathOriginal === $originalPath
-                    && $event->pathVariant === $variantPath
+                return $event->pathOriginal === $paths['original']
+                    && $event->pathVariant === $paths['variant']
                     && $event->extension === 'jpg'
                     && $event->targetWidth === 400
                     && $event->targetHeight === 200
@@ -3601,51 +3432,16 @@ final class ProcessorTest extends TestCase
                     && $event->avifGenerated;
             }));
 
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
-            eventDispatcher: $eventDispatcher,
-        );
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-evt-proc-', 'jpg', 800, 400, 200, 0, '', $eventDispatcher);
 
-        $image->method('width')->willReturn(800);
-        $image->method('height')->willReturn(400);
-        $image->method('cover')->willReturn($image);
-        $image->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image): ImageInterface {
-                file_put_contents($path, 'processed-image');
+        $paths['original'] = $scenario['originalPath'];
+        $paths['variant']  = $scenario['variantPath'];
 
-                return $image;
-            },
-        );
+        $this->captureSaveCall($scenario['image'], 'processed-image', expectSingleCall: false);
 
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
+        $this->invokeProcessAndRespond($scenario);
 
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
-
-        $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     // =========================================================================
@@ -3655,24 +3451,6 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondDispatchesImageProcessedEventWithFalseFlags(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-evt-fail-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
-
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpeg-data');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.jpg';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher->expects(self::once())
             ->method('dispatch')
@@ -3685,59 +3463,19 @@ final class ProcessorTest extends TestCase
                     && $event->avifGenerated === false;
             }));
 
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
-            eventDispatcher: $eventDispatcher,
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-evt-fail-', 'jpg', 800, 400, 200, 0, '', $eventDispatcher);
+
+        $this->captureSaveCall(
+            $scenario['image'],
+            'processed-image',
+            expectSingleCall: false,
+            webpError: new RuntimeException('WebP failed'),
+            avifError: new RuntimeException('AVIF failed'),
         );
 
-        $image->method('width')->willReturn(800);
-        $image->method('height')->willReturn(400);
-        $image->method('cover')->willReturn($image);
-        $image->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image): ImageInterface {
-                if (str_ends_with($path, '.webp')) {
-                    throw new RuntimeException('WebP failed');
-                }
+        $this->invokeProcessAndRespond($scenario);
 
-                if (str_ends_with($path, '.avif')) {
-                    throw new RuntimeException('AVIF failed');
-                }
-
-                file_put_contents($path, 'processed-image');
-
-                return $image;
-            },
-        );
-
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
-
-        $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     // =========================================================================
@@ -4077,49 +3815,17 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondLogsWarningWhenWebpAndAvifGenerationFail(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-webp-log-' . uniqid('', true);
-        mkdir($tempDir . '/processed', 0o777, true);
-
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpg');
-        $variantPath = $tempDir . '/processed/original.w400h200m0q80.jpg';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
-        );
-
-        $image->method('width')->willReturn(400);
-        $image->method('height')->willReturn(200);
-        $image->method('cover')->willReturn($image);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-webp-log-', 'jpg', 400, 200, 200, 0, '');
 
         $webpException = new RuntimeException('WebP encoding failed');
         $avifException = new RuntimeException('AVIF encoding failed');
-        $image->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image, $webpException, $avifException): ImageInterface {
-                if (str_ends_with($path, '.webp')) {
-                    throw $webpException;
-                }
 
-                if (str_ends_with($path, '.avif')) {
-                    throw $avifException;
-                }
-
-                file_put_contents($path, 'processed');
-
-                return $image;
-            },
+        $this->captureSaveCall(
+            $scenario['image'],
+            'processed',
+            expectSingleCall: false,
+            webpError: $webpException,
+            avifError: $avifException,
         );
 
         $logger    = $this->createMock(LoggerInterface::class);
@@ -4129,51 +3835,25 @@ final class ProcessorTest extends TestCase
                 $loggedMsg[] = ['message' => $msg, 'context' => $ctx];
             });
 
-        $processor->setLogger($logger);
+        $scenario['processor']->setLogger($logger);
 
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
-
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
-
-        $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
+        $this->invokeProcessAndRespond($scenario);
 
         // Verify WebP warning was logged with correct path and exception
         $webpWarnings = array_filter($loggedMsg, static fn (array $entry): bool => $entry['message'] === 'WebP variant generation failed for "{path}"');
         self::assertNotEmpty($webpWarnings, 'Expected WebP warning log');
         $webpWarning = array_values($webpWarnings)[0];
-        self::assertSame($variantPath, $webpWarning['context']['path']);
+        self::assertSame($scenario['variantPath'], $webpWarning['context']['path']);
         self::assertSame($webpException, $webpWarning['context']['exception']);
 
         // Verify AVIF warning was logged with correct path and exception
         $avifWarnings = array_filter($loggedMsg, static fn (array $entry): bool => $entry['message'] === 'AVIF variant generation failed for "{path}"');
         self::assertNotEmpty($avifWarnings, 'Expected AVIF warning log');
         $avifWarning = array_values($avifWarnings)[0];
-        self::assertSame($variantPath, $avifWarning['context']['path']);
+        self::assertSame($scenario['variantPath'], $avifWarning['context']['path']);
         self::assertSame($avifException, $avifWarning['context']['exception']);
 
-        // Cleanup
-        $files = glob($tempDir . '/processed/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     // =========================================================================
@@ -4399,33 +4079,20 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondCreatesVariantDirectoryBeforeSaving(): void
     {
-        $tempDir = sys_get_temp_dir() . '/nr-pio-mkdir-' . uniqid('', true);
-        mkdir($tempDir, 0o777, true);
-
-        $originalPath = $tempDir . '/original.jpg';
-        file_put_contents($originalPath, 'fake-jpg');
-        $variantPath = $tempDir . '/processed/deep/original.w400h200m0q80.jpg';
-
-        $response200 = $this->createMock(ResponseInterface::class);
-        $response200->method('withHeader')->willReturn($response200);
-        $response200->method('withBody')->willReturn($response200);
-
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $responseFactory->method('createResponse')->willReturn($response200);
-
-        $stream        = $this->createMock(StreamInterface::class);
-        $streamFactory = $this->createMock(StreamFactoryInterface::class);
-        $streamFactory->method('createStreamFromFile')->willReturn($stream);
-
-        ['processor' => $processor, 'image' => $image] = $this->createProcessorWithImageReader(
-            responseFactory: $responseFactory,
-            streamFactory: $streamFactory,
+        $scenario = $this->setUpProcessAndRespondScenario(
+            'nr-pio-mkdir-',
+            'jpg',
+            400,
+            200,
+            200,
+            0,
+            'skipWebP=1&skipAvif=1',
+            variantDir: 'processed/deep',
+            createVariantDir: false,
         );
 
-        $image->method('width')->willReturn(400);
-        $image->method('height')->willReturn(200);
-        $image->method('cover')->willReturn($image);
-        $image->method('save')->willReturnCallback(
+        $image = $scenario['image'];
+        $image->expects(self::once())->method('save')->willReturnCallback(
             static function (string $path, mixed ...$options) use ($image): ImageInterface {
                 self::assertDirectoryExists(dirname($path));
                 file_put_contents($path, 'processed');
@@ -4434,37 +4101,11 @@ final class ProcessorTest extends TestCase
             },
         );
 
-        $uri = $this->createMock(UriInterface::class);
-        $uri->method('getQuery')->willReturn('skipWebP=1&skipAvif=1');
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getUri')->willReturn($uri);
+        $this->invokeProcessAndRespond($scenario);
 
-        $urlInfo = [
-            'pathVariant'    => $variantPath,
-            'pathOriginal'   => $originalPath,
-            'extension'      => 'jpg',
-            'targetWidth'    => 400,
-            'targetHeight'   => 200,
-            'targetQuality'  => 80,
-            'processingMode' => 0,
-        ];
+        self::assertDirectoryExists(dirname($scenario['variantPath']));
 
-        $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
-
-        self::assertDirectoryExists(dirname($variantPath));
-
-        $files = glob($tempDir . '/processed/deep/*');
-
-        if ($files !== false) {
-            foreach ($files as $f) {
-                unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-            }
-        }
-
-        unlink($originalPath); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
-        rmdir($tempDir . '/processed/deep');
-        rmdir($tempDir . '/processed');
-        rmdir($tempDir);
+        $this->tearDownProcessAndRespondScenario($scenario['tempDir']);
     }
 
     // =========================================================================

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -221,7 +221,7 @@ final class ProcessorTest extends TestCase
      * drop a positional one (it never matches an encoder constructor parameter
      * name), so the captured options are asserted by key at each call site.
      *
-     * Pass $expectSingleCall = false when the WebP/AVIF variants are generated as
+     * Pass $expectedCallCount = null when the WebP/AVIF variants are generated as
      * well: those go through save() too, so the mock receives three invocations
      * and only the first one carries the base-format path.
      *
@@ -232,8 +232,7 @@ final class ProcessorTest extends TestCase
      *
      * @param MockObject&ImageInterface $image             Image mock receiving the save() expectation
      * @param string|null               $writeContents     Payload to write to the saved path, or null to write nothing
-     * @param bool                      $expectSingleCall  Whether save() must be invoked exactly once
-     * @param int|null                  $expectedCallCount Exact number of expected invocations, overrides $expectSingleCall
+     * @param int|null                  $expectedCallCount Exact number of expected invocations, null for "at least once"
      * @param list<string>|null         $allowedPaths      When given, every saved path must be one of these
      * @param Throwable|null            $webpError         Thrown instead of writing when the path ends in ".webp"
      * @param Throwable|null            $avifError         Thrown instead of writing when the path ends in ".avif"
@@ -243,8 +242,7 @@ final class ProcessorTest extends TestCase
     private function captureSaveCall(
         MockObject $image,
         ?string $writeContents = null,
-        bool $expectSingleCall = true,
-        ?int $expectedCallCount = null,
+        ?int $expectedCallCount = 1,
         ?array $allowedPaths = null,
         ?Throwable $webpError = null,
         ?Throwable $avifError = null,
@@ -255,11 +253,7 @@ final class ProcessorTest extends TestCase
             'options' => [],
         ]);
 
-        if ($expectedCallCount !== null) {
-            $invocationRule = self::exactly($expectedCallCount);
-        } else {
-            $invocationRule = $expectSingleCall ? self::once() : self::atLeastOnce();
-        }
+        $invocationRule = $expectedCallCount !== null ? self::exactly($expectedCallCount) : self::atLeastOnce();
 
         $image->expects($invocationRule)->method('save')->willReturnCallback(
             static function (?string $path = null, mixed ...$options) use ($capture, $image, $writeContents, $allowedPaths, $webpError, $avifError): ImageInterface {
@@ -272,13 +266,7 @@ final class ProcessorTest extends TestCase
                     self::assertContains($path, $allowedPaths);
                 }
 
-                if (($path !== null) && ($webpError instanceof Throwable) && str_ends_with($path, '.webp')) {
-                    throw $webpError;
-                }
-
-                if (($path !== null) && ($avifError instanceof Throwable) && str_ends_with($path, '.avif')) {
-                    throw $avifError;
-                }
+                self::throwConfiguredVariantError($path, $webpError, $avifError);
 
                 if (($writeContents !== null) && ($path !== null)) {
                     file_put_contents($path, $writeContents);
@@ -289,6 +277,28 @@ final class ProcessorTest extends TestCase
         );
 
         return $capture;
+    }
+
+    /**
+     * Throw the error configured for the variant format the saved path targets.
+     *
+     * @param string|null    $path      Path handed to save(), null when save() was called without one
+     * @param Throwable|null $webpError Thrown when the path ends in ".webp"
+     * @param Throwable|null $avifError Thrown when the path ends in ".avif"
+     */
+    private static function throwConfiguredVariantError(?string $path, ?Throwable $webpError, ?Throwable $avifError): void
+    {
+        if ($path === null) {
+            return;
+        }
+
+        if (($webpError instanceof Throwable) && str_ends_with($path, '.webp')) {
+            throw $webpError;
+        }
+
+        if (($avifError instanceof Throwable) && str_ends_with($path, '.avif')) {
+            throw $avifError;
+        }
     }
 
     #[Test]
@@ -2885,16 +2895,16 @@ final class ProcessorTest extends TestCase
      * Only the parts that actually differ between the tests are parameters; the
      * save() wiring stays with the caller and goes through captureSaveCall().
      *
-     * @param string      $prefix           Temp directory name prefix
-     * @param string      $extension        File extension of original and variant
-     * @param int         $sourceWidth      Width reported by the image mock
-     * @param int         $sourceHeight     Height reported by the image mock
-     * @param int|null    $targetHeight     Requested target height, null for scale mode
-     * @param int         $processingMode   Requested processing mode
-     * @param string      $query            Request query string
-     * @param object|null $eventDispatcher  Event dispatcher stub/mock
-     * @param string      $variantDir       Directory below the temp dir holding the variant
-     * @param bool        $createVariantDir Whether the variant directory is created upfront
+     * The processing mode follows from $targetHeight: an explicit height means
+     * cover mode (0), a null height means scale mode (1).
+     *
+     * @param string                                                                             $prefix       Temp directory name prefix
+     * @param string                                                                             $extension    File extension of original and variant
+     * @param int                                                                                $sourceWidth  Width reported by the image mock
+     * @param int                                                                                $sourceHeight Height reported by the image mock
+     * @param int|null                                                                           $targetHeight Requested target height, null for scale mode
+     * @param string                                                                             $query        Request query string
+     * @param array{eventDispatcher?: object|null, variantDir?: string, createVariantDir?: bool} $options      Optional wiring: dispatcher stub/mock, variant sub-directory, whether it is created upfront
      *
      * @return array{
      *     processor: Processor,
@@ -2913,14 +2923,16 @@ final class ProcessorTest extends TestCase
         int $sourceWidth,
         int $sourceHeight,
         ?int $targetHeight,
-        int $processingMode,
         string $query,
-        ?object $eventDispatcher = null,
-        string $variantDir = 'processed',
-        bool $createVariantDir = true,
+        array $options = [],
     ): array {
-        $targetWidth   = 400;
-        $targetQuality = 80;
+        $eventDispatcher  = $options['eventDispatcher'] ?? null;
+        $variantDir       = $options['variantDir'] ?? 'processed';
+        $createVariantDir = $options['createVariantDir'] ?? true;
+
+        $processingMode = $targetHeight === null ? 1 : 0;
+        $targetWidth    = 400;
+        $targetQuality  = 80;
 
         $tempDir = sys_get_temp_dir() . '/' . $prefix . uniqid('', true);
         mkdir($createVariantDir ? $tempDir . '/' . $variantDir : $tempDir, 0o777, true);
@@ -3022,9 +3034,9 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondProcessesImageAndBuildsResponse(): void
     {
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-process-', 'jpg', 800, 400, 200, 0, '');
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-process-', 'jpg', 800, 400, 200, '');
 
-        $capture = $this->captureSaveCall($scenario['image'], 'processed-image', expectSingleCall: false);
+        $capture = $this->captureSaveCall($scenario['image'], 'processed-image', expectedCallCount: null);
 
         self::assertSame($scenario['response'], $this->invokeProcessAndRespond($scenario));
 
@@ -3038,7 +3050,7 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondSkipsWebpWhenExtensionIsWebp(): void
     {
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-webp-skip-proc-', 'webp', 400, 200, 200, 0, '');
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-webp-skip-proc-', 'webp', 400, 200, 200, '');
 
         // WebP source: save primary (.webp) + AVIF variant, but NOT an extra .webp
         $this->captureSaveCall(
@@ -3056,7 +3068,7 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondSkipsAvifWhenExtensionIsAvif(): void
     {
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-avif-skip-proc-', 'avif', 400, 200, 200, 0, '');
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-avif-skip-proc-', 'avif', 400, 200, 200, '');
 
         // AVIF source: save primary (.avif) + WebP variant, but NOT an extra .avif
         $this->captureSaveCall(
@@ -3074,7 +3086,7 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondSkipsBothVariantsViaQueryParams(): void
     {
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-skip-both-', 'jpg', 400, 200, 200, 0, 'skipWebP=1&skipAvif=1');
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-skip-both-', 'jpg', 400, 200, 200, 'skipWebP=1&skipAvif=1');
 
         // Both variants skipped: save() called exactly once for the primary file only,
         // with the quality passed as a named option (positional is dropped by Intervention v3/v4).
@@ -3091,12 +3103,12 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondHandlesWebpAndAvifGenerationFailure(): void
     {
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-gen-fail-', 'jpg', 400, 200, 200, 0, '');
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-gen-fail-', 'jpg', 400, 200, 200, '');
 
         $this->captureSaveCall(
             $scenario['image'],
             'processed',
-            expectSingleCall: false,
+            expectedCallCount: null,
             webpError: new RuntimeException('WebP encoding failed'),
             avifError: new RuntimeException('AVIF encoding failed'),
         );
@@ -3109,7 +3121,7 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondUsesScaleModeWithDerivedHeight(): void
     {
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-scale-', 'jpg', 800, 400, null, 1, 'skipWebP=1&skipAvif=1');
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-scale-', 'jpg', 800, 400, null, 'skipWebP=1&skipAvif=1');
 
         $this->captureSaveCall($scenario['image'], 'processed');
 
@@ -3432,12 +3444,12 @@ final class ProcessorTest extends TestCase
                     && $event->avifGenerated;
             }));
 
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-evt-proc-', 'jpg', 800, 400, 200, 0, '', $eventDispatcher);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-evt-proc-', 'jpg', 800, 400, 200, '', ['eventDispatcher' => $eventDispatcher]);
 
         $paths['original'] = $scenario['originalPath'];
         $paths['variant']  = $scenario['variantPath'];
 
-        $this->captureSaveCall($scenario['image'], 'processed-image', expectSingleCall: false);
+        $this->captureSaveCall($scenario['image'], 'processed-image', expectedCallCount: null);
 
         $this->invokeProcessAndRespond($scenario);
 
@@ -3463,12 +3475,12 @@ final class ProcessorTest extends TestCase
                     && $event->avifGenerated === false;
             }));
 
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-evt-fail-', 'jpg', 800, 400, 200, 0, '', $eventDispatcher);
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-evt-fail-', 'jpg', 800, 400, 200, '', ['eventDispatcher' => $eventDispatcher]);
 
         $this->captureSaveCall(
             $scenario['image'],
             'processed-image',
-            expectSingleCall: false,
+            expectedCallCount: null,
             webpError: new RuntimeException('WebP failed'),
             avifError: new RuntimeException('AVIF failed'),
         );
@@ -3815,7 +3827,7 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function processAndRespondLogsWarningWhenWebpAndAvifGenerationFail(): void
     {
-        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-webp-log-', 'jpg', 400, 200, 200, 0, '');
+        $scenario = $this->setUpProcessAndRespondScenario('nr-pio-webp-log-', 'jpg', 400, 200, 200, '');
 
         $webpException = new RuntimeException('WebP encoding failed');
         $avifException = new RuntimeException('AVIF encoding failed');
@@ -3823,7 +3835,7 @@ final class ProcessorTest extends TestCase
         $this->captureSaveCall(
             $scenario['image'],
             'processed',
-            expectSingleCall: false,
+            expectedCallCount: null,
             webpError: $webpException,
             avifError: $avifException,
         );
@@ -4085,10 +4097,8 @@ final class ProcessorTest extends TestCase
             400,
             200,
             200,
-            0,
             'skipWebP=1&skipAvif=1',
-            variantDir: 'processed/deep',
-            createVariantDir: false,
+            ['variantDir' => 'processed/deep', 'createVariantDir' => false],
         );
 
         $image = $scenario['image'];

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -214,33 +214,45 @@ final class ProcessorTest extends TestCase
     }
 
     /**
-     * Registers a single save() expectation on the image mock and records the
-     * arguments it receives.
+     * Registers a save() expectation on the image mock and records the arguments
+     * of the first invocation, which is always the base-format variant.
      *
      * The quality must reach the encoder as a NAMED argument -- Intervention v3/v4
      * drop a positional one (it never matches an encoder constructor parameter
      * name), so the captured options are asserted by key at each call site.
      *
-     * @param MockObject&ImageInterface $image     Image mock receiving the save() expectation
-     * @param bool                      $writeFile Whether the callback should also write the target file
+     * Pass $expectSingleCall = false when the WebP/AVIF variants are generated as
+     * well: those go through save() too, so the mock receives three invocations
+     * and only the first one carries the base-format path.
+     *
+     * @param MockObject&ImageInterface $image            Image mock receiving the save() expectation
+     * @param string|null               $writeContents    Payload to write to the saved path, or null to write nothing
+     * @param bool                      $expectSingleCall Whether save() must be invoked exactly once
      *
      * @return ArrayObject<string, mixed> Holder with the captured 'path' and 'options'
      */
-    private function captureSaveCall(MockObject $image, bool $writeFile = false): ArrayObject
-    {
+    private function captureSaveCall(
+        MockObject $image,
+        ?string $writeContents = null,
+        bool $expectSingleCall = true,
+    ): ArrayObject {
         /** @var ArrayObject<string, mixed> $capture */
         $capture = new ArrayObject([
             'path'    => null,
             'options' => [],
         ]);
 
-        $image->expects(self::once())->method('save')->willReturnCallback(
-            static function (?string $path = null, mixed ...$options) use ($capture, $image, $writeFile): ImageInterface {
-                $capture['path']    = $path;
-                $capture['options'] = $options;
+        $invocationRule = $expectSingleCall ? self::once() : self::atLeastOnce();
 
-                if ($writeFile && ($path !== null)) {
-                    file_put_contents($path, 'processed');
+        $image->expects($invocationRule)->method('save')->willReturnCallback(
+            static function (?string $path = null, mixed ...$options) use ($capture, $image, $writeContents): ImageInterface {
+                if ($capture['path'] === null) {
+                    $capture['path']    = $path;
+                    $capture['options'] = $options;
+                }
+
+                if (($writeContents !== null) && ($path !== null)) {
+                    file_put_contents($path, $writeContents);
                 }
 
                 return $image;
@@ -2864,13 +2876,7 @@ final class ProcessorTest extends TestCase
         $image->method('width')->willReturn(800);
         $image->method('height')->willReturn(400);
         $image->method('cover')->willReturn($image);
-        $image->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image): ImageInterface {
-                file_put_contents($path, 'processed-image');
-
-                return $image;
-            },
-        );
+        $capture = $this->captureSaveCall($image, 'processed-image', expectSingleCall: false);
 
         $uri = $this->createMock(UriInterface::class);
         $uri->method('getQuery')->willReturn('');
@@ -2890,6 +2896,10 @@ final class ProcessorTest extends TestCase
         $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
 
         self::assertSame($response200, $result);
+
+        // The base format is saved with the requested quality as a named option.
+        self::assertSame($variantPath, $capture['path']);
+        self::assertSame(['quality' => 80], $capture['options']);
 
         $files = glob($tempDir . '/processed/*');
 
@@ -3086,7 +3096,7 @@ final class ProcessorTest extends TestCase
 
         // Both variants skipped: save() called exactly once for the primary file only,
         // with the quality passed as a named option (positional is dropped by Intervention v3/v4).
-        $capture = $this->captureSaveCall($image, true);
+        $capture = $this->captureSaveCall($image, 'processed');
 
         $uri = $this->createMock(UriInterface::class);
         $uri->method('getQuery')->willReturn('skipWebP=1&skipAvif=1');

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -506,9 +506,24 @@ final class ProcessorTest extends TestCase
 
         $variantBase = sys_get_temp_dir() . '/nr-image-optimize-' . uniqid('variant', true);
 
-        $image->expects(self::once())->method('save')->with($variantBase . '.webp', 90)->willReturnSelf();
+        // The quality must reach the encoder as a NAMED argument -- Intervention v3/v4 drop a
+        // positional one (it never matches a constructor parameter name), so capture the call
+        // and assert the option key explicitly.
+        $capturedPath    = null;
+        $capturedOptions = [];
+        $image->expects(self::once())->method('save')->willReturnCallback(
+            static function (?string $path = null, mixed ...$options) use (&$capturedPath, &$capturedOptions, $image): ImageInterface {
+                $capturedPath    = $path;
+                $capturedOptions = $options;
+
+                return $image;
+            },
+        );
 
         $this->callMethod($this->processor, 'generateWebpVariant', $image, 90, $variantBase);
+
+        self::assertSame($variantBase . '.webp', $capturedPath);
+        self::assertSame(['quality' => 90], $capturedOptions);
     }
 
     #[Test]
@@ -518,9 +533,22 @@ final class ProcessorTest extends TestCase
 
         $variantBase = sys_get_temp_dir() . '/nr-image-optimize-' . uniqid('variant', true);
 
-        $image->expects(self::once())->method('save')->with($variantBase . '.avif', 75)->willReturnSelf();
+        // See generateWebpVariantEncodesAndSavesImage: the quality must be passed by name.
+        $capturedPath    = null;
+        $capturedOptions = [];
+        $image->expects(self::once())->method('save')->willReturnCallback(
+            static function (?string $path = null, mixed ...$options) use (&$capturedPath, &$capturedOptions, $image): ImageInterface {
+                $capturedPath    = $path;
+                $capturedOptions = $options;
+
+                return $image;
+            },
+        );
 
         $this->callMethod($this->processor, 'generateAvifVariant', $image, 75, $variantBase);
+
+        self::assertSame($variantBase . '.avif', $capturedPath);
+        self::assertSame(['quality' => 75], $capturedOptions);
     }
 
     #[Test]
@@ -3040,9 +3068,14 @@ final class ProcessorTest extends TestCase
         $image->method('height')->willReturn(200);
         $image->method('cover')->willReturn($image);
 
-        // Both variants skipped: save() called exactly once for the primary file only
-        $image->expects(self::once())->method('save')->with($variantPath, 80)->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image): ImageInterface {
+        // Both variants skipped: save() called exactly once for the primary file only,
+        // with the quality passed as a named option (positional is dropped by Intervention v3/v4).
+        $capturedPath    = null;
+        $capturedOptions = [];
+        $image->expects(self::once())->method('save')->willReturnCallback(
+            static function (string $path, mixed ...$options) use ($image, &$capturedPath, &$capturedOptions): ImageInterface {
+                $capturedPath    = $path;
+                $capturedOptions = $options;
                 file_put_contents($path, 'processed');
 
                 return $image;
@@ -3066,6 +3099,9 @@ final class ProcessorTest extends TestCase
 
         $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
         self::assertSame($response200, $result);
+
+        self::assertSame($variantPath, $capturedPath);
+        self::assertSame(['quality' => 80], $capturedOptions);
 
         $files = glob($tempDir . '/processed/*');
 

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrImageOptimize\Tests\Unit;
 
+use ArrayObject;
 use Intervention\Image\Interfaces\ImageInterface;
 use Netresearch\NrImageOptimize\Event\ImageProcessedEvent;
 use Netresearch\NrImageOptimize\Event\VariantServedEvent;
@@ -212,6 +213,43 @@ final class ProcessorTest extends TestCase
         return $reflection->invoke($object, ...$arguments);
     }
 
+    /**
+     * Registers a single save() expectation on the image mock and records the
+     * arguments it receives.
+     *
+     * The quality must reach the encoder as a NAMED argument -- Intervention v3/v4
+     * drop a positional one (it never matches an encoder constructor parameter
+     * name), so the captured options are asserted by key at each call site.
+     *
+     * @param MockObject&ImageInterface $image     Image mock receiving the save() expectation
+     * @param bool                      $writeFile Whether the callback should also write the target file
+     *
+     * @return ArrayObject<string, mixed> Holder with the captured 'path' and 'options'
+     */
+    private function captureSaveCall(MockObject $image, bool $writeFile = false): ArrayObject
+    {
+        /** @var ArrayObject<string, mixed> $capture */
+        $capture = new ArrayObject([
+            'path'    => null,
+            'options' => [],
+        ]);
+
+        $image->expects(self::once())->method('save')->willReturnCallback(
+            static function (?string $path = null, mixed ...$options) use ($capture, $image, $writeFile): ImageInterface {
+                $capture['path']    = $path;
+                $capture['options'] = $options;
+
+                if ($writeFile && ($path !== null)) {
+                    file_put_contents($path, 'processed');
+                }
+
+                return $image;
+            },
+        );
+
+        return $capture;
+    }
+
     #[Test]
     public function gatherInformationBasedOnUrlParsesVariantConfiguration(): void
     {
@@ -250,7 +288,7 @@ final class ProcessorTest extends TestCase
 
         self::assertSame(800, $result['targetWidth']);
         self::assertNull($result['targetHeight']);
-        self::assertSame(100, $result['targetQuality']);
+        self::assertSame(75, $result['targetQuality']);
         self::assertSame(0, $result['processingMode']);
     }
 
@@ -506,24 +544,12 @@ final class ProcessorTest extends TestCase
 
         $variantBase = sys_get_temp_dir() . '/nr-image-optimize-' . uniqid('variant', true);
 
-        // The quality must reach the encoder as a NAMED argument -- Intervention v3/v4 drop a
-        // positional one (it never matches a constructor parameter name), so capture the call
-        // and assert the option key explicitly.
-        $capturedPath    = null;
-        $capturedOptions = [];
-        $image->expects(self::once())->method('save')->willReturnCallback(
-            static function (?string $path = null, mixed ...$options) use (&$capturedPath, &$capturedOptions, $image): ImageInterface {
-                $capturedPath    = $path;
-                $capturedOptions = $options;
-
-                return $image;
-            },
-        );
+        $capture = $this->captureSaveCall($image);
 
         $this->callMethod($this->processor, 'generateWebpVariant', $image, 90, $variantBase);
 
-        self::assertSame($variantBase . '.webp', $capturedPath);
-        self::assertSame(['quality' => 90], $capturedOptions);
+        self::assertSame($variantBase . '.webp', $capture['path']);
+        self::assertSame(['quality' => 90], $capture['options']);
     }
 
     #[Test]
@@ -533,22 +559,12 @@ final class ProcessorTest extends TestCase
 
         $variantBase = sys_get_temp_dir() . '/nr-image-optimize-' . uniqid('variant', true);
 
-        // See generateWebpVariantEncodesAndSavesImage: the quality must be passed by name.
-        $capturedPath    = null;
-        $capturedOptions = [];
-        $image->expects(self::once())->method('save')->willReturnCallback(
-            static function (?string $path = null, mixed ...$options) use (&$capturedPath, &$capturedOptions, $image): ImageInterface {
-                $capturedPath    = $path;
-                $capturedOptions = $options;
-
-                return $image;
-            },
-        );
+        $capture = $this->captureSaveCall($image);
 
         $this->callMethod($this->processor, 'generateAvifVariant', $image, 75, $variantBase);
 
-        self::assertSame($variantBase . '.avif', $capturedPath);
-        self::assertSame(['quality' => 75], $capturedOptions);
+        self::assertSame($variantBase . '.avif', $capture['path']);
+        self::assertSame(['quality' => 75], $capture['options']);
     }
 
     #[Test]
@@ -3070,17 +3086,7 @@ final class ProcessorTest extends TestCase
 
         // Both variants skipped: save() called exactly once for the primary file only,
         // with the quality passed as a named option (positional is dropped by Intervention v3/v4).
-        $capturedPath    = null;
-        $capturedOptions = [];
-        $image->expects(self::once())->method('save')->willReturnCallback(
-            static function (string $path, mixed ...$options) use ($image, &$capturedPath, &$capturedOptions): ImageInterface {
-                $capturedPath    = $path;
-                $capturedOptions = $options;
-                file_put_contents($path, 'processed');
-
-                return $image;
-            },
-        );
+        $capture = $this->captureSaveCall($image, true);
 
         $uri = $this->createMock(UriInterface::class);
         $uri->method('getQuery')->willReturn('skipWebP=1&skipAvif=1');
@@ -3100,8 +3106,8 @@ final class ProcessorTest extends TestCase
         $result = $this->callMethod($processor, 'processAndRespond', $request, $urlInfo);
         self::assertSame($response200, $result);
 
-        self::assertSame($variantPath, $capturedPath);
-        self::assertSame(['quality' => 80], $capturedOptions);
+        self::assertSame($variantPath, $capture['path']);
+        self::assertSame(['quality' => 80], $capture['options']);
 
         $files = glob($tempDir . '/processed/*');
 

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -272,11 +272,11 @@ final class ProcessorTest extends TestCase
                     self::assertContains($path, $allowedPaths);
                 }
 
-                if (($path !== null) && ($webpError !== null) && str_ends_with($path, '.webp')) {
+                if (($path !== null) && ($webpError instanceof Throwable) && str_ends_with($path, '.webp')) {
                     throw $webpError;
                 }
 
-                if (($path !== null) && ($avifError !== null) && str_ends_with($path, '.avif')) {
+                if (($path !== null) && ($avifError instanceof Throwable) && str_ends_with($path, '.avif')) {
                     throw $avifError;
                 }
 

--- a/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
@@ -100,7 +100,7 @@ final class SourceSetViewHelperTest extends TestCase
         $result = $this->viewHelper->render();
 
         // Test legacy 2x density output
-        self::assertStringContainsString('srcset="/processed/path/to/image.w200h200m0q100.jpg 2x"', $result);
+        self::assertStringContainsString('srcset="/processed/path/to/image.w200h200m0q75.jpg 2x"', $result);
         self::assertStringContainsString('width="100"', $result);
         self::assertStringContainsString('height="100"', $result);
         self::assertStringContainsString('alt="Test Image"', $result);
@@ -128,7 +128,7 @@ final class SourceSetViewHelperTest extends TestCase
 
         $srcMatchResult = preg_match('/src="([^"]+)"/', $result, $srcMatches);
         self::assertSame(1, $srcMatchResult);
-        self::assertSame('/processed/path/to/image.w1250h1250m0q100.jpg', $srcMatches[1]);
+        self::assertSame('/processed/path/to/image.w1250h1250m0q75.jpg', $srcMatches[1]);
 
         $srcsetMatchResult = preg_match('/srcset="([^"]+)"/', $result, $matches);
         self::assertSame(1, $srcsetMatchResult);
@@ -457,8 +457,8 @@ final class SourceSetViewHelperTest extends TestCase
         $result = $this->viewHelper->generateSrcSet();
 
         $expected = '<source media="(max-width: 480px)" '
-            . 'srcset="/processed/images/picture.w200h120m0q100.jpg, '
-            . '/processed/images/picture.w400h240m0q100.jpg 2x" />' . PHP_EOL;
+            . 'srcset="/processed/images/picture.w200h120m0q75.jpg, '
+            . '/processed/images/picture.w400h240m0q75.jpg 2x" />' . PHP_EOL;
 
         self::assertSame($expected, $result);
     }
@@ -1225,7 +1225,7 @@ final class SourceSetViewHelperTest extends TestCase
         $result = $this->viewHelper->render();
 
         // The srcset entry must be "URL 320w" with exactly one space before the width descriptor
-        self::assertStringContainsString('/processed/path/to/image.w320h160m0q100.jpg 320w', $result);
+        self::assertStringContainsString('/processed/path/to/image.w320h160m0q75.jpg 320w', $result);
     }
 
     // =========================================================================
@@ -1713,7 +1713,7 @@ final class SourceSetViewHelperTest extends TestCase
 
         $result = $this->viewHelper->generateSrcSet();
 
-        $expectedSrcset = '/processed/images/pic.w300h200m0q100.jpg, /processed/images/pic.w600h400m0q100.jpg 2x';
+        $expectedSrcset = '/processed/images/pic.w300h200m0q75.jpg, /processed/images/pic.w600h400m0q75.jpg 2x';
         self::assertStringContainsString('srcset="' . $expectedSrcset . '"', $result);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -130,6 +130,7 @@
             "@ci:test:php:rector",
             "@ci:test:php:fractor",
             "@ci:test:php:unit",
+            "@ci:test:php:acceptance",
             "@ci:test:php:cgl"
         ]
     }


### PR DESCRIPTION
## What

The requested image quality had no effect: every processed variant (original format, WebP, AVIF) was encoded at Intervention Image's built-in default of 75, regardless of the `q` value in the `/processed/…` URL.

## Why

`Processor` passed the quality **positionally** to `save()`:

```php
$image->save($urlInfo['pathVariant'], $targetQuality);
```

Intervention v3/v4 declare `save(?string $path = null, mixed ...$options)`. A positional value ends up in `$options` under the integer key `0`; `Format::encoder()` then filters options with `ARRAY_FILTER_USE_KEY`, keeping only keys matching the encoder constructor's parameter names (`quality`, …). Key `0` matches nothing, so it is dropped and the encoder falls back to `AbstractEncoder::DEFAULT_QUALITY = 75`. The positional call was correct under Intervention v2 — this is a silent v2→v3 migration regression.

## Change

- Pass the quality as a **named argument** (`quality: $targetQuality`) at the three `save()` call sites in `Processor`.
- Lower `SourceSetViewHelper::DEFAULT_QUALITY` from 100 to **75**, so output stays byte-stable for URLs the ViewHelper generates.
- Add `Processor::DEFAULT_QUALITY = 75` for the fallback used when a `/processed/` URL carries no `q` segment. That fallback previously used `MAX_QUALITY` (100); before the fix the value was discarded and everything encoded at 75, so applying the quality would otherwise have inflated those URLs to a real 100. `MAX_QUALITY` remains the clamp ceiling.

## Tests

- The `save()` call is asserted by option **key** (`['quality' => N]`), not positionally, so a revert to the positional form fails the suite rather than silently regressing.
- Acceptance expectations corrected from `q100` to `q75`. That suite was never executed by CI, which is why the stale expectations went unnoticed; it now runs through the shared workflow via the new `run-acceptance-tests` input (netresearch/typo3-ci-workflows#136) and is part of the `ci:test` aggregate.
- The `processAndRespond*` tests shared large identical arrangement blocks, which put the SonarCloud new-code duplication gate at 58.8% against a 3% threshold. That arrangement now lives in shared helpers; the gate is at 0.0%.

## Documentation

- The stated default changes from 100 to 75, and the rendered-output examples no longer show `q100`.
- The basic usage example passed a `quality="85"` argument to the ViewHelper. No such argument is registered, so Fluid would raise an exception on that snippet — it has been removed and replaced with a note that quality is not configurable per call.

## Verification

- Before: `…q10.jpg` and `…q100.jpg` (same dimensions) are byte-identical.
- After: quality varies as expected, e.g. one 1800px sample — JPEG q40 89 KB / q75 157 KB / q95 212 KB.

Closes #114.

## Out of scope

With quality applied, Imagick's AVIF encoder yields larger files than WebP at the same quality number (steeper AV1 scale). That is tracked as a separate observation in #114 and intentionally left out of this correctness fix.
