### PR TITLE
feat(viewhelper): derive crop-aware height in SourceSetViewHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`image` and `cropVariant` arguments on `SourceSetViewHelper`** — when a FAL
+  `FileReference` is passed via `image`, the ViewHelper derives the effective
+  height from that image's crop-variant area (falling back to its original
+  aspect ratio when the variant has no crop data), instead of requiring
+  callers to pre-compute a crop-aware height themselves via a separate,
+  site-specific ViewHelper. `height` remains authoritative when `image` is
+  omitted (NEXT-100).
+
 ### Changed
 
 ### Deprecated

--- a/Classes/ViewHelpers/SourceSetViewHelper.php
+++ b/Classes/ViewHelpers/SourceSetViewHelper.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Netresearch\NrImageOptimize\ViewHelpers;
 
 use function array_filter;
+use function array_key_exists;
 use function array_map;
 use function array_unique;
 use function explode;
@@ -21,6 +22,7 @@ use function htmlspecialchars;
 use function http_build_query;
 use function implode;
 use function is_array;
+use function json_decode;
 use function round;
 use function sort;
 use function sprintf;
@@ -31,6 +33,7 @@ use function trigger_error;
 use function trim;
 
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -128,6 +131,8 @@ final class SourceSetViewHelper extends AbstractViewHelper
         $this->registerArgument('widthVariants', 'string|array', 'Width variants for responsive srcset (comma-separated string or array).', false);
         $this->registerArgument('sizes', 'string', 'Sizes attribute for responsive images.', false, self::DEFAULT_SIZES);
         $this->registerArgument('fetchpriority', 'string', "Resource fetch priority for the image: 'high', 'low', or 'auto'.", false, '');
