### PR TITLE
chore: sync checks.yml with current org template

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,13 @@ permissions: {}
 # extension-specific test matrix lives in ci.yml (intentional-drift). Every
 # `uses:` job grants exactly the reusable's caller contract; no reliance on
 # default_workflow_permissions.
+#
+# ANY JOB ADDED BELOW MUST ALSO BE ADDED TO `gate.needs`. The gate is the only
+# context a ruleset requires, so a job missing from that list is a job whose
+# failure cannot block a merge — the coverage loss is silent, and nothing in CI
+# catches it. GitHub Actions does not support YAML anchors in workflow files,
+# so the list cannot be shared with the job definitions; it has to be kept in
+# step by hand.
 jobs:
   security:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
@@ -44,12 +51,20 @@ jobs:
     permissions:
       contents: read
 
+  # `auto` rather than the `actions` default: a TYPO3 extension that ships
+  # JavaScript had none of it analysed, because the default scans workflows
+  # only and GitHub disables code-scanning default setup — which did cover
+  # javascript-typescript — as soon as an advanced configuration uploads its
+  # first SARIF. Merging this file is what triggers that handover, so the
+  # narrow default silently removed a control that had been in place.
   codeql:
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
       actions: read
+    with:
+      languages: auto
 
   scorecard:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
@@ -111,7 +126,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 


### PR DESCRIPTION
Syncs `.github/workflows/checks.yml` with the current `netresearch/.github` template revision. The file is a byte-identical copy of `templates/typo3-extension/.github/workflows/checks.yml` at blob `787510c1`.

## What changes

**`codeql` now passes `languages: auto`.** The previous revision called the reusable `codeql.yml` with no `with:` block, so `languages` took its default of `actions` — workflows only. GitHub disables code-scanning *default* setup as soon as an advanced configuration uploads its first SARIF, and merging `checks.yml` is exactly what triggers that handover, so the previous revision silently switched off the `javascript-typescript` coverage default setup had been providing. `auto` could not be used before because it hardcoded Go; it now detects `actions` always, `go` on a `go.mod` or any `.go` file, and `javascript-typescript` on a `package.json` or any JS/TS source.

**`step-security/harden-runner` moves from v2.20.0 to v2.20.1** in the gate job, pinned to commit `b09bb98e06d4d774595224525879c09bc6e98c40`.

**A comment records the `gate.needs` invariant.** Any job added to this workflow must also be added to `gate.needs`, because the aggregate gate is the only context a ruleset requires — a job missing from that list is a job whose failure cannot block a merge, and nothing in CI catches the omission.

## Effect in this repository

This extension ships `Resources/Public/JavaScript/Maintenance.js` and `Resources/Public/JavaScript/SystemRequirements.js`, so `auto` resolves to `actions` plus `javascript-typescript` and CodeQL will analyse those files for the first time. Any alerts it raises are handled on their merits in this PR rather than suppressed wholesale.
