### PR TITLE
fix: treat zero URL dimensions as auto instead of clamping to 1px

### DIFF
--- a/Classes/Processor.php
+++ b/Classes/Processor.php
@@ -702,8 +702,11 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
     /**
      * Clamp a dimension value to the allowed range.
      *
-     * Returns null if input is null (dimension not specified), otherwise
-     * restricts to 1..MAX_DIMENSION to prevent zero-pixel images and
+     * Returns null if input is null or zero: the SourceSetViewHelper always
+     * writes both dimensions into the variant URL and encodes "derive this
+     * side from the aspect ratio" as 0 (e.g. w1920h0), so a zero must map to
+     * "not specified" for calculateTargetDimensions() to fill it in — not to
+     * a 1px floor. Otherwise restricts to 1..MAX_DIMENSION to prevent
      * excessive memory allocation.
      *
      * @param int|null $value Raw dimension from URL
@@ -712,7 +715,7 @@ final class Processor implements LoggerAwareInterface, ProcessorInterface
      */
     private function clampDimension(?int $value): ?int
     {
-        if ($value === null) {
+        if ($value === null || $value === 0) {
             return null;
         }
 

--- a/Tests/Unit/ProcessorTest.php
+++ b/Tests/Unit/ProcessorTest.php
@@ -345,6 +345,31 @@ final class ProcessorTest extends TestCase
     }
 
     #[Test]
+    public function gatherInformationBasedOnUrlTreatsZeroHeightAsAutoDimension(): void
+    {
+        // The SourceSetViewHelper encodes "derive from aspect ratio" as 0
+        // (e.g. stage teaser desktop variants: w1920h0). A zero must map to
+        // null so calculateTargetDimensions() fills it in — not to a 1px floor.
+        /** @var array<string, mixed> $result */
+        $result = $this->callMethod($this->processor, 'gatherInformationBasedOnUrl', '/processed/path/to/image.w1920h0m0q75.jpg');
+
+        self::assertSame(1920, $result['targetWidth']);
+        self::assertNull($result['targetHeight']);
+    }
+
+    #[Test]
+    public function gatherInformationBasedOnUrlTreatsZeroWidthAsAutoDimension(): void
+    {
+        // Height-based variants (e.g. footer logos: w0h100) leave the width
+        // to be derived from the aspect ratio.
+        /** @var array<string, mixed> $result */
+        $result = $this->callMethod($this->processor, 'gatherInformationBasedOnUrl', '/processed/path/to/image.w0h100m1q75.png');
+
+        self::assertNull($result['targetWidth']);
+        self::assertSame(100, $result['targetHeight']);
+    }
+
+    #[Test]
     public function parseAllModeValuesExtractsAllParameters(): void
     {
         /** @var array<string, int> $result */
@@ -907,14 +932,16 @@ final class ProcessorTest extends TestCase
     }
 
     #[Test]
-    public function gatherInformationClampsZeroDimensionToOne(): void
+    public function gatherInformationTreatsZeroDimensionsAsAuto(): void
     {
         /** @var array<string, mixed> $result */
         $result = $this->callMethod($this->processor, 'gatherInformationBasedOnUrl', '/processed/image.w0h0q0m0.jpg');
 
-        // Width and height of 0 should be clamped to 1
-        self::assertSame(1, $result['targetWidth']);
-        self::assertSame(1, $result['targetHeight']);
+        // Width and height of 0 mean "derive from the aspect ratio" (the
+        // SourceSetViewHelper always writes both dimensions and encodes the
+        // unspecified side as 0) — they must map to null, not a 1px floor.
+        self::assertNull($result['targetWidth']);
+        self::assertNull($result['targetHeight']);
         // Quality of 0 should be clamped to 1
         self::assertSame(1, $result['targetQuality']);
     }
@@ -928,7 +955,9 @@ final class ProcessorTest extends TestCase
     #[Test]
     public function clampDimensionClampsToRange(): void
     {
-        self::assertSame(1, $this->callMethod($this->processor, 'clampDimension', 0));
+        // 0 encodes "auto" in variant URLs and maps to null (see
+        // gatherInformationTreatsZeroDimensionsAsAuto)
+        self::assertNull($this->callMethod($this->processor, 'clampDimension', 0));
         self::assertSame(1, $this->callMethod($this->processor, 'clampDimension', -5));
         self::assertSame(100, $this->callMethod($this->processor, 'clampDimension', 100));
         self::assertSame(8192, $this->callMethod($this->processor, 'clampDimension', 99999));


### PR DESCRIPTION
The SourceSetViewHelper always writes both dimensions into the variant URL and encodes "derive this side from the aspect ratio" as 0 (stage teaser desktop variants `w1920h0`, height-based logos `w0h100`). Since the clamping was introduced, `clampDimension()` floored 0 to 1, so those variants were generated as 1920x1 or 1x1 pixel images — on www.netresearch.de every viewport above the last `<source>` breakpoint got an invisible slider image and all footer logos collapsed to 1x1.

Map 0 to null so `calculateTargetDimensions()` derives the missing side, as it already does for absent dimensions. Negative values keep the 1px floor (they cannot originate from the `\d+` URL pattern anyway).

Backported ahead of this PR as v1.3.1 on the TYPO3_12 branch (production hotfix). Reported in Jira NRNR-1586.

Unit tests: two new cases (`w1920h0`, `w0h100`), two existing zero-clamp assertions updated to the corrected semantics. Full unit suite: no new failures vs origin/main baseline (10 pre-existing env failures identical on both).