### PR TITLE
fix(processor): resolve public/_assets/<hash> symlinks in allowed roots

### DIFF
--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -810,7 +810,10 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
      * Always includes the TYPO3 public path. Additionally includes the
      * resolved base path of every Local-driver FAL storage so that storages
      * whose directory is a symlink to an external mount (e.g. fileadmin on
-     * AWS EFS or another NFS share) remain servable.
+     * AWS EFS or another NFS share) remain servable, and the resolved
+     * target of every extension asset published under public/_assets/
+     * (see the dedicated block below) so that images shipped inside an
+     * extension's Resources/Public/ directory remain servable too.
      *
      * Storages are silently skipped when their driver type is not "Local",
      * when basePath is missing or empty, or when the configured directory
@@ -917,26 +920,54 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
         // namespaces relevant to image serving are covered.
         if ($publicPath !== false) {
             foreach (['processed', 'uploads'] as $knownChild) {
-                $childPath = $publicPathRaw . DIRECTORY_SEPARATOR . $knownChild;
+                $resolvedChild = $this->resolveSymlinkedDirectory(
+                    $publicPathRaw . DIRECTORY_SEPARATOR . $knownChild,
+                );
 
-                if (!is_link($childPath)) {
-                    continue;
+                if ($resolvedChild !== null) {
+                    $roots[$resolvedChild] = true;
                 }
+            }
 
-                $resolvedChild = realpath($childPath);
+            // TYPO3 core publishes each extension's Resources/Public/
+            // directory by symlinking public/_assets/<hash>/ to it --
+            // typically vendor/<package>/Resources/Public/ for
+            // composer-managed extensions, or
+            // typo3conf/ext/<key>/Resources/Public/ in classic mode. Both
+            // targets sit outside the public webroot, so requesting a
+            // variant of an image shipped this way (e.g. an extension's
+            // default/fallback image) would otherwise be rejected as
+            // "outside allowed roots" even though the file is a legitimate
+            // part of the deployed application.
+            //
+            // Unlike processed/uploads, the hash-named children are not a
+            // fixed set -- one is created per published extension -- so
+            // every immediate child of _assets is resolved individually
+            // rather than a hardcoded name. The blast radius is bounded to
+            // that one well-known directory: an admin-created symlink
+            // elsewhere in the public root (e.g. `public/etc -> /etc`)
+            // still does not widen the allow-list.
+            $assetsDir      = $publicPathRaw . DIRECTORY_SEPARATOR . '_assets';
+            $assetsChildren = is_dir($assetsDir) ? scandir($assetsDir) : false;
 
-                if ($resolvedChild === false) {
-                    continue;
+            if ($assetsChildren !== false) {
+                foreach ($assetsChildren as $assetsChild) {
+                    if ($assetsChild === '.') {
+                        continue;
+                    }
+
+                    if ($assetsChild === '..') {
+                        continue;
+                    }
+
+                    $resolvedChild = $this->resolveSymlinkedDirectory(
+                        $assetsDir . DIRECTORY_SEPARATOR . $assetsChild,
+                    );
+
+                    if ($resolvedChild !== null) {
+                        $roots[$resolvedChild] = true;
+                    }
                 }
-
-                // A symlinked *file* (e.g. public/uploads -> /etc/passwd)
-                // must not become an allowed root via the equality branch in
-                // isWithinAnyRoot(). Require the target to be a directory.
-                if (!is_dir($resolvedChild)) {
-                    continue;
-                }
-
-                $roots[$resolvedChild] = true;
             }
         }
 
@@ -957,6 +988,34 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
         // cache on the next invocation, giving findAll() another chance.
         if (!$storageLookupFailed) {
             self::$resolvedAllowedRootsByPublicPath[$publicPathRaw] = $resolved;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Resolve a symlink at `$path` to its real, existing directory target.
+     *
+     * Returns null when `$path` is not a symlink, when the target cannot be
+     * resolved via realpath(), or when the resolved target is not a
+     * directory. The directory requirement matters because a symlinked
+     * *file* (e.g. `public/uploads -> /etc/passwd`) must not become an
+     * allowed root via the equality branch in isWithinAnyRoot().
+     *
+     * @param string $path Absolute filesystem path that may be a symlink
+     *
+     * @return string|null Realpath-resolved directory, or null if not applicable
+     */
+    private function resolveSymlinkedDirectory(string $path): ?string
+    {
+        if (!is_link($path)) {
+            return null;
+        }
+
+        $resolved = realpath($path);
+
+        if ($resolved === false || !is_dir($resolved)) {
+            return null;
         }
 
         return $resolved;

--- a/Tests/Functional/ProcessorSymlinkedFileadminTest.php
+++ b/Tests/Functional/ProcessorSymlinkedFileadminTest.php
@@ -189,6 +189,53 @@ final class ProcessorSymlinkedFileadminTest extends FunctionalTestCase
     }
 
     /**
+     * Regression for #117: TYPO3 core publishes each extension's
+     * Resources/Public/ folder by symlinking public/_assets/<hash>/ to a
+     * location outside the public root (typically vendor/<package>/Resources/Public/
+     * via composer, or typo3conf/ext/<key>/Resources/Public/ for
+     * classic-mode extensions). Requesting a variant of an image shipped
+     * inside such a directory (e.g. an extension's default/fallback image)
+     * must succeed instead of being rejected as "outside allowed roots".
+     */
+    #[Test]
+    public function uncachedVariantUnderAssetsPackageSymlinkReturns200(): void
+    {
+        $publicPath = Environment::getPublicPath();
+
+        $packageResourcesDir = $this->externalMount . '/vendor-package/Resources/Public/Images';
+        self::assertTrue(mkdir($packageResourcesDir, 0o777, true));
+
+        $fixture = $publicPath . '/typo3temp/nr-pio-fixture/test-image.png';
+        self::assertFileExists($fixture, 'Fixture staging failed');
+        self::assertTrue(copy($fixture, $packageResourcesDir . '/default.png'));
+
+        $assetsDir = $publicPath . '/_assets';
+        if (!is_dir($assetsDir)) {
+            self::assertTrue(mkdir($assetsDir, 0o777, true));
+        }
+
+        $assetChild = $assetsDir . '/deadbeefdeadbeefdeadbeefdeadbeef';
+        symlink($this->externalMount . '/vendor-package/Resources/Public', $assetChild);
+
+        $this->resetAllowedRootsCache();
+
+        $processor = $this->get(Processor::class);
+
+        $uri     = new Uri('https://example.com/processed/_assets/deadbeefdeadbeefdeadbeefdeadbeef/Images/default.w50h38m0q80.png');
+        $request = new ServerRequest($uri);
+
+        $response = $processor->generateAndSend($request);
+
+        self::assertNotSame(
+            400,
+            $response->getStatusCode(),
+            'Path validation rejected a request for an image published via public/_assets/<hash> symlink into vendor/. '
+            . 'Check the regression conditions of issue #117.',
+        );
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
      * Security guarantee: the symlinked-fileadmin fix must not be
      * permissive enough to let a traversal sequence escape the allowed
      * roots and hit an arbitrary file on disk.


### PR DESCRIPTION
## Summary
- `getAllowedRoots()` only whitelisted the public webroot, FAL storage base paths, and the hardcoded `processed`/`uploads` symlink children — it didn't know about TYPO3 core's extension-asset publishing, which symlinks `public/_assets/<hash>/` to `vendor/<package>/Resources/Public/` (or `typo3conf/ext/<key>/Resources/Public/` in classic mode), both outside the public webroot.
- Any image shipped inside an extension's `Resources/Public/` directory (e.g. a fallback/default image) therefore got HTTP 400 on every variant request, even though the file is a legitimate part of the deployed application.
- Every immediate child of `_assets` is now resolved individually (unlike `processed`/`uploads`, there's no fixed set of names — one hash-named symlink per published extension) and added as an allowed root when it resolves to an existing directory. Extracted a small `resolveSymlinkedDirectory()` helper shared by both the `processed`/`uploads` block and the new `_assets` loop.

Fixes #117

## Test plan
- [x] Added `uncachedVariantUnderAssetsPackageSymlinkReturns200` to `Tests/Functional/ProcessorSymlinkedFileadminTest.php`, reproducing the `_assets/<hash>` symlink-into-vendor layout; failed with HTTP 400 before the fix, passes after.
- [x] `composer ci:test:php:lint` — clean
- [x] `composer ci:test:php:phpstan` — clean on changed files (pre-existing unrelated errors on `main` in test-mock files, confirmed via `git stash`)
- [x] `composer ci:test:php:cgl` — clean
- [x] `composer ci:test:php:rector` — clean
- [x] `composer ci:test:php:unit` — 558/558 passing
- [x] `composer ci:test:php:functional` — 31/31 passing (was 30/31 before the fix)
- [ ] `composer ci:test:php:fractor` — fails identically on unmodified `main` too (pre-existing local environment issue, unrelated to this change)