+        $this->registerArgument('image', FileReference::class, 'Optional FAL FileReference used to derive a crop-aware height (overrides `height`).', false);
+        $this->registerArgument('cropVariant', 'string', 'FAL crop variant to read from `image` when deriving height.', false, 'default');
     }
 
     /**
@@ -138,7 +143,7 @@ final class SourceSetViewHelper extends AbstractViewHelper
     public function render(): string
     {
         $width  = $this->getArgWidth();
-        $height = $this->getArgHeight();
+        $height = $this->resolveEffectiveHeight($width);
 
         if ($this->isPassthroughUrl($this->getArgPath())) {
             return $this->renderPassthroughImage($this->getArgPath(), $width, $height);
@@ -573,6 +578,111 @@ final class SourceSetViewHelper extends AbstractViewHelper
         $height = $this->arguments['height'] ?? 0;
 
         return (int) floor(is_numeric($height) ? (float) $height : 0);
+    }
+
+    /**
+     * Resolve the effective height for the given target width.
+     *
+     * When the `image` argument carries a FAL FileReference, the height is derived
+     * from that image's crop-variant aspect ratio instead of the raw `height`
+     * argument, so callers no longer need a separate crop-aware ViewHelper to
+     * pre-compute it. Falls back to `getArgHeight()` when no image is given or
+     * no usable ratio can be determined.
+     *
+     * @param int $width Target width in pixels
+     *
+     * @return int Effective height in pixels
+     */
+    private function resolveEffectiveHeight(int $width): int
+    {
+        $height = $this->getArgHeight();
+        $image  = $this->arguments['image'] ?? null;
+
+        if (!$image instanceof FileReference || $width <= 0) {
+            return $height;
+        }
+
+        $ratio = $this->cropAspectRatio($image, $this->getArgCropVariant());
+
+        if ($ratio === null) {
+            return $height;
+        }
+
+        $computedHeight = (int) round($width * $ratio);
+
+        return $computedHeight > 0 ? $computedHeight : $height;
+    }
+
+    /**
+     * Derive the height-to-width ratio for a FAL image, honoring its crop variant.
+     *
+     * Falls back to the image's original aspect ratio when the crop variant is
+     * missing, malformed, or does not carry a usable crop area — mirroring the
+     * behaviour previously duplicated in consuming site packages.
+     *
+     * @param FileReference $image       FAL file reference to read `width`/`height`/`crop` from
+     * @param string        $cropVariant Crop variant key to read from the `crop` property
+     *
+     * @return float|null Height-to-width ratio, or null if the image has no usable dimensions
+     */
+    private function cropAspectRatio(FileReference $image, string $cropVariant): ?float
+    {
+        $rawWidth  = $image->getProperty('width');
+        $rawHeight = $image->getProperty('height');
+
+        $originalWidth  = is_numeric($rawWidth) ? (int) $rawWidth : 0;
+        $originalHeight = is_numeric($rawHeight) ? (int) $rawHeight : 0;
+
+        if ($originalWidth <= 0 || $originalHeight <= 0) {
+            return null;
+        }
+
+        $originalRatio = $originalHeight / $originalWidth;
+        $rawCrop       = $image->getProperty('crop');
+        $cropJson      = is_string($rawCrop) ? $rawCrop : '';
+
+        if ($cropJson === '') {
+            return $originalRatio;
+        }
+
+        $data = json_decode($cropJson, true);
+
+        if (!is_array($data)) {
+            return $originalRatio;
+        }
+
+        $variantData = $data[$cropVariant] ?? null;
+        $area        = (is_array($variantData) && array_key_exists('cropArea', $variantData))
+            ? $variantData['cropArea']
+            : ($data['cropArea'] ?? null);
+
+        if (!is_array($area) || !array_key_exists('width', $area) || !array_key_exists('height', $area)) {
+            return $originalRatio;
+        }
+
+        $rawCropWidth  = $area['width'];
+        $rawCropHeight = $area['height'];
+
+        $cropWidthRatio  = is_numeric($rawCropWidth) ? (float) $rawCropWidth : 0.0;
+        $cropHeightRatio = is_numeric($rawCropHeight) ? (float) $rawCropHeight : 0.0;
+
+        if ($cropWidthRatio <= 0.0 || $cropHeightRatio <= 0.0) {
+            return $originalRatio;
+        }
+
+        return ($originalHeight * $cropHeightRatio) / ($originalWidth * $cropWidthRatio);
+    }
+
+    /**
+     * Resolve the crop variant argument used to read crop data from `image`.
+     *
+     * @return string Crop variant key (defaults to "default")
+     */
+    private function getArgCropVariant(): string
+    {
+        $cropVariant = $this->arguments['cropVariant'] ?? 'default';
+
+        return is_string($cropVariant) && $cropVariant !== '' ? $cropVariant : 'default';
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SourceSetViewHelperTest.php
@@ -42,6 +42,7 @@ use function sys_get_temp_dir;
 
 use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 
@@ -1994,5 +1995,140 @@ final class SourceSetViewHelperTest extends TestCase
         foreach ($result as $width) {
             self::assertGreaterThan(0, $width, 'All returned widths must be positive');
         }
+    }
+
+    // =========================================================================
+    // Crop-aware height derivation (NEXT-100)
+    // =========================================================================
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    private function createFileReference(array $properties): FileReference
+    {
+        $image = $this->createMock(FileReference::class);
+        $image->method('getProperty')->willReturnCallback(
+            static fn (string $key): mixed => $properties[$key] ?? null,
+        );
+
+        return $image;
+    }
+
+    #[Test]
+    public function resolveEffectiveHeightDerivesNonSquareHeightFromCropArea(): void
+    {
+        // 1000x1000 original, "default" crop variant narrows height to 50% of width
+        $image = $this->createFileReference([
+            'width'  => 1000,
+            'height' => 1000,
+            'crop'   => json_encode(['default' => ['cropArea' => ['width' => 1.0, 'height' => 0.5]]]),
+        ]);
+
+        $this->viewHelper->setArguments([
+            'image' => $image,
+        ]);
+
+        self::assertSame(200, $this->callMethod('resolveEffectiveHeight', 400));
+    }
+
+    #[Test]
+    public function resolveEffectiveHeightFallsBackToOriginalRatioWhenCropMissing(): void
+    {
+        $image = $this->createFileReference([
+            'width'  => 800,
+            'height' => 600,
+            'crop'   => '',
+        ]);
+
+        $this->viewHelper->setArguments([
+            'image' => $image,
+        ]);
+
+        self::assertSame(300, $this->callMethod('resolveEffectiveHeight', 400));
+    }
+
+    #[Test]
+    public function resolveEffectiveHeightFallsBackToOriginalRatioWhenCropJsonInvalid(): void
+    {
+        $image = $this->createFileReference([
+            'width'  => 800,
+            'height' => 600,
+            'crop'   => 'not-json',
+        ]);
+
+        $this->viewHelper->setArguments([
+            'image' => $image,
+        ]);
+
+        self::assertSame(300, $this->callMethod('resolveEffectiveHeight', 400));
+    }
+
+    #[Test]
+    public function resolveEffectiveHeightUsesSelectedCropVariant(): void
+    {
+        $image = $this->createFileReference([
+            'width'  => 1000,
+            'height' => 1000,
+            'crop'   => json_encode([
+                'default' => ['cropArea' => ['width' => 1.0, 'height' => 0.5]],
+                'wide'    => ['cropArea' => ['width' => 1.0, 'height' => 0.25]],
+            ]),
+        ]);
+
+        $this->viewHelper->setArguments([
+            'image'       => $image,
+            'cropVariant' => 'wide',
+        ]);
+
+        self::assertSame(100, $this->callMethod('resolveEffectiveHeight', 400));
+    }
+
+    #[Test]
+    public function resolveEffectiveHeightKeepsExplicitHeightWhenNoImageProvided(): void
+    {
+        $this->viewHelper->setArguments([
+            'height' => 337,
+        ]);
+
+        self::assertSame(337, $this->callMethod('resolveEffectiveHeight', 400));
+    }
+
+    #[Test]
+    public function renderResponsiveSrcsetUsesCropAwareHeightFromImage(): void
+    {
+        $image = $this->createFileReference([
+            'width'  => 1000,
+            'height' => 1000,
+            'crop'   => json_encode(['default' => ['cropArea' => ['width' => 1.0, 'height' => 0.5]]]),
+        ]);
+
+        $this->viewHelper->setArguments([
+            'path'             => '/path/to/image.jpg',
+            'width'            => 400,
+            'height'           => 999, // must be ignored in favor of crop-derived height
+            'image'            => $image,
+            'responsiveSrcset' => true,
+        ]);
+
+        $result = $this->viewHelper->render();
+
+        self::assertStringContainsString('height="200"', $result);
+        self::assertStringContainsString('/processed/path/to/image.w400h200m0q75.jpg', $result);
+    }
+
+    #[Test]
+    public function initializeArgumentsRegistersImageAndCropVariantArguments(): void
+    {
+        $viewHelper = new SourceSetViewHelper();
+        $viewHelper->initializeArguments();
+
+        $reflection = new ReflectionProperty(AbstractViewHelper::class, 'argumentDefinitions');
+        /** @var array<string, ArgumentDefinition> $definitions */
+        $definitions = $reflection->getValue($viewHelper);
+
+        self::assertArrayHasKey('image', $definitions);
+        self::assertFalse($definitions['image']->isRequired(), "'image' must be optional.");
+        self::assertArrayHasKey('cropVariant', $definitions);
+        self::assertSame('default', $definitions['cropVariant']->getDefaultValue());
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `image` (FAL `FileReference`) and `cropVariant` arguments to `SourceSetViewHelper`.
- When `image` is given, the effective height is derived from that image's crop-variant area (falling back to its original aspect ratio when the variant has no crop data) instead of the raw `height` argument.
- Fully backward compatible: behavior is unchanged when `image` is omitted.

This absorbs logic that consuming site packages (e.g. `nrc-site-hsm`) previously had to duplicate in their own separate ViewHelper just to pre-compute a crop-aware height before calling into `nrio:sourceSet`.

Ref: NEXT-100

## Test plan
- [x] `composer ci:test:php:unit` — new unit tests (RED before, GREEN after) covering: square image + non-square crop variant, missing/invalid crop JSON fallback, explicit crop variant selection, no-image backward compatibility, and full `render()` integration
- [x] `composer ci:test:php:phpstan` — no new findings (baseline unchanged)
- [x] `composer ci:test:php:cgl` / `lint` / `rector` / `fractor` — clean
- [x] `composer ci:test:php:acceptance` — unchanged, still green