### PR TITLE
fix: v14 theme-aware backend icons and dark-mode module templates

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -10,10 +10,19 @@
 declare(strict_types=1);
 
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/*
+ * TYPO3 v14 ships a redesigned backend with light/dark mode: use the flat
+ * icon (currentColor + teal accent) that adapts to the active color scheme.
+ * v13 uses the colored (teal tile) legacy variant that matches the classic
+ * module menu.
+ */
+$suffix = (new Typo3Version())->getMajorVersion() >= 14 ? '.svg' : '.legacy.svg';
 
 return [
     'module-image-optimize' => [
         'provider' => SvgIconProvider::class,
-        'source'   => 'EXT:nr_image_optimize/Resources/Public/Icons/module-image-optimize.svg',
+        'source'   => 'EXT:nr_image_optimize/Resources/Public/Icons/module-image-optimize' . $suffix,
     ],
 ];

--- a/Resources/Private/Templates/Maintenance/Index.html
+++ b/Resources/Private/Templates/Maintenance/Index.html
@@ -83,7 +83,7 @@
         <div class="col-lg-6">
             <!-- Storage Path -->
             <div class="card mb-4">
-                <div class="card-header bg-light">
+                <div class="card-header bg-body-tertiary">
                     <h2 class="card-title mb-0 h5">
                         <strong><f:translate key="stats.storageInfo" extensionName="NrImageOptimize" /></strong>
                     </h2>
@@ -122,7 +122,7 @@
 
             <!-- File Types -->
             <div class="card">
-                <div class="card-header bg-light">
+                <div class="card-header bg-body-tertiary">
                     <h2 class="card-title mb-0 h5">
                         <strong><f:translate key="stats.typesDistribution" extensionName="NrImageOptimize" /></strong>
                     </h2>
@@ -130,7 +130,7 @@
                 <div class="card-body p-0">
                     <div class="table-responsive">
                         <table class="table table-hover table-sm mb-0">
-                            <thead class="table-light">
+                            <thead>
                                 <tr>
                                     <th class="ps-3"><f:translate key="stats.extension" extensionName="NrImageOptimize" /></th>
                                     <th class="text-end"><f:translate key="stats.count" extensionName="NrImageOptimize" /></th>
@@ -143,7 +143,7 @@
                                         <f:for each="{fileTypes}" key="ext" as="typeData">
                                             <tr>
                                                 <td class="ps-3">
-                                                    <code class="bg-light px-2 py-1 rounded">.{ext}</code>
+                                                    <code class="bg-body-tertiary px-2 py-1 rounded">.{ext}</code>
                                                 </td>
                                                 <td class="text-end">{typeData.count}</td>
                                                 <td class="text-end pe-3"><strong>{typeData.sizeHuman}</strong></td>
@@ -167,7 +167,7 @@
         <div class="col-lg-6">
             <!-- Largest Files -->
             <div class="card mb-4">
-                <div class="card-header bg-light">
+                <div class="card-header bg-body-tertiary">
                     <h2 class="card-title mb-0 h5">
                         <strong><f:translate key="stats.largest" extensionName="NrImageOptimize" /></strong>
                     </h2>
@@ -175,7 +175,7 @@
                 <div class="card-body p-0">
                     <div class="table-responsive">
                         <table class="table table-hover table-sm mb-0">
-                            <thead class="table-light">
+                            <thead>
                                 <tr>
                                     <th class="ps-3"><f:translate key="stats.filePath" extensionName="NrImageOptimize" /></th>
                                     <th class="text-end pe-3"><f:translate key="stats.sizeColumn" extensionName="NrImageOptimize" /></th>

--- a/Resources/Private/Templates/Maintenance/SystemRequirements.html
+++ b/Resources/Private/Templates/Maintenance/SystemRequirements.html
@@ -21,7 +21,7 @@
 
     <f:for each="{requirements}" as="category">
         <div class="card mb-4">
-            <div class="card-header bg-light">
+            <div class="card-header bg-body-tertiary">
                 <h2 class="card-title mb-0 h5">
                     <strong><f:translate key="{category.labelKey}" extensionName="NrImageOptimize" /></strong>
                 </h2>
@@ -29,7 +29,7 @@
             <div class="card-body p-0">
                 <div class="table-responsive">
                     <table class="table table-hover table-sm mb-0">
