### PR TITLE
docs: state the commit-signing requirement where contributors look

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,7 @@ For security vulnerabilities, please follow the [Security Policy](SECURITY.md). 
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [GPL-3.0-or-later](LICENSE) license.
+
+## Commit Signing
+
+All commits must be cryptographically signed and carry a DCO sign-off: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch enforces the signature (the "Verified" badge on GitHub); the DCO check enforces the `Signed-off-by` trailer — these are two different things and both are required. Quickest setup is SSH signing: register your SSH key as a *signing key* on your GitHub account, then `git config gpg.format ssh && git config user.signingkey ~/.ssh/<key>.pub`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,4 +78,4 @@ By contributing, you agree that your contributions will be licensed under the [G
 
 ## Commit Signing
 
-All commits must be cryptographically signed and carry a DCO sign-off: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch enforces the signature (the "Verified" badge on GitHub); the DCO check enforces the `Signed-off-by` trailer — these are two different things and both are required. Quickest setup is SSH signing: register your SSH key as a *signing key* on your GitHub account, then `git config gpg.format ssh && git config user.signingkey ~/.ssh/<key>.pub`.
+All commits must be cryptographically signed and carry a DCO sign-off: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch enforces the signature (the "Verified" badge on GitHub); the DCO check enforces the `Signed-off-by` trailer — these are two different things and both are required. Quickest setup is SSH signing: register your SSH key as a *signing key* on your GitHub account, then `git config --global gpg.format ssh && git config --global user.signingkey ~/.ssh/<key>.pub`.


### PR DESCRIPTION
Campaign phase 1 (signing enforcement). Signed commits have been org convention but were documented inconsistently and enforced nowhere — a fork contributor reasonably shipped unsigned, DCO-signed-off commits and the gap only surfaced in review (see the note on [t3x-nr-llm#569](https://github.com/netresearch/t3x-nr-llm/pull/569)). Since today a `require-signed-commits` ruleset on the default branch enforces the signature machine-side in every `t3x-*` repo; this PR makes the rule visible where contributors actually look, as applicable per repo: a `CLAUDE.md → AGENTS.md` symlink where missing (agent tooling loads repo conventions via CLAUDE.md), a **Commit Signing** section in `AGENTS.md`, and the same section in `CONTRIBUTING.md`.

For the record, DCO and signature are complementary, not redundant: the DCO check verifies the `Signed-off-by` trailer (a legal provenance statement, no cryptography), the new ruleset verifies the cryptographic signature ("Verified" badge).
