### PR TITLE
feat: configurable WebP/AVIF output quality

### DIFF
--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrImageOptimize;
 
+use function array_key_exists;
 use function array_keys;
 use function count;
 use function dirname;
@@ -23,6 +24,7 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 use function is_dir;
 use function is_link;
+use function is_numeric;
 use function is_string;
 use function max;
 use function md5;
@@ -124,6 +126,22 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
      * without an explicit quality keep encoding byte-stable.
      */
     private const DEFAULT_QUALITY = 75;
+
+    /**
+     * Default quality for the generated WebP variant when `qualityWebp` is unset.
+     */
+    private const DEFAULT_QUALITY_WEBP = 75;
+
+    /**
+     * Default quality for the generated AVIF variant when `qualityAvif` is unset.
+     *
+     * Lower than WebP/JPEG on purpose: the AVIF (AV1/AOM) quality scale is
+     * steeper, so at the same number an AVIF variant comes out larger than the
+     * WebP equivalent and defeats the point of serving AVIF. Encoding AVIF a
+     * few points lower yields a visually comparable image at a genuinely
+     * smaller size.
+     */
+    private const DEFAULT_QUALITY_AVIF = 60;
 
     /**
      * Cache-Control max-age for processed images (1 year in seconds).
@@ -514,6 +532,12 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
         $targetQuality  = $urlInfo['targetQuality'];
         $processingMode = $urlInfo['processingMode'];
 
+        // WebP/AVIF quality is a config-driven encoding parameter -- unlike the
+        // base quality it is not encoded in the URL/cache key -- so it is
+        // resolved here at encode time rather than in the URL parser.
+        $webpQuality = $this->resolveFormatQuality('qualityWebp', self::DEFAULT_QUALITY_WEBP);
+        $avifQuality = $this->resolveFormatQuality('qualityAvif', self::DEFAULT_QUALITY_AVIF);
+
         $image = $this->processImage($image, $targetWidth, $targetHeight, $processingMode);
 
         $this->ensureDirectoryExists(dirname($urlInfo['pathVariant']));
@@ -532,7 +556,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
 
         if (!$this->isWebpImage($extension) && !$queryParams['skipWebP']) {
             try {
-                $this->generateWebpVariant($image, $targetQuality, $pathVariant);
+                $this->generateWebpVariant($image, $webpQuality, $pathVariant);
                 $webpGenerated = true;
             } catch (Throwable $e) {
                 $this->getLogger()->warning('WebP variant generation failed for "{path}"', [
@@ -544,7 +568,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
 
         if (!$this->isAvifImage($extension) && !$queryParams['skipAvif']) {
             try {
-                $this->generateAvifVariant($image, $targetQuality, $pathVariant);
+                $this->generateAvifVariant($image, $avifQuality, $pathVariant);
                 $avifGenerated = true;
             } catch (Throwable $e) {
                 $this->getLogger()->warning('AVIF variant generation failed for "{path}"', [
@@ -705,6 +729,35 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
     private function clampQuality(int $value): int
     {
         return max(self::MIN_QUALITY, min($value, self::MAX_QUALITY));
+    }
+
+    /**
+     * Resolve the configured output quality for a specific variant format.
+     *
+     * Reads the given extension-configuration key (e.g. "qualityAvif") and
+     * clamps it to the valid range. Falls back to $default when the setting is
+     * unconfigured, non-numeric, or the ExtensionConfiguration API is
+     * unavailable (e.g. in test scaffolding that instantiates the Processor
+     * without the container).
+     *
+     * @param non-empty-string $key     Extension-configuration key to read
+     * @param int              $default Fallback quality when unset/invalid
+     *
+     * @return int Clamped quality (1-100)
+     */
+    private function resolveFormatQuality(string $key, int $default): int
+    {
+        try {
+            $raw = $this->extensionConfiguration->get(self::EXTENSION_KEY, $key);
+        } catch (Throwable) {
+            return $default;
+        }
+
+        if (!is_numeric($raw)) {
+            return $default;
+        }
+
+        return $this->clampQuality((int) $raw);
     }
 
     /**

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -39,6 +39,7 @@ use RuntimeException;
 use SplFileInfo;
 use Throwable;
 use TypeError;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Locking\Exception\LockCreateException;
@@ -586,6 +587,42 @@ final class ProcessorTest extends TestCase
         self::assertFalse($this->callMethod($this->processor, 'hasVariantFor', $base, 'avif'));
 
         unlink($webp); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture teardown of self-created tmp file
+    }
+
+    #[Test]
+    public function resolveFormatQualityFallsBackToDefaultWhenConfigurationUnavailable(): void
+    {
+        // extensionConfiguration is intentionally not injected in setUp(), so
+        // reading it throws and the method must fall back to the given default.
+        self::assertSame(60, $this->callMethod($this->processor, 'resolveFormatQuality', 'qualityAvif', 60));
+    }
+
+    #[Test]
+    #[DataProvider('configuredQualityProvider')]
+    public function resolveFormatQualityClampsConfiguredValue(int|string $configured, int $expected): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($configured);
+        $this->setProperty($this->processor, 'extensionConfiguration', $extensionConfiguration);
+
+        self::assertSame(
+            $expected,
+            $this->callMethod($this->processor, 'resolveFormatQuality', 'qualityAvif', 60),
+        );
+    }
+
+    /**
+     * @return array<string, array{int|string, int}>
+     */
+    public static function configuredQualityProvider(): array
+    {
+        return [
+            'in range'               => ['55', 55],
+            'clamped to max'         => ['150', 100],
+            'clamped to min'         => ['0', 1],
+            'non-numeric falls back' => ['nan', 60],
+            'integer value'          => [42, 42],
+        ];
     }
 
     #[Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,3 +3,9 @@ additionalTrustedStorageSymlinks =
 
 # cat=basic/enable; type=string; label=Additional trusted absolute roots (comma-separated): absolute filesystem paths, outside FAL and TYPO3-internal locations, that are realpath-resolved and added to the path-validation allow-list. Leave empty (default). Only add paths you fully trust -- this widens where the processor will read from and publicly serve variants of.
 additionalTrustedRoots =
+
+# cat=quality/enable/10; type=int+; label=WebP quality (1-100): output quality for the generated WebP variant.
+qualityWebp = 75
+
+# cat=quality/enable/20; type=int+; label=AVIF quality (1-100): output quality for the generated AVIF variant. AVIF's quality scale is steeper than WebP/JPEG -- at the same number an AVIF comes out larger and defeats the point of serving AVIF, so a lower value (default 60) keeps it genuinely smaller while staying visually comparable. Changing this requires clearing the processed images.
+qualityAvif = 60


### PR DESCRIPTION
Closes #132

WebP/AVIF variants were encoded at the same numeric quality as the primary image; AVIF's steeper scale made AVIF variants larger than WebP, so negotiation served the biggest file.

- Add `qualityWebp` (75) and `qualityAvif` (60) extension-configuration settings.
- Resolve them at encode time in the Processor; primary/JPEG quality is unchanged (still the URL `q`).
- Default AVIF 60 keeps AVIF genuinely smaller than WebP while staying visually comparable (SSIM 0.974 vs a q100 reference on a photographic hero).

Changing these requires clearing processed images (the per-format quality is not part of the cache filename). Reliable clearing on symlinked deployments needs #131.

Adds unit tests for the quality resolution (fallback, clamping).
