### PR TITLE
fix(processor): resolve public/_assets/<hash> symlinks in allowed roots (TYPO3_12)

### DIFF
--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -46,6 +46,7 @@ use function preg_match;
 use function preg_match_all;
 use function realpath;
 use function round;
+use function scandir;
 use function sprintf;
 use function str_contains;
 use function str_starts_with;
@@ -724,7 +725,10 @@ class Processor
      * Always includes the TYPO3 public path. Additionally includes the
      * resolved base path of every Local-driver FAL storage so that storages
      * whose directory is a symlink to an external mount (e.g. fileadmin on
-     * AWS EFS or another NFS share) remain servable.
+     * AWS EFS or another NFS share) remain servable, and the resolved
+     * target of every extension asset published under public/_assets/
+     * (see the dedicated block below) so that images shipped inside an
+     * extension's Resources/Public/ directory remain servable too.
      *
      * Storages are silently skipped when their driver type is not "Local",
      * when basePath is missing or empty, or when the configured directory
@@ -833,26 +837,54 @@ class Processor
         // namespaces relevant to image serving are covered.
         if ($publicPath !== false) {
             foreach (['processed', 'uploads'] as $knownChild) {
-                $childPath = $publicPathRaw . DIRECTORY_SEPARATOR . $knownChild;
+                $resolvedChild = $this->resolveSymlinkedDirectory(
+                    $publicPathRaw . DIRECTORY_SEPARATOR . $knownChild,
+                );
 
-                if (!is_link($childPath)) {
-                    continue;
+                if ($resolvedChild !== null) {
+                    $roots[$resolvedChild] = true;
                 }
+            }
 
-                $resolvedChild = realpath($childPath);
+            // TYPO3 core publishes each extension's Resources/Public/
+            // directory by symlinking public/_assets/<hash>/ to it --
+            // typically vendor/<package>/Resources/Public/ for
+            // composer-managed extensions, or
+            // typo3conf/ext/<key>/Resources/Public/ in classic mode. Both
+            // targets sit outside the public webroot, so requesting a
+            // variant of an image shipped this way (e.g. an extension's
+            // default/fallback image) would otherwise be rejected as
+            // "outside allowed roots" even though the file is a legitimate
+            // part of the deployed application.
+            //
+            // Unlike processed/uploads, the hash-named children are not a
+            // fixed set -- one is created per published extension -- so
+            // every immediate child of _assets is resolved individually
+            // rather than a hardcoded name. The blast radius is bounded to
+            // that one well-known directory: an admin-created symlink
+            // elsewhere in the public root (e.g. `public/etc -> /etc`)
+            // still does not widen the allow-list.
+            $assetsDir      = $publicPathRaw . DIRECTORY_SEPARATOR . '_assets';
+            $assetsChildren = is_dir($assetsDir) ? scandir($assetsDir) : false;
 
-                if ($resolvedChild === false) {
-                    continue;
+            if ($assetsChildren !== false) {
+                foreach ($assetsChildren as $assetsChild) {
+                    if ($assetsChild === '.') {
+                        continue;
+                    }
+
+                    if ($assetsChild === '..') {
+                        continue;
+                    }
+
+                    $resolvedChild = $this->resolveSymlinkedDirectory(
+                        $assetsDir . DIRECTORY_SEPARATOR . $assetsChild,
+                    );
+
+                    if ($resolvedChild !== null) {
+                        $roots[$resolvedChild] = true;
+                    }
                 }
-
-                // A symlinked *file* (e.g. public/uploads -> /etc/passwd)
-                // must not become an allowed root via the equality branch in
-                // isWithinAnyRoot(). Require the target to be a directory.
-                if (!is_dir($resolvedChild)) {
-                    continue;
-                }
-
-                $roots[$resolvedChild] = true;
             }
         }
 
@@ -873,6 +905,34 @@ class Processor
         // cache on the next invocation, giving findAll() another chance.
         if (!$storageLookupFailed) {
             self::$resolvedAllowedRootsByPublicPath[$publicPathRaw] = $resolved;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Resolve a symlink at `$path` to its real, existing directory target.
+     *
+     * Returns null when `$path` is not a symlink, when the target cannot be
+     * resolved via realpath(), or when the resolved target is not a
+     * directory. The directory requirement matters because a symlinked
+     * *file* (e.g. `public/uploads -> /etc/passwd`) must not become an
+     * allowed root via the equality branch in isWithinAnyRoot().
+     *
+     * @param string $path Absolute filesystem path that may be a symlink
+     *
+     * @return string|null Realpath-resolved directory, or null if not applicable
+     */
+    private function resolveSymlinkedDirectory(string $path): ?string
+    {
+        if (!is_link($path)) {
+            return null;
+        }
+
+        $resolved = realpath($path);
+
+        if ($resolved === false || !is_dir($resolved)) {
+            return null;
         }
 
         return $resolved;

--- a/Tests/Functional/ProcessorSymlinkedFileadminTest.php
+++ b/Tests/Functional/ProcessorSymlinkedFileadminTest.php
@@ -194,6 +194,53 @@ final class ProcessorSymlinkedFileadminTest extends FunctionalTestCase
     }
 
     /**
+     * Regression for #117: TYPO3 core publishes each extension's
+     * Resources/Public/ folder by symlinking public/_assets/<hash>/ to a
+     * location outside the public root (typically vendor/<package>/Resources/Public/
+     * via composer, or typo3conf/ext/<key>/Resources/Public/ for
+     * classic-mode extensions). Requesting a variant of an image shipped
+     * inside such a directory (e.g. an extension's default/fallback image)
+     * must succeed instead of being rejected as "outside allowed roots".
+     */
+    #[Test]
+    public function uncachedVariantUnderAssetsPackageSymlinkReturns200(): void
+    {
+        $publicPath = Environment::getPublicPath();
+
+        $packageResourcesDir = $this->externalMount . '/vendor-package/Resources/Public/Images';
+        self::assertTrue(mkdir($packageResourcesDir, 0o777, true));
+
+        $fixture = $publicPath . '/typo3temp/nr-pio-fixture/test-image.png';
+        self::assertFileExists($fixture, 'Fixture staging failed');
+        self::assertTrue(copy($fixture, $packageResourcesDir . '/default.png'));
+
+        $assetsDir = $publicPath . '/_assets';
+        if (!is_dir($assetsDir)) {
+            self::assertTrue(mkdir($assetsDir, 0o777, true));
+        }
+
+        $assetChild = $assetsDir . '/deadbeefdeadbeefdeadbeefdeadbeef';
+        symlink($this->externalMount . '/vendor-package/Resources/Public', $assetChild);
+
+        $this->resetAllowedRootsCache();
+
+        $processor = $this->get(Processor::class);
+
+        $uri     = new Uri('https://example.com/processed/_assets/deadbeefdeadbeefdeadbeefdeadbeef/Images/default.w50h38m0q80.png');
+        $request = new ServerRequest($uri);
+
+        $response = $processor->generateAndSend($request);
+
+        self::assertNotSame(
+            400,
+            $response->getStatusCode(),
+            'Path validation rejected a request for an image published via public/_assets/<hash> symlink into vendor/. '
+            . 'Check the regression conditions of issue #117.',
+        );
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
      * Security guarantee: the symlinked-fileadmin fix must not be
      * permissive enough to let a traversal sequence escape the allowed
      * roots and hit an arbitrary file on disk.


### PR DESCRIPTION
## Summary
Port of #118 to the TYPO3_12 maintenance branch (v1.x releases): `getAllowedRoots()` now resolves every immediate symlinked child of `public/_assets/` (TYPO3 core's extension-asset publishing target) and adds it as an allowed root, so variant requests for images shipped inside an extension's `Resources/Public/` directory no longer get rejected with HTTP 400.

Fixes #117

## Test plan
- [x] Added `uncachedVariantUnderAssetsPackageSymlinkReturns200` to `Tests/Functional/ProcessorSymlinkedFileadminTest.php`
- [x] `composer ci:test:php:lint` — clean
- [x] `composer ci:test:php:phpstan` — clean
- [x] `composer ci:test:php:cgl` — clean
- [x] `composer ci:test:php:rector` — clean
- [x] `composer ci:test:php:unit` — 267/267 passing
- [x] `composer ci:test:php:functional` — 31/31 passing