### PR TITLE
fix: simplify ImageManagerAdapter::read() per Rector 2.5.8

### DIFF
--- a/Classes/Service/ImageManagerAdapter.php
+++ b/Classes/Service/ImageManagerAdapter.php
@@ -58,9 +58,6 @@ final readonly class ImageManagerAdapter implements ImageReaderInterface
 
     public function read(string $path): ImageInterface
     {
-        $result = ($this->readCallback)($path);
-        assert($result instanceof ImageInterface);
-
-        return $result;
+        return ($this->readCallback)($path);
     }
 }


### PR DESCRIPTION
## Problem
`ci / Rector` fails on `main`. Rector 2.5.8 (unpinned; no committed `composer.lock`) flags `ImageManagerAdapter::read()` via `SimplifyUselessVariableRector` + `RemoveDeadInstanceOfAssertRector`: the `$readCallback` closure is typed `Closure(string): ImageInterface`, so `assert($result instanceof ImageInterface)` is provably dead and the `$result` temporary is redundant.

## Fix
Return the callback result directly.

## Verification
`.build/bin/rector process --dry-run --config Build/rector.php` locally with Rector 2.5.8: `[OK] Rector is done!`, exit 0.

## Note
The same simplification may be needed on the `TYPO3_12` branch if its CI also picks up Rector 2.5.8 — out of scope for this CI-fix PR.