### PR TITLE
chore: prepare release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.4.0] - 2026-07-24
+
+### Added
+
 - **`Environment::getVarPath()` is now an allowed root** — TYPO3-internal
   generated assets under `var/` (cache, lock, transient, log) are now
   accepted by path validation even in composer-mode installs where `var/`
@@ -21,15 +35,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   locations that are neither a FAL storage base path nor one of the
   hardcoded TYPO3-internal locations.
 
-### Changed
-
-### Deprecated
-
-### Removed
+- **Configurable WebP/AVIF output quality** — new `qualityWebp` (default
+  75) and `qualityAvif` (default 60) extension-configuration settings.
+  Previously both variants were encoded at the same numeric quality as
+  the primary image; AVIF's steeper quality scale made AVIF variants
+  larger than WebP at matching numbers, so format negotiation ended up
+  serving the biggest file. The lower AVIF default keeps AVIF variants
+  genuinely smaller than WebP while staying visually comparable.
+  Changing either setting requires clearing processed images, since
+  per-format quality is not part of the cache filename ([#132], [#134]).
 
 ### Fixed
 
-### Security
+- **`clear-processed-images` (Maintenance module) failed on symlinked
+  deployments.** The action validated the target path with `realpath()`,
+  which resolves a `processed` symlink (shared-directory deployment
+  layouts, e.g. Deployer) to its target and never matched
+  `<public>/processed` — so clearing failed on every symlinked
+  deployment. The directory is now emptied in place instead of
+  `rmdir()` + `mkdir()`, preserving the symlink ([#131], [#133]).
+
+[#131]: https://github.com/netresearch/t3x-nr-image-optimize/issues/131
+[#132]: https://github.com/netresearch/t3x-nr-image-optimize/issues/132
+[#133]: https://github.com/netresearch/t3x-nr-image-optimize/pull/133
+[#134]: https://github.com/netresearch/t3x-nr-image-optimize/pull/134
+
+## [2.3.1] - 2026-07-22
+
+### Fixed
+
+- **Backend module icon and templates were not TYPO3 v14 theme-aware.**
+  The module icon (`module-image-optimize.svg`) and extension icon
+  (`Extension.svg`) were flat, hard-coded tiles that did not adapt to
+  the v14 backend light/dark colour scheme. The Maintenance module's
+  Fluid templates also used Bootstrap utility classes with fixed light
+  values (`bg-light`, `table-light`, `text-dark`), causing card headers,
+  table heads, and code chips to render as light boxes on a dark
+  backend. The module icon is now theme-aware via `fill="currentColor"`
+  (TYPO3 v14+, with a legacy full-colour tile kept for v13), and the
+  templates use adaptive `bg-body-tertiary` tokens instead ([#127]).
+
+[#127]: https://github.com/netresearch/t3x-nr-image-optimize/pull/127
 
 ## [2.3.0] - 2026-07-22
 
@@ -402,7 +448,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected crop variant examples.
 - Improved lazy loading behavior.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.3.1...v2.4.0
+[2.3.1]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.2.4...v2.3.0
 [2.2.4]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.2.3...v2.2.4
 [2.2.3]: https://github.com/netresearch/t3x-nr-image-optimize/compare/v2.2.2...v2.2.3

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -6,6 +6,63 @@
 Changelog
 =========
 
+..  _changelog-2-4-0:
+
+2.4.0
+=====
+
+-   Added: ``Environment::getVarPath()`` (the composer-mode
+    :file:`var/` directory, a sibling of :file:`public/` rather than
+    nested under it) is now an allowed root for path validation, so
+    TYPO3-internal generated assets (cache, lock, transient, log) are
+    accepted.
+-   Added: ``additionalTrustedRoots`` extension configuration --
+    per-instance, opt-in, comma-separated list of absolute filesystem
+    paths that are realpath-resolved and added directly to the
+    path-validation allow-list. Closes the gap for integrator-trusted
+    locations that are neither a FAL storage base path nor one of the
+    hardcoded TYPO3-internal locations. See
+    :ref:`configuration-additional-trusted-roots`.
+-   Added: configurable WebP/AVIF output quality via the new
+    ``qualityWebp`` (default 75) and ``qualityAvif`` (default 60)
+    extension-configuration settings. Previously both variants were
+    encoded at the same numeric quality as the primary image; AVIF's
+    steeper quality scale made AVIF variants larger than WebP at
+    matching numbers, so format negotiation ended up serving the
+    biggest file. The lower AVIF default keeps AVIF variants
+    genuinely smaller than WebP while staying visually comparable.
+    See :ref:`configuration-sidecar-quality`. Changing either setting
+    requires clearing processed images, since per-format quality is
+    not part of the cache filename. Reported in
+    `issue #132 <https://github.com/netresearch/t3x-nr-image-optimize/issues/132>`__.
+-   Fixed: ``clear-processed-images`` (Maintenance module) failed on
+    symlinked deployments. The action validated the target path with
+    ``realpath()``, which resolves a :file:`processed` symlink
+    (shared-directory deployment layouts, e.g. Deployer) to its
+    target and never matched :file:`<public>/processed` -- so
+    clearing failed on every symlinked deployment. The directory is
+    now emptied in place instead of ``rmdir()`` + ``mkdir()``,
+    preserving the symlink. Reported in
+    `issue #131 <https://github.com/netresearch/t3x-nr-image-optimize/issues/131>`__.
+
+..  _changelog-2-3-1:
+
+2.3.1
+=====
+
+-   Fixed: the backend module icon and Maintenance module templates
+    were not TYPO3 v14 theme-aware. The module icon
+    (:file:`module-image-optimize.svg`) and extension icon
+    (:file:`Extension.svg`) were flat, hard-coded tiles that did not
+    adapt to the v14 backend light/dark colour scheme. The
+    Maintenance module's Fluid templates also used Bootstrap utility
+    classes with fixed light values (``bg-light``, ``table-light``,
+    ``text-dark``), causing card headers, table heads, and code chips
+    to render as light boxes on a dark backend. The module icon is
+    now theme-aware via ``fill="currentColor"`` (TYPO3 v14+, with a
+    legacy full-colour tile kept for v13), and the templates use
+    adaptive ``bg-body-tertiary`` tokens instead.
+
 ..  _changelog-2-3-0:
 
 2.3.0

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -315,6 +315,50 @@ These flags are useful when specific consumers (for example
 e-mail clients or legacy RSS renderers) cannot handle modern
 formats.
 
+..  _configuration-sidecar-quality:
+
+WebP/AVIF output quality
+========================
+
+..  versionadded:: 2.4.0
+    The ``qualityWebp`` and ``qualityAvif`` extension configuration
+    settings.
+
+The primary variant's quality is controlled per-request via the
+``q<n>`` URL segment (see :ref:`configuration-url-format`). The
+``.webp`` and ``.avif`` sidecars previously reused that same numeric
+quality, but AVIF's quality scale is steeper than WebP's or JPEG's --
+at matching numbers an AVIF file comes out larger than the WebP
+sidecar, defeating the point of serving AVIF at all.
+
+Two extension configuration settings control sidecar quality
+independently of the primary variant:
+
+``qualityWebp`` (default ``75``)
+    Output quality for the generated WebP variant.
+
+``qualityAvif`` (default ``60``)
+    Output quality for the generated AVIF variant. The lower default
+    keeps AVIF variants genuinely smaller than WebP while staying
+    visually comparable.
+
+..  code-block:: php
+    :caption: config/system/additional.php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_image_optimize']['qualityWebp'] = 75;
+    $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_image_optimize']['qualityAvif'] = 60;
+
+The settings can also be edited via the backend:
+*Admin Tools > Settings > Extension Configuration >
+nr_image_optimize*.
+
+..  attention::
+    Per-format quality is not part of the processed-variant cache
+    filename. Changing either setting only affects newly generated
+    variants -- clear already-processed images (see
+    :ref:`maintenance-clear`) to apply the new quality to existing
+    ones.
+
 ..  _configuration-cache-headers:
 
 Cache headers


### PR DESCRIPTION
## Summary

Prepares CHANGELOG.md and Documentation/Changelog/Index.rst for v2.4.0 (minor — 5 feat commits since v2.3.1). No version-file bumps: `ext_emconf.php`, `composer.json`, and `Documentation/guides.xml` are updated by the `release.yml` workflow on tag push, not manually.

- Backfills the missing `[2.3.1]` CHANGELOG entry (v14 theme-aware backend icons/dark-mode templates, #127) — it was never added when that version was tagged.
- Adds `[2.4.0]` covering everything merged since:
  - `Environment::getVarPath()` as an allowed root + `additionalTrustedRoots` extension configuration (#135)
  - Configurable WebP/AVIF output quality via `qualityWebp`/`qualityAvif` (#132, #134)
  - `clear-processed-images` symlink-preservation fix (#131, #133)
- Adds a `Documentation/Configuration/Index.rst` section for `qualityWebp`/`qualityAvif` (#134 shipped the feature without a Configuration doc entry).
- Updates the CHANGELOG footer compare-links for `2.3.1` and `2.4.0`.

Verified with the repo's own `check-changelog-links.py` and a full `render-guides` Docker render (`--fail-on-error`, no warnings on new content).

## Issue gate

Two open issues predate this work stream, neither is a regression from it:
- #108 — CI labeler fails on fork PRs (pre-existing infra issue)
- #6 — Dependency Dashboard (Renovate's standing issue, not a bug)

## Test plan

- [x] `check-changelog-links.py CHANGELOG.md` — clean
- [x] `suggest-version.sh` — confirms `2.4.0` / minor bump
- [x] Docker `render-guides --fail-on-error` — renders clean, new anchors resolve