-                        <thead class="table-light">
+                        <thead>
                             <tr>
                                 <th class="ps-3 sysreq-col-component"><f:translate key="sysreq.component" extensionName="NrImageOptimize" /></th>
                                 <th class="sysreq-col-status"><f:translate key="sysreq.status" extensionName="NrImageOptimize" /></th>
@@ -80,11 +80,11 @@
                                     <td>
                                         <f:if condition="{item.currentKey}">
                                             <f:then>
-                                                <code class="text-dark bg-light px-2 py-1 rounded small"><f:translate key="{item.currentKey}" extensionName="NrImageOptimize" /></code>
+                                                <code class="bg-body-tertiary px-2 py-1 rounded small"><f:translate key="{item.currentKey}" extensionName="NrImageOptimize" /></code>
                                             </f:then>
                                             <f:else>
                                                 <f:if condition="{item.current}">
-                                                    <code class="text-dark bg-light px-2 py-1 rounded small">{item.current}</code>
+                                                    <code class="bg-body-tertiary px-2 py-1 rounded small">{item.current}</code>
                                                 </f:if>
                                             </f:else>
                                         </f:if>

--- a/Resources/Public/Icons/Extension.svg
+++ b/Resources/Public/Icons/Extension.svg
@@ -1,20 +1,7 @@
-<svg id="ff9f1127-f95e-4bc9-93ad-3960cfa941f0" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 300 300">
-    <defs>
-        <style>
-            .f4097b67-2213-40bd-9c3a-94cf64be6239{fill:none;}.ac0374ef-26de-4333-a951-e8ab8d27f8bd{clip-path:url(#b89874de-42cc-4a08-a445-73aac157aa7c);}.bbf856c7-1511-45c6-8eda-8aee74e5919c{fill:#2999a4;}.f2146b65-50d1-4dbc-ac26-007b4f3da77c{fill:#595a62;}
-        </style>
-        <clipPath id="b89874de-42cc-4a08-a445-73aac157aa7c" transform="translate(-0.39 -0.04)">
-            <rect class="f4097b67-2213-40bd-9c3a-94cf64be6239" x="0.39" y="0.04" width="300" height="300"/>
-        </clipPath>
-    </defs>
-    <title>Netresearch Logo</title>
-    <g class="ac0374ef-26de-4333-a951-e8ab8d27f8bd">
-        <path class="bbf856c7-1511-45c6-8eda-8aee74e5919c"
-              d="M209.6,0V31.62h32.77a26.38,26.38,0,0,1,26.44,26.43V242a26.38,26.38,0,0,1-26.44,26.44H209.6V300h47.93a42.77,42.77,0,0,0,42.86-42.86V42.89A42.76,42.76,0,0,0,257.53,0ZM43.25,0A42.76,42.76,0,0,0,.39,42.89V257.18A42.76,42.76,0,0,0,43.25,300H91.18V268.46H58.4A26.38,26.38,0,0,1,32,242v-184A26.37,26.37,0,0,1,58.4,31.62H91.18V0Z"
-              transform="translate(-0.39 -0.04)"/>
-        <path class="f2146b65-50d1-4dbc-ac26-007b4f3da77c"
-              d="M221.44,120.41c0-34.48-13.94-57.82-48.93-57.82-26.62,0-48.54,7.74-64.17,26.56l-.7-22.06-28.31.06V232.94h31.59V124.69c7.14-18.38,32.14-34.8,53-34.5,27.38.4,25.2,26.24,26,45.81v96.94h31.58"
-              transform="translate(-0.39 -0.04)"/>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <rect width="64" height="64" rx="8" fill="#2F99A4"/>
+    <rect x="14" y="18" width="36" height="28" rx="4" fill="#FFFFFF"/>
+    <circle cx="40" cy="27" r="3.5" fill="#2F99A4"/>
+    <path fill="#2F99A4" d="M18 42l6-7 4 4 7-9 11 12z"/>
+    <circle cx="51" cy="13" r="5" fill="#FF4D00"/>
 </svg>

--- a/Resources/Public/Icons/module-image-optimize.legacy.svg
+++ b/Resources/Public/Icons/module-image-optimize.legacy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path fill="#2F99A4" d="M0 0h64v64H0z"/><path fill="#FFF" d="M48 22v20H16V22h32m2-4H14c-1.1 0-2 .9-2 2v24c0 1.1.9 2 2 2h36c1.1 0 2-.9 2-2V20c0-1.1-.9-2-2-2Z"/><g opacity=".6"><path fill="#FFF" d="M16 42l7-8 4 4 8-11 13 15z"/></g><circle fill="#FFF" cx="41" cy="28" r="3.5"/></svg>

--- a/Resources/Public/Icons/module-image-optimize.svg
+++ b/Resources/Public/Icons/module-image-optimize.svg
@@ -1,9 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-    <path fill="#2f99a4" d="M0 0h64v64H0z"/>
-    <path fill="#FFF" d="M14 18h36v28H14z"/>
-    <path fill="#2f99a4" d="M18 22h28v20H18z" opacity=".3"/>
-    <circle fill="#2f99a4" cx="25" cy="28" r="3"/>
-    <path fill="#2f99a4" d="M18 38l6-6 4 4 8-10 10 10v6H18z" opacity=".7"/>
-    <path fill="#FFF" d="M48 14l4 4-4 4-4-4z"/>
-    <path fill="#2f99a4" d="M46 16h6v4h-6z" opacity=".5"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path fill="currentColor" d="M48 22v20H16V22h32m2-4H14c-1.1 0-2 .9-2 2v24c0 1.1.9 2 2 2h36c1.1 0 2-.9 2-2V20c0-1.1-.9-2-2-2Z"/><g opacity=".4"><path fill="currentColor" d="M16 42l7-8 4 4 8-11 13 15z"/></g><circle fill="var(--nr-icon-accent, #2F99A4)" cx="41" cy="28" r="3.5"/></svg>


### PR DESCRIPTION
## Problem

On `/typo3/module/tools/nr-image-optimize` (TYPO3 v14 backend) two issues were reported:

1. **Icon not in the v14 style.** The backend module icon (`module-image-optimize.svg`) and the extension icon (`Extension.svg`) were flat, hard-coded full-colour tiles. The module icon did not adapt to the v14 backend light/dark colour scheme, and `Extension.svg` was still the raw 300×300 Netresearch logo.
2. **Dark-mode breakage in the module.** The Maintenance module Fluid templates used Bootstrap utility classes with fixed *light* values (`bg-light`, `table-light`, `text-dark`) that stay light regardless of the active colour mode, so card headers, table heads and code chips rendered as light boxes on a dark backend.

## Changes

### Icons — mirror the sibling `nr-vault` v14 icon system
- **`module-image-optimize.svg`** — theme-aware glyph: monochrome primary shapes via `fill="currentColor"` (auto-adapts to BE light/dark), a secondary mountain at `opacity=".4"`, and a single teal accent via `fill="var(--nr-icon-accent, #2F99A4)"`. `viewBox="0 0 64 64"`.
- **`module-image-optimize.legacy.svg`** *(new)* — full-colour teal tile with a white glyph for the classic v13 module menu (matches `module-vault.legacy.svg`).
- **`Extension.svg`** — redesigned v14 teal tile: white picture glyph, teal detail, orange accent dot (matches `nr-vault/Extension.svg`).
- **`Configuration/Icons.php`** — registers the flat icon on TYPO3 v14+ and the legacy tile on v13, switching on `Typo3Version::getMajorVersion()` (same pattern as `nr-vault`).

### Dark mode — theme-aware Bootstrap 5.3 tokens
In `Resources/Private/Templates/Maintenance/{Index,SystemRequirements}.html`:
- `card-header bg-light` → `card-header bg-body-tertiary`
- `<thead class="table-light">` → `<thead>` (inherits the color-mode table theming)
- code chips `bg-light` / `text-dark bg-light` → `bg-body-tertiary` (dropping the fixed `text-dark` so code text follows the colour mode)

`bg-body-tertiary` resolves to the adaptive `--bs-tertiary-bg` token, so these surfaces flip correctly in both light and dark. The one remaining `bg-warning text-dark` (status badge) is intentionally left: the warning background stays yellow in both modes, so dark text is the correct contrast.

## Validation
- `xmllint --noout` passes on all three SVGs.
- `composer ci:test:php:cgl` (php-cs-fixer dry-run) passes on `Configuration/Icons.php`.
- Icons rendered via headless Chromium and visually verified: the module icon flips with `currentColor` (dark frame in BE light, light frame in BE dark) while keeping the teal accent; legacy tile and `Extension.svg` match the sibling full-colour style.

Dark mode was verified by **code inspection against the known-good `nr-vault` sibling pattern and an offline render simulating both colour modes** — not in a live v14 backend browser session.
