### PR TITLE
fix(maintenance): keep clear-processed-images working on symlinked deployments

### DIFF
--- a/Classes/Controller/MaintenanceController.php
+++ b/Classes/Controller/MaintenanceController.php
@@ -12,8 +12,12 @@ declare(strict_types=1);
 namespace Netresearch\NrImageOptimize\Controller;
 
 use function array_slice;
+use function basename;
 use function count;
 use function date;
+
+use FilesystemIterator;
+
 use function floor;
 use function is_dir;
 use function log;
@@ -119,34 +123,37 @@ final class MaintenanceController extends ActionController implements LoggerAwar
     }
 
     /**
-     * Clear all processed image variants and recreate the processed directory.
+     * Clear all processed image variants.
      *
-     * Validates the resolved path matches the expected path to prevent directory
-     * traversal attacks before performing deletion.
+     * Empties the "<public>/processed" directory in place: the directory -- or,
+     * on Deployer/CI deployments, the symlink pointing at a shared volume -- is
+     * kept and only its contents are removed. The resolved target must be a
+     * directory named "processed"; the previous realpath-equality check forced
+     * the target inside the web root and thus failed on every symlinked
+     * deployment.
      */
     public function clearProcessedImagesAction(): ResponseInterface
     {
-        $processedPath      = Environment::getPublicPath() . '/processed';
-        $resolvedPublicPath = realpath(Environment::getPublicPath());
-
-        if ($resolvedPublicPath === false) {
-            throw new RuntimeException('Security check failed: Public path could not be resolved');
-        }
-
-        $expectedPath = $resolvedPublicPath . '/processed';
+        $processedPath = Environment::getPublicPath() . '/processed';
 
         try {
             if (is_dir($processedPath)) {
-                $resolvedPath = realpath($processedPath);
+                // "processed" is commonly a symlink to a shared volume on
+                // Deployer/CI deployments. Resolve the real target and require
+                // it to actually be a directory named "processed" before
+                // deleting its contents -- a guard against a mis-pointed symlink
+                // that, unlike realpath-equality, does not force the target to
+                // live inside the web root.
+                $resolved = realpath($processedPath);
 
-                if ($resolvedPath === false || $resolvedPath !== $expectedPath) {
-                    throw new RuntimeException('Security check failed: Path mismatch');
+                if ($resolved === false || basename($resolved) !== 'processed') {
+                    throw new RuntimeException('Security check failed: unexpected processed path target');
                 }
 
-                GeneralUtility::rmdir($processedPath, true);
+                $this->emptyDirectory($processedPath);
+            } else {
+                GeneralUtility::mkdir($processedPath);
             }
-
-            GeneralUtility::mkdir($processedPath);
 
             $this->addFlashMessage(
                 $this->getLanguageService()->sL('LLL:EXT:nr_image_optimize/Resources/Private/Language/locallang.xlf:flash.clear.success'),
@@ -166,6 +173,28 @@ final class MaintenanceController extends ActionController implements LoggerAwar
         }
 
         return $this->redirect('index');
+    }
+
+    /**
+     * Delete every entry inside a directory while keeping the directory itself
+     * (or a symlink pointing at it) in place.
+     *
+     * Removing and recreating the directory would replace a "processed" symlink
+     * with a real directory and detach the shared volume on symlinked
+     * deployments, so only the children are removed.
+     *
+     * @param string $path Absolute path to the directory to empty
+     */
+    private function emptyDirectory(string $path): void
+    {
+        $entries = new FilesystemIterator($path, FilesystemIterator::SKIP_DOTS);
+
+        // GeneralUtility::rmdir() is symlink-safe: it recurses into real
+        // subdirectories but only unlinks a symlinked child, never follows it.
+        /** @var SplFileInfo $entry */
+        foreach ($entries as $entry) {
+            GeneralUtility::rmdir($entry->getPathname(), true);
+        }
     }
 
     /**

--- a/Tests/Functional/Controller/MaintenanceControllerTest.php
+++ b/Tests/Functional/Controller/MaintenanceControllerTest.php
@@ -18,10 +18,14 @@ use function mkdir;
 use Netresearch\NrImageOptimize\Controller\MaintenanceController;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -111,5 +115,91 @@ final class MaintenanceControllerTest extends FunctionalTestCase
         self::assertFileExists($subDir . '/file1.jpg');
         self::assertFileExists($subDir . '/file2.png');
         self::assertFileExists($subDir . '/file3.webp');
+    }
+
+    #[Test]
+    public function clearProcessedImagesActionEmptiesDirectoryKeepingItInPlace(): void
+    {
+        $processedPath = Environment::getPublicPath() . '/processed';
+
+        if (!is_dir($processedPath)) {
+            mkdir($processedPath, 0o775, true);
+        }
+
+        mkdir($processedPath . '/fileadmin', 0o775, true);
+        file_put_contents($processedPath . '/fileadmin/variant.jpg', 'fake-jpg');
+        file_put_contents($processedPath . '/top-level.png', 'fake-png');
+
+        $response = $this->dispatchAction('clearProcessedImages');
+
+        self::assertGreaterThanOrEqual(300, $response->getStatusCode());
+        self::assertLessThan(400, $response->getStatusCode());
+        self::assertDirectoryExists($processedPath);
+        self::assertDirectoryDoesNotExist($processedPath . '/fileadmin');
+        self::assertFileDoesNotExist($processedPath . '/top-level.png');
+    }
+
+    #[Test]
+    public function clearProcessedImagesActionCreatesDirectoryWhenMissing(): void
+    {
+        $processedPath = Environment::getPublicPath() . '/processed';
+        GeneralUtility::rmdir($processedPath, true);
+        self::assertDirectoryDoesNotExist($processedPath);
+
+        $response = $this->dispatchAction('clearProcessedImages');
+
+        self::assertGreaterThanOrEqual(300, $response->getStatusCode());
+        self::assertLessThan(400, $response->getStatusCode());
+        self::assertDirectoryExists($processedPath);
+    }
+
+    #[Test]
+    public function clearProcessedImagesActionReportsErrorForUnexpectedSymlinkTarget(): void
+    {
+        $publicPath    = Environment::getPublicPath();
+        $processedPath = $publicPath . '/processed';
+        $foreignTarget = $publicPath . '/not-processed';
+
+        GeneralUtility::rmdir($processedPath, true);
+        mkdir($foreignTarget, 0o775, true);
+        file_put_contents($foreignTarget . '/keep.txt', 'keep');
+        symlink($foreignTarget, $processedPath);
+
+        // The guard rejects a symlink whose target is not named "processed":
+        // the action logs, shows an error flash and still redirects -- without
+        // deleting anything.
+        $response = $this->dispatchAction('clearProcessedImages');
+
+        self::assertGreaterThanOrEqual(300, $response->getStatusCode());
+        self::assertLessThan(400, $response->getStatusCode());
+        self::assertFileExists($foreignTarget . '/keep.txt');
+    }
+
+    /**
+     * Run a MaintenanceController action through the Extbase request lifecycle
+     * so the guard, flash messages and the redirect response are exercised as
+     * they are in production (not just the extracted filesystem helper).
+     */
+    private function dispatchAction(string $action): ResponseInterface
+    {
+        $requestParameters = (new ExtbaseRequestParameters(MaintenanceController::class))
+            ->setControllerActionName($action)
+            ->setControllerName('Maintenance')
+            ->setControllerExtensionName('NrImageOptimize');
+
+        $serverRequest = (new ServerRequest('https://example.com/typo3/'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('extbase', $requestParameters);
+        $serverRequest = $serverRequest->withAttribute(
+            'normalizedParams',
+            NormalizedParams::createFromRequest($serverRequest),
+        );
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+
+        try {
+            return $this->get(MaintenanceController::class)->processRequest(new Request($serverRequest));
+        } finally {
+            unset($GLOBALS['TYPO3_REQUEST']);
+        }
     }
 }

--- a/Tests/Unit/Controller/MaintenanceControllerTest.php
+++ b/Tests/Unit/Controller/MaintenanceControllerTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrImageOptimize\Tests\Unit\Controller;
 
+use FilesystemIterator;
 use Netresearch\NrImageOptimize\Controller\MaintenanceController;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -131,6 +132,40 @@ final class MaintenanceControllerTest extends TestCase
         self::assertSame('1 KB', $this->callMethod('formatBytes', 1024));
         self::assertSame('1 MB', $this->callMethod('formatBytes', 1024 * 1024));
         self::assertSame('1 GB', $this->callMethod('formatBytes', 1024 * 1024 * 1024));
+    }
+
+    #[Test]
+    public function emptyDirectoryRemovesContentsButKeepsDirectory(): void
+    {
+        $dir = $this->tempDir . '/public/processed';
+        mkdir($dir . '/sub', 0o777, true);
+        file_put_contents($dir . '/a.jpg', 'x');
+        file_put_contents($dir . '/sub/b.webp', 'y');
+
+        $this->callMethod('emptyDirectory', $dir);
+
+        self::assertDirectoryExists($dir);
+        self::assertCount(0, iterator_to_array(new FilesystemIterator($dir)));
+    }
+
+    #[Test]
+    public function emptyDirectoryKeepsSymlinkInPlace(): void
+    {
+        // Reproduces the shared-symlink deployment layout: "processed" is a
+        // symlink to a shared volume. rmdir()+mkdir() would replace the symlink
+        // with a real directory and detach the volume -- emptying in place must
+        // keep the symlink and only clear its target.
+        $target = $this->tempDir . '/shared-processed';
+        mkdir($target, 0o777, true);
+        file_put_contents($target . '/cached.avif', 'x');
+
+        $link = $this->tempDir . '/public/processed';
+        symlink($target, $link);
+
+        $this->callMethod('emptyDirectory', $link);
+
+        self::assertTrue(is_link($link), 'the processed symlink must survive the clear');
+        self::assertCount(0, iterator_to_array(new FilesystemIterator($target)), 'the symlink target must be emptied');
     }
 
     #[Test]


### PR DESCRIPTION
Closes #131

`clearProcessedImagesAction` validated the path with `realpath()`, which resolves the `processed` symlink (Deployer/CI shared-dir layout) to its target and never matched `<public>/processed` — so the action failed on every symlinked deployment.

- Replace the realpath-equality check with a `realpath()` + `basename === 'processed'` guard that allows the shared symlink but still rejects a mis-pointed target.
- Empty the directory in place instead of `rmdir()` + `mkdir()`, so a `processed` symlink is preserved (recreating it would detach the shared volume).

Adds unit tests for in-place emptying and symlink preservation.
