### PR TITLE
fix: target the TYPO3 v14 LTS (14.3), not the EOL 14.0 sprint line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require": {
         "php": ">=8.2",
-        "typo3/cms-core": "^13.4 || ^14.0",
+        "typo3/cms-core": "^13.4 || ^14.3",
         "typo3/cms-extbase": "^13.4 || ^14.0",
         "typo3/cms-fluid": "^13.4 || ^14.0",
         "intervention/image": "^3.11 || ^4.0"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,7 +19,7 @@ $EM_CONF['nr_image_optimize'] = [
     'constraints'    => [
         'depends' => [
             'php'   => '8.2.0-8.5.99',
-            'typo3' => '13.4.0-14.4.99',
+            'typo3' => '13.4.0-14.3.99',
         ],
         'conflicts' => [],
         'suggests'  => [],


### PR DESCRIPTION
The v14 constraint was `^14.0` with an ext_emconf max of `14.4.99`.

- v14 **LTS is 14.3** — there is no 14.4 (the next feature line is v15), and 14.0–14.2 are EOL sprint releases the extension is not tested against.
- `^14.0` already resolves to 14.3.x, so this only makes the declared floor honest — no change to what CI installs.

Fixed to:
- composer: `^13.4 || ^14.3`
- ext_emconf: `13.4.0-14.3.99`, capping at the LTS minor per the traditional TYPO3 `<LTS>.0-<LTS>.99` convention (`14.4.99` implied a version that will never exist)

Version-only change; nothing else touched.